### PR TITLE
fix(types): type error when using 2 or more decorators on one int-handler

### DIFF
--- a/.changeset/lucky-rice-obey.md
+++ b/.changeset/lucky-rice-obey.md
@@ -1,0 +1,5 @@
+---
+'seedcord': patch
+---
+
+A previous change to make interaction handler routing decorators be very strict with types made it so that you couldn't use more than one on a single InteractionHandler anymore, which was a previous behavior that worked. This change now infers the types provided to the generic of InteractionHandler, extracts the type of the class, and compares it to the types expected by each decorator being used. It'll also tell you which one is missing in case of a mismatch.

--- a/.changeset/lucky-rice-obey.md
+++ b/.changeset/lucky-rice-obey.md
@@ -1,5 +1,0 @@
----
-'seedcord': patch
----
-
-A previous change to make interaction handler routing decorators be very strict with types made it so that you couldn't use more than one on a single InteractionHandler anymore, which was a previous behavior that worked. This change now infers the types provided to the generic of InteractionHandler, extracts the type of the class, and compares it to the types expected by each decorator being used. It'll also tell you which one is missing in case of a mismatch.

--- a/packages/seedcord/CHANGELOG.md
+++ b/packages/seedcord/CHANGELOG.md
@@ -1,5 +1,11 @@
 # seedcord
 
+## 0.10.3
+
+### Patch Changes
+
+- 398b08f: A previous change to make interaction handler routing decorators be very strict with types made it so that you couldn't use more than one on a single InteractionHandler anymore, which was a previous behavior that worked. This change now infers the types provided to the generic of InteractionHandler, extracts the type of the class, and compares it to the types expected by each decorator being used. It'll also tell you which one is missing in case of a mismatch.
+
 ## 0.10.2
 
 ### Patch Changes

