### PR TITLE
feat!: drop the startupPhase arg from attach

### DIFF
--- a/mock/src/bot.ts
+++ b/mock/src/bot.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import { resolve } from 'node:path';
 
-import { Seedcord, StartupPhase } from '@seedcord/gateway';
+import { Seedcord } from '@seedcord/gateway';
 import { Mongo } from '@seedcord/plugins';
 import { GatewayIntentBits, Partials } from 'discord.js';
 import { Envapter } from 'envapt';
@@ -52,7 +52,7 @@ export const seedcord = new Seedcord({
         path: null
     },
     botColor: '#fe565a'
-}).attach('db', Mongo, StartupPhase.Configuration, {
+}).attach('db', Mongo, {
     dir: resolve(import.meta.dirname, './services'),
     uri: Vars.mongoUri,
     name: Vars.dbName

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -42,7 +42,6 @@ export * from './Seedcord';
 
 // Exports from other packages
 export * from '@seedcord/core';
-export { StartupPhase, ShutdownPhase } from '@seedcord/core/node';
 export * from '@seedcord/errors';
 export * from '@seedcord/event-emitter';
 export * from '@seedcord/logger';

--- a/packages/gateway/src/interfaces/Plugin.ts
+++ b/packages/gateway/src/interfaces/Plugin.ts
@@ -1,10 +1,11 @@
 import { getDevChannel } from '@seedcord/core/internal';
+import { StartupPhase } from '@seedcord/core/node';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { TypedEventEmitter } from '@seedcord/event-emitter';
 
 import type { Core } from './Core';
-import type { CoordinatedShutdown, CoordinatedStartup, StartupPhase } from '@seedcord/core/node';
+import type { CoordinatedShutdown, CoordinatedStartup } from '@seedcord/core/node';
 import type { EventMap, NoEvents } from '@seedcord/event-emitter';
 import type { Logger } from '@seedcord/logger';
 import type { Tail, HmrAware, HmrUpdateEvent } from '@seedcord/types';
@@ -113,7 +114,7 @@ export class Pluggable<
     /**
      * Attaches a plugin to this instance
      *
-     * Plugins provide external functionality and are initialized during the specified startup phase.
+     * Plugins provide external functionality and are initialized during startup.
      * The plugin instance becomes available as a property in `core` wherever it's available.
      *
      * Make sure to augment the {@link Core} interface with the plugin type to ensure TypeScript recognizes it and provides intellisense.
@@ -122,20 +123,18 @@ export class Pluggable<
      * @typeParam Ctor - The plugin constructor type
      * @param key - Property name to access the plugin instance
      * @param Plugin - Plugin constructor class
-     * @param startupPhase - When during startup to initialize this plugin ({@link StartupPhase})
      * @param args - Additional arguments to pass to the plugin constructor
      * @returns This instance with the plugin attached as a typed property
      * @throws A **SeedcordError** When called after initialization or if key already exists
      * @example
      * ```typescript
-     * seedcord.attach('db', Mongo, StartupPhase.Configuration, { uri: 'mongodb://...', name: 'seedcord', dir: ... })
+     * seedcord.attach('db', Mongo, { uri: 'mongodb://...', name: 'seedcord', dir: ... })
      * ```
      */
     public attach<Key extends string, Ctor extends PluginCtor>(
         this: this,
         key: Key,
         Plugin: Ctor,
-        startupPhase: StartupPhase,
         ...args: PluginArgs<Ctor>
     ): this & Record<Key, InstanceType<Ctor>> {
         if (this.isInitialized) {
@@ -156,7 +155,8 @@ export class Pluggable<
         } as Record<Key, InstanceType<Ctor>>;
 
         this.startup.addTask(
-            startupPhase,
+            // TEMP: plugins init before the bot logs in at Instantiation
+            StartupPhase.Configuration,
             `Plugin:${key}`,
             async () => {
                 instance.logger.utils.initialization(key, 'start');

--- a/packages/gateway/tests/interfaces/pluggable-attach.test.ts
+++ b/packages/gateway/tests/interfaces/pluggable-attach.test.ts
@@ -1,0 +1,80 @@
+import { CoordinatedShutdown, CoordinatedStartup } from '@seedcord/core/node';
+import { Logger } from '@seedcord/logger';
+import { describe, it, expect } from 'vitest';
+
+import { Plugin, Pluggable } from '@interfaces/Plugin';
+
+import type { Core } from '@interfaces/Core';
+
+class TestPlugin extends Plugin {
+    public logger = new Logger('TestPlugin');
+    public initCalls = 0;
+
+    constructor(
+        core: Core,
+        public readonly tag: string
+    ) {
+        super(core);
+    }
+
+    public init(): Promise<void> {
+        this.initCalls++;
+        this.onInit?.();
+        return Promise.resolve();
+    }
+
+    public onInit?: () => void;
+}
+
+class TestHost extends Pluggable {
+    public run(): Promise<this> {
+        return this.init();
+    }
+}
+
+function makeHost(): { host: TestHost; startup: CoordinatedStartup } {
+    const startup = new CoordinatedStartup();
+    const host = new TestHost(new CoordinatedShutdown(false), startup);
+    return { host, startup };
+}
+
+describe('Pluggable.attach', () => {
+    it('attaches without a phase argument and threads ctor args', async () => {
+        const { host, startup } = makeHost();
+
+        const withDb = host.attach('db', TestPlugin, 'hello');
+
+        expect(withDb.db).toBeInstanceOf(TestPlugin);
+        expect(withDb.db.tag).toBe('hello');
+
+        await host.run();
+        expect(withDb.db.initCalls).toBe(1);
+        expect(startup.isReady).toBe(true);
+    });
+
+    it('runs plugin init inside the Configuration phase', async () => {
+        const { host, startup } = makeHost();
+        const order: string[] = [];
+
+        startup.on('phase:4:start', () => order.push('4:start'));
+        startup.on('phase:4:complete', () => order.push('4:complete'));
+
+        const withDb = host.attach('db', TestPlugin, 'x');
+        withDb.db.onInit = () => order.push('init');
+
+        await host.run();
+        expect(order).toEqual(['4:start', 'init', '4:complete']);
+    });
+
+    it('rejects a duplicate key', () => {
+        const { host } = makeHost();
+        host.attach('db', TestPlugin, 'one');
+        expect(() => host.attach('db', TestPlugin, 'two')).toThrow(/db/);
+    });
+
+    it('rejects attach after init', async () => {
+        const { host } = makeHost();
+        await host.run();
+        expect(() => host.attach('late', TestPlugin, 'x')).toThrow();
+    });
+});


### PR DESCRIPTION
trunk of the stack. WIP rn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugins can now be attached without specifying a startup phase.
  - Plugin initialization now runs during the configuration stage.
  - Gateway exports now re-export the full core package for broader access.

- **Bug Fixes**
  - Attachment behavior is enforced more consistently, including rejecting duplicate keys and attempts to attach after startup.

- **Tests**
  - Added integration coverage for attachment without a phase argument, constructor argument forwarding, initialization order, and attachment restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->