### PR TITLE
feat!: drop shutdownEnabled and move healthCheck to a transport union

### DIFF
--- a/mock/Dockerfile
+++ b/mock/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /usr/source/app/package.json ./
 USER seedcord
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:6967/healthcheck || exit 1
+  CMD curl -f http://localhost:6967/health || exit 1
 
 EXPOSE 3000
 EXPOSE 6967

--- a/packages/core/src/node/HealthCheck.ts
+++ b/packages/core/src/node/HealthCheck.ts
@@ -6,14 +6,14 @@ import chalk from 'chalk';
 import { ShutdownPhase } from './Lifecycle/CoordinatedShutdown';
 
 import type { CoordinatedShutdown } from './Lifecycle/CoordinatedShutdown';
-import type { HealthCheckConfig } from '@seedcord/types';
+import type { HealthCheckConfig, HealthCheckOption } from '@seedcord/types';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 
 const HTTP_OK = 200;
 const HTTP_NOT_FOUND = 404;
 
 const DEFAULT_HEALTH_CHECK_PORT = 6967;
-const DEFAULT_HEALTH_CHECK_PATH = '/healthcheck';
+const DEFAULT_HEALTH_CHECK_PATH = '/health';
 
 /**
  * HTTP health check service for monitoring bot status.
@@ -37,6 +37,15 @@ export class HealthCheck {
         this.host = options?.host;
 
         shutdown.addTask(ShutdownPhase.StopServices, 'stop-healthcheck-server', async () => await this.stop());
+    }
+
+    /**
+     * Resolves the config `healthCheck` option. `false` returns undefined, `true` and `undefined`
+     * return an instance with the defaults, an object applies its options.
+     */
+    public static fromOption(shutdown: CoordinatedShutdown, option?: HealthCheckOption): HealthCheck | undefined {
+        if (option === false) return undefined;
+        return new HealthCheck(shutdown, typeof option === 'object' ? option : undefined);
     }
 
     /**

--- a/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
+++ b/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
@@ -45,22 +45,19 @@ const LOG_FLUSH_DELAY_MS = 500;
  * Tasks can be added or removed dynamically, and each task has an associated timeout.
  */
 export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase, CoordinatedShutdownEvents> {
-    private readonly isShutdownEnabled: boolean;
-
     private isShuttingDown = false;
     private exitCode = 0;
     private onSigTerm: (() => void) | null = null;
     private onSigInt: (() => void) | null = null;
 
-    public constructor(enabled = true) {
+    public constructor() {
         super('Shutdown', PHASE_ORDER, ShutdownPhase);
 
-        this.isShutdownEnabled = enabled;
         this.registerSignalHandlers();
     }
 
     protected canAddTask(): boolean {
-        return this.isShutdownEnabled;
+        return true;
     }
 
     protected canRemoveTask(): boolean {
@@ -80,8 +77,6 @@ export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase, Coo
     }
 
     private registerSignalHandlers(): void {
-        if (!this.isShutdownEnabled) return;
-
         this.onSigTerm = () => {
             this.logger.info(`Received ${chalk.yellow.bold('SIGTERM')} signal`);
             void this.run(0);
@@ -96,7 +91,8 @@ export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase, Coo
         process.on('SIGINT', this.onSigInt);
     }
 
-    private removeSignalHandlers(): void {
+    /** @internal */
+    public removeSignalHandlers(): void {
         if (this.onSigTerm) {
             process.off('SIGTERM', this.onSigTerm);
             this.onSigTerm = null;

--- a/packages/core/tests/node/health-check-option.test.ts
+++ b/packages/core/tests/node/health-check-option.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { HealthCheck } from '@node/HealthCheck';
+
+import type { CoordinatedShutdown } from '@node/Lifecycle/CoordinatedShutdown';
+
+function stubShutdown(): { shutdown: CoordinatedShutdown; addTask: ReturnType<typeof vi.fn> } {
+    const addTask = vi.fn();
+    // justified: fromOption only reaches addTask
+    const shutdown = { addTask } as unknown as CoordinatedShutdown;
+    return { shutdown, addTask };
+}
+
+describe('HealthCheck.fromOption', () => {
+    it('false returns undefined and registers nothing', () => {
+        const { shutdown, addTask } = stubShutdown();
+
+        expect(HealthCheck.fromOption(shutdown, false)).toBeUndefined();
+        expect(addTask).not.toHaveBeenCalled();
+    });
+
+    it('undefined returns the defaults', () => {
+        const { shutdown } = stubShutdown();
+        const check = HealthCheck.fromOption(shutdown, undefined);
+
+        expect(check).toBeInstanceOf(HealthCheck);
+        expect(check?.port).toBe(6967);
+        expect(check?.path).toBe('/health');
+    });
+
+    it('true returns the defaults', () => {
+        const { shutdown } = stubShutdown();
+
+        expect(HealthCheck.fromOption(shutdown, true)?.port).toBe(6967);
+    });
+
+    it('an options object is applied', () => {
+        const { shutdown } = stubShutdown();
+        const check = HealthCheck.fromOption(shutdown, { port: 7000, path: '/ready' });
+
+        expect(check?.port).toBe(7000);
+        expect(check?.path).toBe('/ready');
+    });
+});

--- a/packages/core/tests/node/lifecycle/coordinated-shutdown-signals.test.ts
+++ b/packages/core/tests/node/lifecycle/coordinated-shutdown-signals.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+
+import { CoordinatedShutdown } from '@node/Lifecycle/CoordinatedShutdown';
+
+// construction only, never run(), which would exit the test process
+describe('CoordinatedShutdown signal handlers', () => {
+    it('registers handlers at construction and releases them', () => {
+        const base = process.listenerCount('SIGTERM');
+        const shutdown = new CoordinatedShutdown();
+
+        expect(process.listenerCount('SIGTERM')).toBe(base + 1);
+
+        shutdown.removeSignalHandlers();
+        expect(process.listenerCount('SIGTERM')).toBe(base);
+        expect(process.listenerCount('SIGINT')).toBeLessThanOrEqual(base + 1);
+    });
+
+    it('release is idempotent', () => {
+        const base = process.listenerCount('SIGTERM');
+        const shutdown = new CoordinatedShutdown();
+
+        shutdown.removeSignalHandlers();
+        shutdown.removeSignalHandlers();
+
+        expect(process.listenerCount('SIGTERM')).toBe(base);
+    });
+});

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -33,7 +33,8 @@ export class Seedcord extends Pluggable implements Core {
     public readonly version: string = packageVersion;
 
     private static isInstantiated = false;
-    private readonly healthCheck: HealthCheck;
+    private static instance?: Seedcord | undefined;
+    private readonly healthCheck?: HealthCheck | undefined;
     private readonly hmrManager: HmrManager;
 
     /** @see {@link CoordinatedShutdown} */
@@ -64,7 +65,7 @@ export class Seedcord extends Pluggable implements Core {
 
         Seedcord.isInstantiated = true;
 
-        const shutdown = new CoordinatedShutdown(config.shutdownEnabled);
+        const shutdown = new CoordinatedShutdown();
         const startup = new CoordinatedStartup();
 
         super(shutdown, startup);
@@ -80,9 +81,10 @@ export class Seedcord extends Pluggable implements Core {
         this.bus = new Bus(this);
         this.bot = new Bot(this);
         this.rateLimiter = config.store ?? new MemoryRateLimiter();
-        this.healthCheck = new HealthCheck(this.shutdown, config.healthCheck);
+        this.healthCheck = HealthCheck.fromOption(this.shutdown, config.healthCheck);
 
         this.registerStartupTasks();
+        Seedcord.instance = this;
     }
 
     /** The bot's discord username, populated after login. */
@@ -92,6 +94,8 @@ export class Seedcord extends Pluggable implements Core {
 
     // @ts-expect-error called only by tests, so the source build sees it as unused
     private static reset(): void {
+        Seedcord.instance?.shutdown.removeSignalHandlers();
+        Seedcord.instance = undefined;
         Seedcord.isInstantiated = false;
         LoggerChannelRegistry.instance.reset();
     }
@@ -111,11 +115,14 @@ export class Seedcord extends Pluggable implements Core {
             this.bot.logger.utils.initialization('Bot', 'end');
         });
 
-        this.startup.addTask(StartupPhase.Ready, 'Health Check', async () => {
-            this.healthCheck.logger.utils.initialization('HealthCheck', 'start');
-            await this.healthCheck.init();
-            this.healthCheck.logger.utils.initialization('HealthCheck', 'end');
-        });
+        const { healthCheck } = this;
+        if (healthCheck) {
+            this.startup.addTask(StartupPhase.Ready, 'Health Check', async () => {
+                healthCheck.logger.utils.initialization('HealthCheck', 'start');
+                await healthCheck.init();
+                healthCheck.logger.utils.initialization('HealthCheck', 'end');
+            });
+        }
     }
 
     /**

--- a/packages/gateway/src/interfaces/Config.ts
+++ b/packages/gateway/src/interfaces/Config.ts
@@ -1,4 +1,4 @@
-import type { BotConfig, Config } from '@seedcord/types';
+import type { BotConfig, Config, HealthCheckOption } from '@seedcord/types';
 import type { ClientOptions } from 'discord.js';
 
 /**
@@ -38,4 +38,9 @@ export interface GatewayBotConfig extends BotConfig {
  */
 export interface GatewayConfig extends Config {
     bot: GatewayBotConfig;
+
+    /**
+     * The health-check server. `false` disables it, omit for the defaults.
+     */
+    healthCheck?: HealthCheckOption;
 }

--- a/packages/gateway/tests/interfaces/pluggable-attach.test.ts
+++ b/packages/gateway/tests/interfaces/pluggable-attach.test.ts
@@ -1,6 +1,6 @@
 import { CoordinatedShutdown, CoordinatedStartup } from '@seedcord/core/node';
 import { Logger } from '@seedcord/logger';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 
 import { Plugin, Pluggable } from '@interfaces/Plugin';
 
@@ -32,13 +32,19 @@ class TestHost extends Pluggable {
     }
 }
 
+const shutdowns: CoordinatedShutdown[] = [];
+
 function makeHost(): { host: TestHost; startup: CoordinatedStartup } {
     const startup = new CoordinatedStartup();
-    const host = new TestHost(new CoordinatedShutdown(false), startup);
-    return { host, startup };
+    const shutdown = new CoordinatedShutdown();
+    shutdowns.push(shutdown);
+    return { host: new TestHost(shutdown, startup), startup };
 }
 
 describe('Pluggable.attach', () => {
+    afterEach(() => {
+        for (const shutdown of shutdowns.splice(0)) shutdown.removeSignalHandlers();
+    });
     it('attaches without a phase argument and threads ctor args', async () => {
         const { host, startup } = makeHost();
 

--- a/packages/gateway/tests/seedcord-host.test.ts
+++ b/packages/gateway/tests/seedcord-host.test.ts
@@ -1,0 +1,42 @@
+import { ShutdownPhase } from '@seedcord/core/node';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { Seedcord } from '@src/Seedcord';
+
+import { testConfig } from './utils/test-config';
+
+import './utils/mock-client';
+import './utils/mock-env';
+
+function reset(): void {
+    // @ts-expect-error reset the Seedcord singleton between tests
+    Seedcord.reset();
+}
+
+describe('Seedcord host', () => {
+    beforeEach(reset);
+    afterEach(reset);
+
+    it('reset() releases the signal handlers', () => {
+        const base = process.listenerCount('SIGTERM');
+
+        // eslint-disable-next-line no-new -- construction registers the handlers under test
+        new Seedcord(testConfig());
+        expect(process.listenerCount('SIGTERM')).toBe(base + 1);
+
+        reset();
+        expect(process.listenerCount('SIGTERM')).toBe(base);
+    });
+
+    it('registers the health server by default', () => {
+        const seedcord = new Seedcord(testConfig());
+
+        expect(seedcord.shutdown.removeTask(ShutdownPhase.StopServices, 'stop-healthcheck-server')).toBe(true);
+    });
+
+    it('healthCheck: false skips the health server', () => {
+        const seedcord = new Seedcord(testConfig({ healthCheck: false }));
+
+        expect(seedcord.shutdown.removeTask(ShutdownPhase.StopServices, 'stop-healthcheck-server')).toBe(false);
+    });
+});

--- a/packages/gateway/tests/utils/test-config.ts
+++ b/packages/gateway/tests/utils/test-config.ts
@@ -1,5 +1,5 @@
 import type { GatewayConfig } from '@interfaces/Config';
-import type { CustomIdMatcher } from '@seedcord/types';
+import type { CustomIdMatcher, HealthCheckOption } from '@seedcord/types';
 
 interface TestConfigOverrides {
     interactions?: string;
@@ -10,6 +10,7 @@ interface TestConfigOverrides {
     subscribers?: string;
     ignoreCustomIds?: CustomIdMatcher[];
     ownerIds?: string[];
+    healthCheck?: HealthCheckOption;
 }
 
 export function testConfig(overrides: TestConfigOverrides = {}): GatewayConfig {
@@ -21,7 +22,8 @@ export function testConfig(overrides: TestConfigOverrides = {}): GatewayConfig {
         commands,
         subscribers,
         ignoreCustomIds,
-        ownerIds
+        ownerIds,
+        healthCheck
     } = overrides;
 
     const config: GatewayConfig = {
@@ -45,6 +47,7 @@ export function testConfig(overrides: TestConfigOverrides = {}): GatewayConfig {
     };
 
     if (ownerIds) config.ownerIds = ownerIds;
+    if (healthCheck !== undefined) config.healthCheck = healthCheck;
 
     return config;
 }

--- a/packages/seedcord/playground/scenarios/filters.ts
+++ b/packages/seedcord/playground/scenarios/filters.ts
@@ -4,7 +4,7 @@ const FEED: readonly (readonly [string, string, PreviewLogLevel])[] = [
     ['bot', 'Ready. 3 guilds, 142 members.', 'info'],
     ['db', 'Connected to postgres.', 'info'],
     ['db', 'Slow query 820ms on users.', 'warn'],
-    ['http', 'GET /healthcheck 200 1ms', 'debug'],
+    ['http', 'GET /health 200 1ms', 'debug'],
     ['cache', 'miss key session:abc', 'trace'],
     ['events', 'messageCreate from user#1234', 'debug'],
     ['bot', 'Interaction /play failed', 'error'],

--- a/packages/seedcord/playground/scenarios/happyStartup.ts
+++ b/packages/seedcord/playground/scenarios/happyStartup.ts
@@ -3,13 +3,13 @@ import type { Scenario } from './types';
 const FEED: readonly (readonly [string, string])[] = [
     ['bot', 'Ready. 3 guilds, 142 members.'],
     ['bot', 'Registered 12 application commands.'],
-    ['http', 'GET /healthcheck 200 1ms'],
+    ['http', 'GET /health 200 1ms'],
     ['hmr', 'watching src/**/*.ts'],
     ['bot', 'Interaction /ping from user#1234'],
     ['http', 'GET /metrics 200 3ms'],
     ['bot', 'Interaction /play from user#5678'],
     ['hmr', 'no changes detected'],
-    ['http', 'GET /healthcheck 200 1ms'],
+    ['http', 'GET /health 200 1ms'],
     ['bot', 'Interaction /queue from user#9012']
 ];
 

--- a/packages/types/src/Interfaces/Config.ts
+++ b/packages/types/src/Interfaces/Config.ts
@@ -85,6 +85,12 @@ export interface BotConfig {
 }
 
 /**
+ * The transport configs' `healthCheck` field. `false` disables the health server, `true` and
+ * `undefined` run it with the defaults, an object supplies {@link HealthCheckConfig} options.
+ */
+export type HealthCheckOption = boolean | HealthCheckConfig;
+
+/**
  * Health-check HTTP server settings.
  */
 export interface HealthCheckConfig {
@@ -97,7 +103,7 @@ export interface HealthCheckConfig {
     /**
      * Path the health-check server responds on.
      *
-     * @defaultValue `'/healthcheck'`
+     * @defaultValue `'/health'`
      */
     path?: string;
     /**
@@ -134,18 +140,6 @@ export interface Config {
      * Omit for Discord's default color.
      */
     botColor?: BotColor;
-
-    /**
-     * Whether coordinated shutdown registers OS signal handlers and runs teardown tasks.
-     *
-     * @defaultValue `true`
-     */
-    shutdownEnabled?: boolean;
-
-    /**
-     * Health-check HTTP server settings.
-     */
-    healthCheck?: HealthCheckConfig;
 
     /**
      * Settings for framework-sent error notifications.


### PR DESCRIPTION
`HttpConfig` is added in the http-class PR.