--- a/packages/seedcord/package.json
+++ b/packages/seedcord/package.json
@@ -1,7 +1,7 @@
 {
     "name": "seedcord",
     "type": "module",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "A Discord bot framework built on top of Discord.js",
     "repository": {
         "type": "git",

--- a/packages/seedcord/src/bot/decorators/Interactions.ts
+++ b/packages/seedcord/src/bot/decorators/Interactions.ts
@@ -1,6 +1,6 @@
 import { areRoutes } from '@miscellaneous/areRoutes';
 
-import type { AutocompleteHandler, InteractionHandler, Repliables } from '@interfaces/Handler';
+import type { InteractionHandler, AutocompleteHandler, HandlerConstructor, Repliables } from '@interfaces/Handler';
 import type {
     ButtonInteraction,
     ChannelSelectMenuInteraction,
@@ -52,6 +52,24 @@ export enum SelectMenuType {
 export const InteractionMetadataKey = Symbol('interaction:metadata');
 
 /**
+ * Extract the event type from an InteractionHandler subclass
+ *
+ * @internal
+ */
+type HandlerEventType<TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
+    InstanceType<TCtor> extends InteractionHandler<infer TEvent> ? TEvent : never;
+
+/**
+ * Compile time assertion that Required is included in the handler event union
+ *
+ * @internal
+ */
+type AssertHandles<TRequired, TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
+    Extract<HandlerEventType<TCtor>, TRequired> extends never
+        ? Constructor<['Handler event generic must include', TRequired]>
+        : TCtor;
+
+/**
  * Routes slash commands to handler classes
  *
  * Supports single commands, subcommands, and subcommand groups.
@@ -84,8 +102,10 @@ export const InteractionMetadataKey = Symbol('interaction:metadata');
  * ```
  */
 export function SlashRoute(routeOrRoutes: string | string[]) {
-    return function (constructor: Constructor<InteractionHandler<ChatInputCommandInteraction>>): void {
-        storeMetadata(InteractionRoutes.Slash, routeOrRoutes, constructor);
+    return function <TCtor extends new (...args: any[]) => InteractionHandler<Repliables>>(
+        constructor: AssertHandles<ChatInputCommandInteraction, TCtor>
+    ): void {
+        storeMetadata(InteractionRoutes.Slash, routeOrRoutes, constructor as HandlerConstructor);
     };
 }
 
@@ -100,8 +120,10 @@ export function SlashRoute(routeOrRoutes: string | string[]) {
  * @decorator
  */
 export function ButtonRoute(routeOrRoutes: string | string[]) {
-    return function (constructor: Constructor<InteractionHandler<ButtonInteraction>>): void {
-        storeMetadata(InteractionRoutes.Button, routeOrRoutes, constructor);
+    return function <TCtor extends new (...args: any[]) => InteractionHandler<Repliables>>(
+        constructor: AssertHandles<ButtonInteraction, TCtor>
+    ): void {
+        storeMetadata(InteractionRoutes.Button, routeOrRoutes, constructor as HandlerConstructor);
     };
 }
 
@@ -114,8 +136,10 @@ export function ButtonRoute(routeOrRoutes: string | string[]) {
  * @decorator
  */
 export function ModalRoute(routeOrRoutes: string | string[]) {
-    return function (constructor: Constructor<InteractionHandler<ModalSubmitInteraction>>): void {
-        storeMetadata(InteractionRoutes.Modal, routeOrRoutes, constructor);
+    return function <TCtor extends new (...args: any[]) => InteractionHandler<Repliables>>(
+        constructor: AssertHandles<ModalSubmitInteraction, TCtor>
+    ): void {
+        storeMetadata(InteractionRoutes.Modal, routeOrRoutes, constructor as HandlerConstructor);
     };
 }
 
@@ -127,9 +151,11 @@ export function ModalRoute(routeOrRoutes: string | string[]) {
  * @decorator
  */
 export function ContextMenuRoute(type: 'message' | 'user', routeOrRoutes: string | string[]) {
-    return function (constructor: Constructor<InteractionHandler<ContextMenuCommandInteraction>>): void {
+    return function <TCtor extends new (...args: any[]) => InteractionHandler<Repliables>>(
+        constructor: AssertHandles<ContextMenuCommandInteraction, TCtor>
+    ): void {
         const routeType = type === 'message' ? InteractionRoutes.MessageContextMenu : InteractionRoutes.UserContextMenu;
-        storeMetadata(routeType, routeOrRoutes, constructor);
+        storeMetadata(routeType, routeOrRoutes, constructor as HandlerConstructor);
     };
 }
 
@@ -196,7 +222,9 @@ export type SelectMenuInteractionFor<SelectMenu extends SelectMenuType> = Select
  * ```
  */
 export function SelectMenuRoute<SelectMenu extends SelectMenuType>(type: SelectMenu, routeOrRoutes: string | string[]) {
-    return function (constructor: Constructor<InteractionHandler<SelectMenuInteractionFor<SelectMenu>>>): void {
+    return function <TCtor extends new (...args: any[]) => InteractionHandler<Repliables>>(
+        constructor: AssertHandles<SelectMenuInteractionFor<SelectMenu>, TCtor>
+    ): void {
         const routeMap = {
             [SelectMenuType.String]: InteractionRoutes.StringMenu,
             [SelectMenuType.User]: InteractionRoutes.UserMenu,
@@ -205,7 +233,7 @@ export function SelectMenuRoute<SelectMenu extends SelectMenuType>(type: SelectM
             [SelectMenuType.Mentionable]: InteractionRoutes.MentionableMenu
         };
 
-        storeMetadata(routeMap[type], routeOrRoutes, constructor);
+        storeMetadata(routeMap[type], routeOrRoutes, constructor as HandlerConstructor);
     };
 }
 

--- a/packages/seedcord/src/bot/decorators/Interactions.ts
+++ b/packages/seedcord/src/bot/decorators/Interactions.ts
@@ -54,17 +54,21 @@ export const InteractionMetadataKey = Symbol('interaction:metadata');
 /**
  * Extract the event type from an InteractionHandler subclass
  *
+ * Used by the interaction routing decorators.
+ *
  * @internal
  */
-type HandlerEventType<TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
+export type HandlerEventType<TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
     InstanceType<TCtor> extends InteractionHandler<infer TEvent> ? TEvent : never;
 
 /**
  * Compile time assertion that Required is included in the handler event union
  *
+ * Used by the interaction routing decorators.
+ *
  * @internal
  */
-type AssertHandles<TRequired, TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
+export type AssertHandles<TRequired, TCtor extends new (...args: any[]) => InteractionHandler<Repliables>> =
     Extract<HandlerEventType<TCtor>, TRequired> extends never
         ? Constructor<['Handler event generic must include', TRequired]>
         : TCtor;

--- a/packages/seedcord/src/bot/decorators/Interactions.ts
+++ b/packages/seedcord/src/bot/decorators/Interactions.ts
@@ -62,7 +62,7 @@ export type HandlerEventType<TCtor extends new (...args: any[]) => InteractionHa
     InstanceType<TCtor> extends InteractionHandler<infer TEvent> ? TEvent : never;
 
 /**
- * Compile time assertion that Required is included in the handler event union
+ * Compile time assertion that the required event type(s) `TRequired` are included in the handler event union.
  *
  * Used by the interaction routing decorators.
  *


### PR DESCRIPTION
newer strict handler type rules broke the ability to use multiple decorators that used to work.