### PR TITLE
feat: update modal builder-component for the latest djs version

### DIFF
--- a/.changeset/itchy-seals-slide.md
+++ b/.changeset/itchy-seals-slide.md
@@ -1,0 +1,5 @@
+---
+'seedcord': minor
+---
+
+remove action row components for modals. (we are not following deprecations till seedcord v1 is out. minor versions will be breaking changes)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -41,8 +41,8 @@
     "dependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@types/lodash.merge": "^4.6.9",
-        "@typescript-eslint/eslint-plugin": "^8.45.0",
-        "@typescript-eslint/parser": "^8.45.0",
+        "@typescript-eslint/eslint-plugin": "^8.46.0",
+        "@typescript-eslint/parser": "^8.46.0",
         "eslint": "catalog:peer",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -51,7 +51,7 @@
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-tsdoc": "^0.4.0",
         "lodash.merge": "^4.6.2",
-        "typescript-eslint": "^8.45.0"
+        "typescript-eslint": "^8.46.0"
     },
     "devDependencies": {
         "@types/eslint-plugin-security": "^3.0.0",

--- a/packages/seedcord/src/interfaces/Components.ts
+++ b/packages/seedcord/src/interfaces/Components.ts
@@ -7,6 +7,7 @@ import {
     EmbedBuilder,
     FileBuilder,
     InteractionContextType,
+    LabelBuilder,
     MediaGalleryBuilder,
     MentionableSelectMenuBuilder,
     ModalBuilder,
@@ -24,11 +25,24 @@ import {
 } from 'discord.js';
 import { Envapt } from 'envapt';
 
-import type { ColorResolvable, ModalActionRowComponentBuilder } from 'discord.js';
+import type { ColorResolvable } from 'discord.js';
 
 const BuilderTypes = {
+    // Command Components
     command: SlashCommandBuilder,
+    context_menu: ContextMenuCommandBuilder,
+    subcommand: SlashCommandSubcommandBuilder,
+    group: SlashCommandSubcommandGroupBuilder,
+
+    // Embed Components
     embed: EmbedBuilder,
+
+    // Modal Components
+    modal: ModalBuilder,
+    label: LabelBuilder,
+    text_input: TextInputBuilder,
+
+    // Action Row Components
     button: ButtonBuilder,
     menu_string: StringSelectMenuBuilder,
     menu_option_string: StringSelectMenuOptionBuilder,
@@ -36,10 +50,8 @@ const BuilderTypes = {
     menu_channel: ChannelSelectMenuBuilder,
     menu_mentionable: MentionableSelectMenuBuilder,
     menu_role: RoleSelectMenuBuilder,
-    modal: ModalBuilder,
-    context_menu: ContextMenuCommandBuilder,
-    subcommand: SlashCommandSubcommandBuilder,
-    group: SlashCommandSubcommandGroupBuilder,
+
+    // ComponentsV2
     container: ContainerBuilder,
     text_display: TextDisplayBuilder,
     file: FileBuilder,
@@ -55,19 +67,13 @@ const RowTypes: {
     menu_channel: typeof ActionRowBuilder<ChannelSelectMenuBuilder>;
     menu_mentionable: typeof ActionRowBuilder<MentionableSelectMenuBuilder>;
     menu_role: typeof ActionRowBuilder<RoleSelectMenuBuilder>;
-    modal: typeof ActionRowBuilder<ModalActionRowComponentBuilder>;
 } = {
     button: ActionRowBuilder<ButtonBuilder>,
     menu_string: ActionRowBuilder<StringSelectMenuBuilder>,
     menu_user: ActionRowBuilder<UserSelectMenuBuilder>,
     menu_channel: ActionRowBuilder<ChannelSelectMenuBuilder>,
     menu_mentionable: ActionRowBuilder<MentionableSelectMenuBuilder>,
-    menu_role: ActionRowBuilder<RoleSelectMenuBuilder>,
-    modal: ActionRowBuilder<ModalActionRowComponentBuilder>
-};
-
-const ModalTypes = {
-    text: TextInputBuilder
+    menu_role: ActionRowBuilder<RoleSelectMenuBuilder>
 };
 
 type BuilderType = keyof typeof BuilderTypes;
@@ -75,9 +81,6 @@ type InstantiatedBuilder<BuilderKey extends BuilderType> = InstanceType<(typeof 
 
 type ActionRowComponentType = keyof typeof RowTypes;
 type InstantiatedActionRow<RowKey extends ActionRowComponentType> = InstanceType<(typeof RowTypes)[RowKey]>;
-
-type ModalFieldTypes = keyof typeof ModalTypes;
-type InstantiatedModalField<ModalKey extends ModalFieldTypes> = InstanceType<(typeof ModalTypes)[ModalKey]>;
 
 /**
  * Base class for Discord component wrappers
@@ -183,48 +186,6 @@ export abstract class RowComponent<RowKey extends ActionRowComponentType> extend
 
     get component(): InstantiatedActionRow<RowKey> {
         return this.instance;
-    }
-}
-
-/**
- * Action row wrapper for modal components
- *
- * Automatically wraps modal field components in an action row for use in modals.
- *
- * @typeParam ModalKey - The type of modal field component being wrapped
- * @internal
- */
-class ModalRow<ModalKey extends ModalFieldTypes> extends RowComponent<'modal'> {
-    /**
-     * Creates a new modal action row with the specified component.
-     *
-     * @param component - The modal field component to wrap in an action row
-     */
-    constructor(component: InstantiatedModalField<ModalKey>) {
-        super('modal');
-
-        this.instance.addComponents(component);
-    }
-}
-
-/**
- * Base class for modal field components
- *
- * Wraps Discord.js modal field builders (TextInputBuilder, etc.) and
- * packages them in action rows for use in modals.
- *
- * @typeParam ModalKey - The type of modal field builder being wrapped
- */
-export abstract class ModalComponent<ModalKey extends ModalFieldTypes> extends BaseComponent<
-    InstantiatedModalField<ModalKey>
-> {
-    protected constructor(type: ModalKey) {
-        const ComponentClass = ModalTypes[type] as unknown;
-        super(ComponentClass as new () => InstantiatedModalField<ModalKey>);
-    }
-
-    get component(): InstantiatedActionRow<'modal'> {
-        return new ModalRow<ModalKey>(this.instance).component;
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ catalogs:
             specifier: 5.6.2
             version: 5.6.2
         discord.js:
-            specifier: 14.22.1
+            specifier: 14.23.2
             version: 14.22.1
         envapt:
             specifier: 4.0.0
             version: 4.0.0
         mongoose:
-            specifier: 8.19.0
+            specifier: 8.19.1
             version: 8.19.0
         reflect-metadata:
             specifier: 0.2.2
@@ -115,11 +115,11 @@ importers:
                 specifier: ^4.6.9
                 version: 4.6.9
             '@typescript-eslint/eslint-plugin':
-                specifier: ^8.45.0
-                version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+                specifier: ^8.46.0
+                version: 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
             '@typescript-eslint/parser':
-                specifier: ^8.45.0
-                version: 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+                specifier: ^8.46.0
+                version: 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
             eslint:
                 specifier: catalog:peer
                 version: 9.34.0(jiti@2.5.1)
@@ -131,7 +131,7 @@ importers:
                 version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.5.1))
             eslint-plugin-import:
                 specifier: ^2.32.0
-                version: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
+                version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
             eslint-plugin-prettier:
                 specifier: ^5.5.4
                 version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1))(prettier@3.6.2)
@@ -148,8 +148,8 @@ importers:
                 specifier: catalog:peer
                 version: 5.9.2
             typescript-eslint:
-                specifier: ^8.45.0
-                version: 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+                specifier: ^8.46.0
+                version: 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
         devDependencies:
             '@types/eslint-plugin-security':
                 specifier: ^3.0.0
@@ -350,7 +350,7 @@ importers:
                 version: link:../types
             discord.js:
                 specifier: catalog:deps
-                version: 14.22.1
+                version: 14.23.2
             typescript:
                 specifier: catalog:peer
                 version: 5.9.2
@@ -665,10 +665,10 @@ packages:
                 integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==
             }
 
-    '@discordjs/builders@1.11.3':
+    '@discordjs/builders@1.12.2':
         resolution:
             {
-                integrity: sha512-p3kf5eV49CJiRTfhtutUCeivSyQ/l2JlKodW1ZquRwwvlOWmG9+6jFShX6x8rUiYhnP6wKI96rgN/SXMy5e5aw==
+                integrity: sha512-AugKmrgRJOHXEyMkABH/hXpAmIBKbYokCEl9VAM4Kh6FvkdobQ+Zhv7AR6K+y5hS7+VQ7gKXPYCe1JQmV07H1g==
             }
         engines: { node: '>=16.11.0' }
 
@@ -1994,92 +1994,92 @@ packages:
                 integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
             }
 
-    '@typescript-eslint/eslint-plugin@8.45.0':
+    '@typescript-eslint/eslint-plugin@8.46.0':
         resolution:
             {
-                integrity: sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==
+                integrity: sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            '@typescript-eslint/parser': ^8.45.0
+            '@typescript-eslint/parser': ^8.46.0
             eslint: ^8.57.0 || ^9.0.0
             typescript: '>=4.8.4 <6.0.0'
 
-    '@typescript-eslint/parser@8.45.0':
+    '@typescript-eslint/parser@8.46.0':
         resolution:
             {
-                integrity: sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-        peerDependencies:
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: '>=4.8.4 <6.0.0'
-
-    '@typescript-eslint/project-service@8.45.0':
-        resolution:
-            {
-                integrity: sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-        peerDependencies:
-            typescript: '>=4.8.4 <6.0.0'
-
-    '@typescript-eslint/scope-manager@8.45.0':
-        resolution:
-            {
-                integrity: sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-    '@typescript-eslint/tsconfig-utils@8.45.0':
-        resolution:
-            {
-                integrity: sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-        peerDependencies:
-            typescript: '>=4.8.4 <6.0.0'
-
-    '@typescript-eslint/type-utils@8.45.0':
-        resolution:
-            {
-                integrity: sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==
+                integrity: sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
             eslint: ^8.57.0 || ^9.0.0
             typescript: '>=4.8.4 <6.0.0'
 
-    '@typescript-eslint/types@8.45.0':
+    '@typescript-eslint/project-service@8.46.0':
         resolution:
             {
-                integrity: sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-    '@typescript-eslint/typescript-estree@8.45.0':
-        resolution:
-            {
-                integrity: sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==
+                integrity: sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
             typescript: '>=4.8.4 <6.0.0'
 
-    '@typescript-eslint/utils@8.45.0':
+    '@typescript-eslint/scope-manager@8.46.0':
         resolution:
             {
-                integrity: sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==
+                integrity: sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@typescript-eslint/tsconfig-utils@8.46.0':
+        resolution:
+            {
+                integrity: sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            typescript: '>=4.8.4 <6.0.0'
+
+    '@typescript-eslint/type-utils@8.46.0':
+        resolution:
+            {
+                integrity: sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
             eslint: ^8.57.0 || ^9.0.0
             typescript: '>=4.8.4 <6.0.0'
 
-    '@typescript-eslint/visitor-keys@8.45.0':
+    '@typescript-eslint/types@8.46.0':
         resolution:
             {
-                integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==
+                integrity: sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@typescript-eslint/typescript-estree@8.46.0':
+        resolution:
+            {
+                integrity: sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            typescript: '>=4.8.4 <6.0.0'
+
+    '@typescript-eslint/utils@8.46.0':
+        resolution:
+            {
+                integrity: sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0
+            typescript: '>=4.8.4 <6.0.0'
+
+    '@typescript-eslint/visitor-keys@8.46.0':
+        resolution:
+            {
+                integrity: sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -2949,10 +2949,23 @@ packages:
                 integrity: sha512-xpmPviHjIJ6dFu1eNwNDIGQ3N6qmPUUYFVAx/YZ64h7ZgPkTcKjnciD8bZe8Vbeji7yS5uYljyciunpq0J5NSw==
             }
 
+    discord-api-types@0.38.29:
+        resolution:
+            {
+                integrity: sha512-+5BfrjLJN1hrrcK0MxDQli6NSv5lQH7Y3/qaOfk9+k7itex8RkA/UcevVMMLe8B4IKIawr4ITBTb2fBB2vDORg==
+            }
+
     discord.js@14.22.1:
         resolution:
             {
                 integrity: sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w==
+            }
+        engines: { node: '>=18' }
+
+    discord.js@14.23.2:
+        resolution:
+            {
+                integrity: sha512-tU2NFr823X3TXEc8KyR/4m296KLxPai4nirN3q9kHCpY4TKj96n9lHZnyLzRNMui8EbL07jg9hgH2PWWfKMGIg==
             }
         engines: { node: '>=18' }
 
@@ -3581,6 +3594,12 @@ packages:
         resolution:
             {
                 integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
+            }
+
+    get-tsconfig@4.12.0:
+        resolution:
+            {
+                integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==
             }
 
     git-raw-commits@4.0.0:
@@ -5207,6 +5226,14 @@ packages:
         engines: { node: '>=10' }
         hasBin: true
 
+    semver@7.7.3:
+        resolution:
+            {
+                integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
     set-function-length@1.2.2:
         resolution:
             {
@@ -5831,10 +5858,10 @@ packages:
         peerDependencies:
             typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
 
-    typescript-eslint@8.45.0:
+    typescript-eslint@8.46.0:
         resolution:
             {
-                integrity: sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==
+                integrity: sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw==
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
@@ -6415,7 +6442,7 @@ snapshots:
     '@commitlint/is-ignored@19.8.1':
         dependencies:
             '@commitlint/types': 19.8.1
-            semver: 7.7.2
+            semver: 7.7.3
 
     '@commitlint/lint@19.8.1':
         dependencies:
@@ -6489,12 +6516,12 @@ snapshots:
             enabled: 2.0.0
             kuler: 2.0.0
 
-    '@discordjs/builders@1.11.3':
+    '@discordjs/builders@1.12.2':
         dependencies:
             '@discordjs/formatters': 0.6.1
             '@discordjs/util': 1.1.1
             '@sapphire/shapeshift': 4.0.0
-            discord-api-types: 0.38.26
+            discord-api-types: 0.38.29
             fast-deep-equal: 3.1.3
             ts-mixer: 6.0.4
             tslib: 2.8.1
@@ -7235,14 +7262,14 @@ snapshots:
         dependencies:
             '@types/node': 24.6.2
 
-    '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+    '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
         dependencies:
             '@eslint-community/regexpp': 4.12.1
-            '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-            '@typescript-eslint/scope-manager': 8.45.0
-            '@typescript-eslint/type-utils': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-            '@typescript-eslint/utils': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-            '@typescript-eslint/visitor-keys': 8.45.0
+            '@typescript-eslint/parser': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/scope-manager': 8.46.0
+            '@typescript-eslint/type-utils': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/utils': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/visitor-keys': 8.46.0
             eslint: 9.34.0(jiti@2.5.1)
             graphemer: 1.4.0
             ignore: 7.0.5
@@ -7252,41 +7279,41 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+    '@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
         dependencies:
-            '@typescript-eslint/scope-manager': 8.45.0
-            '@typescript-eslint/types': 8.45.0
-            '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/visitor-keys': 8.45.0
+            '@typescript-eslint/scope-manager': 8.46.0
+            '@typescript-eslint/types': 8.46.0
+            '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/visitor-keys': 8.46.0
             debug: 4.4.3
             eslint: 9.34.0(jiti@2.5.1)
             typescript: 5.9.2
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/project-service@8.45.0(typescript@5.9.2)':
+    '@typescript-eslint/project-service@8.46.0(typescript@5.9.2)':
         dependencies:
-            '@typescript-eslint/tsconfig-utils': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/types': 8.45.0
+            '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/types': 8.46.0
             debug: 4.4.3
             typescript: 5.9.2
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/scope-manager@8.45.0':
+    '@typescript-eslint/scope-manager@8.46.0':
         dependencies:
-            '@typescript-eslint/types': 8.45.0
-            '@typescript-eslint/visitor-keys': 8.45.0
+            '@typescript-eslint/types': 8.46.0
+            '@typescript-eslint/visitor-keys': 8.46.0
 
-    '@typescript-eslint/tsconfig-utils@8.45.0(typescript@5.9.2)':
+    '@typescript-eslint/tsconfig-utils@8.46.0(typescript@5.9.2)':
         dependencies:
             typescript: 5.9.2
 
-    '@typescript-eslint/type-utils@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+    '@typescript-eslint/type-utils@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
         dependencies:
-            '@typescript-eslint/types': 8.45.0
-            '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/utils': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/types': 8.46.0
+            '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/utils': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
             debug: 4.4.3
             eslint: 9.34.0(jiti@2.5.1)
             ts-api-utils: 2.1.0(typescript@5.9.2)
@@ -7294,38 +7321,38 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/types@8.45.0': {}
+    '@typescript-eslint/types@8.46.0': {}
 
-    '@typescript-eslint/typescript-estree@8.45.0(typescript@5.9.2)':
+    '@typescript-eslint/typescript-estree@8.46.0(typescript@5.9.2)':
         dependencies:
-            '@typescript-eslint/project-service': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/tsconfig-utils': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/types': 8.45.0
-            '@typescript-eslint/visitor-keys': 8.45.0
+            '@typescript-eslint/project-service': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/types': 8.46.0
+            '@typescript-eslint/visitor-keys': 8.46.0
             debug: 4.4.3
             fast-glob: 3.3.3
             is-glob: 4.0.3
             minimatch: 9.0.5
-            semver: 7.7.2
+            semver: 7.7.3
             ts-api-utils: 2.1.0(typescript@5.9.2)
             typescript: 5.9.2
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/utils@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+    '@typescript-eslint/utils@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
         dependencies:
             '@eslint-community/eslint-utils': 4.9.0(eslint@9.34.0(jiti@2.5.1))
-            '@typescript-eslint/scope-manager': 8.45.0
-            '@typescript-eslint/types': 8.45.0
-            '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
+            '@typescript-eslint/scope-manager': 8.46.0
+            '@typescript-eslint/types': 8.46.0
+            '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.2)
             eslint: 9.34.0(jiti@2.5.1)
             typescript: 5.9.2
         transitivePeerDependencies:
             - supports-color
 
-    '@typescript-eslint/visitor-keys@8.45.0':
+    '@typescript-eslint/visitor-keys@8.46.0':
         dependencies:
-            '@typescript-eslint/types': 8.45.0
+            '@typescript-eslint/types': 8.46.0
             eslint-visitor-keys: 4.2.1
 
     '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -7835,16 +7862,37 @@ snapshots:
 
     discord-api-types@0.38.26: {}
 
+    discord-api-types@0.38.29: {}
+
     discord.js@14.22.1:
         dependencies:
-            '@discordjs/builders': 1.11.3
+            '@discordjs/builders': 1.12.2
             '@discordjs/collection': 1.5.3
             '@discordjs/formatters': 0.6.1
             '@discordjs/rest': 2.6.0
             '@discordjs/util': 1.1.1
             '@discordjs/ws': 1.2.3
             '@sapphire/snowflake': 3.5.3
-            discord-api-types: 0.38.26
+            discord-api-types: 0.38.29
+            fast-deep-equal: 3.1.3
+            lodash.snakecase: 4.1.1
+            magic-bytes.js: 1.12.1
+            tslib: 2.8.1
+            undici: 6.21.3
+        transitivePeerDependencies:
+            - bufferutil
+            - utf-8-validate
+
+    discord.js@14.23.2:
+        dependencies:
+            '@discordjs/builders': 1.12.2
+            '@discordjs/collection': 1.5.3
+            '@discordjs/formatters': 0.6.1
+            '@discordjs/rest': 2.6.0
+            '@discordjs/util': 1.1.1
+            '@discordjs/ws': 1.2.3
+            '@sapphire/snowflake': 3.5.3
+            discord-api-types: 0.38.29
             fast-deep-equal: 3.1.3
             lodash.snakecase: 4.1.1
             magic-bytes.js: 1.12.1
@@ -8051,7 +8099,7 @@ snapshots:
 
     eslint-import-context@0.1.9(unrs-resolver@1.11.1):
         dependencies:
-            get-tsconfig: 4.10.1
+            get-tsconfig: 4.12.0
             stable-hash-x: 0.2.0
         optionalDependencies:
             unrs-resolver: 1.11.1
@@ -8069,28 +8117,28 @@ snapshots:
             debug: 4.4.3
             eslint: 9.34.0(jiti@2.5.1)
             eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
-            get-tsconfig: 4.10.1
+            get-tsconfig: 4.12.0
             is-bun-module: 2.0.0
             stable-hash-x: 0.2.0
             tinyglobby: 0.2.15
             unrs-resolver: 1.11.1
         optionalDependencies:
-            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
+            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1)):
+    eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1)):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
-            '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/parser': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
             eslint: 9.34.0(jiti@2.5.1)
             eslint-import-resolver-node: 0.3.9
             eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.5.1))
         transitivePeerDependencies:
             - supports-color
 
-    eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1)):
+    eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1)):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.9
@@ -8101,7 +8149,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 9.34.0(jiti@2.5.1)
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
+            eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
             hasown: 2.0.2
             is-core-module: 2.16.1
             is-glob: 4.0.3
@@ -8113,7 +8161,7 @@ snapshots:
             string.prototype.trimend: 1.0.9
             tsconfig-paths: 3.15.0
         optionalDependencies:
-            '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/parser': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
         transitivePeerDependencies:
             - eslint-import-resolver-typescript
             - eslint-import-resolver-webpack
@@ -8364,6 +8412,10 @@ snapshots:
         dependencies:
             resolve-pkg-maps: 1.0.0
 
+    get-tsconfig@4.12.0:
+        dependencies:
+            resolve-pkg-maps: 1.0.0
+
     git-raw-commits@4.0.0:
         dependencies:
             dargs: 8.1.0
@@ -8506,7 +8558,7 @@ snapshots:
 
     is-bun-module@2.0.0:
         dependencies:
-            semver: 7.7.2
+            semver: 7.7.3
 
     is-callable@1.2.7: {}
 
@@ -8812,7 +8864,7 @@ snapshots:
 
     make-dir@4.0.0:
         dependencies:
-            semver: 7.7.2
+            semver: 7.7.3
 
     markdown-it@14.1.0:
         dependencies:
@@ -9256,6 +9308,8 @@ snapshots:
 
     semver@7.7.2: {}
 
+    semver@7.7.3: {}
+
     set-function-length@1.2.2:
         dependencies:
             define-data-property: 1.1.4
@@ -9680,12 +9734,12 @@ snapshots:
             typescript: 5.9.2
             yaml: 2.8.1
 
-    typescript-eslint@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2):
+    typescript-eslint@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2):
         dependencies:
-            '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-            '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-            '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
-            '@typescript-eslint/utils': 8.45.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/parser': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+            '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.2)
+            '@typescript-eslint/utils': 8.46.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
             eslint: 9.34.0(jiti@2.5.1)
             typescript: 5.9.2
         transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,9 @@ packages:
 catalogs:
     deps:
         chalk: 5.6.2
-        discord.js: 14.22.1
+        discord.js: 14.23.2
         envapt: 4.0.0
-        mongoose: 8.19.0
+        mongoose: 8.19.1
         reflect-metadata: 0.2.2
     peer:
         eslint: 9.37.0


### PR DESCRIPTION
- bump deps
- get rid of action row components for modals because they are now deprecated in djs