### PR TITLE
feat: plugin attach type checking

### DIFF
--- a/.changeset/plugin-attach-scope-gates.md
+++ b/.changeset/plugin-attach-scope-gates.md
@@ -1,0 +1,13 @@
+---
+'@seedcord/core': minor
+'@seedcord/gateway': minor
+'@seedcord/http': minor
+---
+
+**BREAKING:** `PluginOptions.transport` and `.runtime` take `'any'` in place of `'both'`. `'any'` is the default for both axes, so a plugin that declares neither is unaffected.
+
+**BREAKING:** `attach` now rejects a plugin whose declared `transport` or `runtime` the host does not run, and an edge host rejects every plugin. The error message contains the plugin's declared value and the bot's.
+
+A plugin declaring any of `transport`, `runtime`, or `needs` can now be attached. Before this, `attach` accepted only plugins that declared no options.
+
+`new Seedcord(config)` on http reads its runtime from the config it is constructed with. A config typed as the whole `HttpConfig` union leaves the host on both runtimes and it accepts no plugins, so narrow the config to `HttpServerConfig` to attach.

--- a/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
+++ b/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
@@ -86,7 +86,14 @@ export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase> {
         this.startupGate = settled;
     }
 
-    /** Adds a shutdown-phase task. @param timeoutMs - Task timeout in ms. {@default 5000} */
+    /**
+     * Adds a shutdown-phase task.
+     *
+     * @param phase - The shutdown phase to run the task in.
+     * @param taskName - A descriptive name for the task.
+     * @param task - The async function to run.
+     * @param timeoutMs - Task timeout in ms. {@default `5000` }
+     */
     public override addTask(phase: ShutdownPhase, taskName: string, task: () => Promise<void>, timeoutMs = 5000): void {
         super.addTask(phase, taskName, task, timeoutMs);
     }
@@ -100,8 +107,8 @@ export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase> {
      * Runs registered tasks across shutdown phases in `ShutdownPhase` order.
      * Tasks within each phase run in parallel.
      *
-     * @param exitCode - Process exit code. {@default `0`}
-     * @param exitProcess - Whether to exit the process after shutdown. {@default `true`}
+     * @param exitCode - Process exit code. {@default `0` }
+     * @param exitProcess - Whether to exit the process after shutdown. {@default `true` }
      * @example
      * ```typescript
      * shutdown.addTask(ShutdownPhase.Disconnect, 'database', () => db.disconnect(), 5000);

--- a/packages/core/src/node/Lifecycle/CoordinatedStartup.ts
+++ b/packages/core/src/node/Lifecycle/CoordinatedStartup.ts
@@ -22,7 +22,14 @@ export class CoordinatedStartup extends CoordinatedLifecycle<StartupPhase> {
         super('Startup', PHASE_ORDER, StartupPhase);
     }
 
-    /** Adds a startup-phase task. @param timeoutMs - Task timeout in ms. {@default 10000} */
+    /**
+     * Adds a startup-phase task.
+     *
+     * @param phase - The startup phase to run the task in.
+     * @param taskName - A descriptive name for the task.
+     * @param task - The async function to run.
+     * @param timeoutMs - Task timeout in ms. {@default `10000` }
+     */
     public override addTask(
         phase: StartupPhase,
         taskName: string,

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -14,12 +14,13 @@ import type { CoordinatedStartup } from '@node/Lifecycle/CoordinatedStartup';
 import type { Config, IRateLimiter, Store } from '@seedcord/types';
 import type { ShutdownPhase } from '@src/lifecycle/phases';
 import type { PluginCapabilities, PluginContext, StoredPluginContext } from '@src/plugin/context';
-import type { PluginArgs, PluginCtor, Plugin } from '@src/plugin/Plugin';
+import type { Runtime, RuntimeAssert, Transport, TransportAssert } from '@src/plugin/options';
+import type { PluginArgs, PluginCtor, PluginLike } from '@src/plugin/Plugin';
 import type { Bus } from '@subscribers/Bus';
 
 interface Attachment {
     readonly key: string;
-    readonly instance: Plugin;
+    readonly instance: PluginLike;
 }
 
 /**
@@ -28,7 +29,8 @@ interface Attachment {
  * Plugins are attached during configuration and initialized during startup, sequentially in attach
  * order within each phase. Not constructed directly, the host is a transport `Seedcord` class.
  */
-export abstract class Pluggable implements CoreBase {
+// no defaults, a default runtime of the full union contains 'edge' and RuntimeAssert rejects every plugin on that
+export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> implements CoreBase {
     public abstract readonly config: Config;
     public abstract readonly rateLimiter: IRateLimiter;
     public abstract readonly bus: Bus;
@@ -41,7 +43,7 @@ export abstract class Pluggable implements CoreBase {
 
     protected isInitialized = false;
     protected startFailed = false;
-    protected readonly plugins: Plugin[] = [];
+    protected readonly plugins: PluginLike[] = [];
 
     private readonly pluginLogger = new Logger('Plugins');
 
@@ -114,6 +116,9 @@ export abstract class Pluggable implements CoreBase {
      * available as a property on `core`. Augment the transport's `Core` interface with the plugin
      * type for intellisense.
      *
+     * A plugin declaring a `transport` or `runtime` this host does not run is a compile error on
+     * this call. An edge host takes no plugins at all.
+     *
      * @typeParam Key - The property name for accessing the plugin
      * @typeParam Ctor - The plugin constructor type
      * @param key - Property name to access the plugin instance
@@ -129,7 +134,7 @@ export abstract class Pluggable implements CoreBase {
     public attach<Key extends string, Ctor extends PluginCtor>(
         this: this,
         key: Key,
-        Plugin: Ctor,
+        Plugin: Ctor & TransportAssert<InstanceType<Ctor>, BotT> & RuntimeAssert<InstanceType<Ctor>, BotRt>,
         ...args: PluginArgs<Ctor>
     ): this & Record<Key, InstanceType<Ctor>> {
         if (this.isInitialized) {
@@ -147,7 +152,7 @@ export abstract class Pluggable implements CoreBase {
         return Object.assign(this, { [key]: instance } as Record<Key, InstanceType<Ctor>>);
     }
 
-    private finalizeContext(key: string, instance: Plugin): void {
+    private finalizeContext(key: string, instance: PluginLike): void {
         const caps = this.pluginCapabilities();
         const readToken = (): string | undefined => this.pluginCapabilities().token;
         const ctx: StoredPluginContext = {

--- a/packages/core/src/plugin/Plugin.ts
+++ b/packages/core/src/plugin/Plugin.ts
@@ -88,13 +88,21 @@ export abstract class Plugin<Opts extends PluginOptions = {}> implements Initial
 }
 
 /** @internal */
-export function resolvedLifecycleSpecOf(plugin: Plugin): ResolvedPluginLifecycleSpec {
+export function resolvedLifecycleSpecOf(plugin: PluginLike): ResolvedPluginLifecycleSpec {
     return plugin[resolvedSpecSlot];
 }
 
 export type { PluginContext, PluginCapabilityTypes } from './context';
 export type { PluginLifecycleSpec } from './lifecycle';
 export type { PluginOptions } from './options';
+
+// a bound of Plugin<{}> rejects every plugin that declares an option, since Plugin<A> and Plugin<B>
+// are mutually unassignable. every member here must stay Opts-independent.
+/** @internal */
+export type PluginLike = Pick<
+    Plugin,
+    'init' | 'ready' | 'dispose' | 'logger' | 'onHmr' | typeof resolvedSpecSlot | typeof pluginContextSlot
+>;
 
 /**
  * Constructor type for plugins that can accept extra arguments after Core.
@@ -106,7 +114,7 @@ export type { PluginOptions } from './options';
  *
  * @internal
  */
-export type PluginCtor<TPlugin extends Plugin = Plugin> = new (...args: any[]) => TPlugin;
+export type PluginCtor<TPlugin extends PluginLike = PluginLike> = new (...args: any[]) => TPlugin;
 
 /** @internal */
 export type PluginArgs<Ctor extends PluginCtor> = Tail<ConstructorParameters<Ctor>>;

--- a/packages/core/src/plugin/options.ts
+++ b/packages/core/src/plugin/options.ts
@@ -1,3 +1,5 @@
+import type { TypedExclude } from '@seedcord/types';
+
 /** A capability a plugin declares through `needs`, each surfacing a typed `ctx` field. */
 export type PluginNeed = 'client' | 'token' | 'rest';
 
@@ -7,28 +9,64 @@ export type PluginNeed = 'client' | 'token' | 'rest';
  */
 export interface PluginOptions {
     /**
-     * Which transport the plugin runs on.
-     * @defaultValue 'both'
+     * Which transport the plugin runs on. `'any'` attaches to either one.
+     * @defaultValue 'any'
      */
-    transport?: 'gateway' | 'http' | 'both';
+    transport?: 'gateway' | 'http' | 'any';
     /**
-     * Which runtime the plugin runs on.
-     * @defaultValue 'both'
+     * Which runtime the plugin runs on. `'any'` attaches to either one.
+     * @defaultValue 'any'
      */
-    runtime?: 'server' | 'edge' | 'both';
+    runtime?: 'server' | 'edge' | 'any';
     /** Capabilities the plugin requests, each a typed `ctx` field. */
     needs?: PluginNeed;
 }
 
 /** @internal */
 export type TransportOf<Opts extends PluginOptions> = undefined extends Opts['transport']
-    ? 'both'
+    ? 'any'
     : NonNullable<Opts['transport']>;
 
 /** @internal */
 export type RuntimeOf<Opts extends PluginOptions> = undefined extends Opts['runtime']
-    ? 'both'
+    ? 'any'
     : NonNullable<Opts['runtime']>;
 
 /** @internal */
 export type NeedsOf<Opts extends PluginOptions> = undefined extends Opts['needs'] ? never : NonNullable<Opts['needs']>;
+
+/** @internal the transport a bot runs */
+export type Transport = TypedExclude<NonNullable<PluginOptions['transport']>, 'any'>;
+
+/** @internal the runtime a bot runs */
+export type Runtime = TypedExclude<NonNullable<PluginOptions['runtime']>, 'any'>;
+
+interface TransportMismatch<PluginT extends string, BotT extends string> {
+    ERROR_plugin_transport_does_not_match_this_bot: { plugin: PluginT; bot: BotT };
+}
+
+interface RuntimeMismatch<PluginRt extends string, BotRt extends string> {
+    ERROR_plugin_runtime_does_not_match_this_bot: { plugin: PluginRt; bot: BotRt };
+}
+
+interface EdgePluginsUnsupported {
+    ERROR_edge_plugins_arrive_post_v1: never;
+}
+
+type BrandTransport<Plug> = Plug extends { readonly __transport?: infer T extends string } ? T : 'any';
+type BrandRuntime<Plug> = Plug extends { readonly __runtime?: infer R extends string } ? R : 'any';
+
+// `unknown` vanishes from the intersection at the attach parameter, and a mismatch object leaves
+// the argument unassignable there.
+/** @internal */
+export type TransportAssert<Plug, BotT extends Transport> =
+    BrandTransport<Plug> extends 'any' | BotT ? unknown : TransportMismatch<BrandTransport<Plug>, BotT>;
+
+// keep `'edge' extends BotRt`. the flipped `BotRt extends 'edge'` distributes, and the 'server' arm
+// gives `unknown`, which absorbs the edge arm and drops the gate on an un-narrowed host runtime.
+/** @internal */
+export type RuntimeAssert<Plug, BotRt extends Runtime> = 'edge' extends BotRt
+    ? EdgePluginsUnsupported
+    : BrandRuntime<Plug> extends 'any' | BotRt
+      ? unknown
+      : RuntimeMismatch<BrandRuntime<Plug>, BotRt>;

--- a/packages/core/tests/node/pluggable-attach-scopes.test.ts
+++ b/packages/core/tests/node/pluggable-attach-scopes.test.ts
@@ -1,0 +1,171 @@
+import { Logger } from '@seedcord/logger';
+import { MemoryRateLimiter } from '@seedcord/rate-limiter';
+import { describe, it, expect, expectTypeOf, afterEach } from 'vitest';
+
+import { CoordinatedShutdown } from '@node/Lifecycle/CoordinatedShutdown';
+import { CoordinatedStartup } from '@node/Lifecycle/CoordinatedStartup';
+import { Pluggable } from '@node/Pluggable';
+import { Plugin } from '@src/plugin/Plugin';
+import { Bus } from '@subscribers/Bus';
+
+import type { Config, IRateLimiter } from '@seedcord/types';
+import type { Runtime } from '@src/plugin/options';
+
+class GatewayScoped extends Plugin<{ transport: 'gateway' }> {
+    public logger = new Logger('GatewayScoped');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class EdgeScoped extends Plugin<{ runtime: 'edge' }> {
+    public logger = new Logger('EdgeScoped');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class NeedsScoped extends Plugin<{ needs: 'rest' }> {
+    public logger = new Logger('NeedsScoped');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class HttpScoped extends Plugin<{ transport: 'http'; runtime: 'server'; needs: 'rest' }> {
+    public logger = new Logger('HttpScoped');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class FullyScoped extends Plugin<{ transport: 'gateway'; runtime: 'server'; needs: 'rest' }> {
+    public logger = new Logger('FullyScoped');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class TestHost extends Pluggable<'gateway', 'server'> {
+    public readonly config = {} as Config;
+    public readonly rateLimiter: IRateLimiter = new MemoryRateLimiter();
+    public readonly bus: Bus;
+
+    constructor() {
+        super(new CoordinatedShutdown(), new CoordinatedStartup());
+        this.bus = new Bus(this);
+    }
+
+    public static resetHost(): void {
+        Pluggable.reset();
+    }
+}
+
+describe('attaching a plugin that declares options', () => {
+    afterEach(() => {
+        TestHost.resetHost();
+    });
+
+    it('accepts each option axis on its own', () => {
+        const host = new TestHost();
+
+        const attached = host.attach('gw', GatewayScoped).attach('needs', NeedsScoped);
+
+        expect(attached.gw).toBeInstanceOf(GatewayScoped);
+        expect(attached.needs).toBeInstanceOf(NeedsScoped);
+    });
+
+    it('accepts all three axes at once and keeps the concrete instance type', () => {
+        const host = new TestHost();
+
+        const attached = host.attach('scoped', FullyScoped);
+
+        expect(attached.scoped).toBeInstanceOf(FullyScoped);
+        expectTypeOf(attached.scoped).toEqualTypeOf<FullyScoped>();
+    });
+
+    it('keeps the declared brands readable off the attached instance type', () => {
+        expectTypeOf<FullyScoped['__transport']>().toEqualTypeOf<'gateway' | undefined>();
+        expectTypeOf<FullyScoped['__runtime']>().toEqualTypeOf<'server' | undefined>();
+        expectTypeOf<GatewayScoped['__runtime']>().toEqualTypeOf<'any' | undefined>();
+    });
+
+    it('rejects a plugin scoped to the other transport', () => {
+        const host = new TestHost();
+
+        // @ts-expect-error HttpScoped declares transport 'http', this host is 'gateway'
+        host.attach('wrong', HttpScoped);
+    });
+
+    it('rejects a plugin scoped to the other runtime', () => {
+        const host = new TestHost();
+
+        // @ts-expect-error EdgeScoped declares runtime 'edge', this host is 'server'
+        host.attach('wrong', EdgeScoped);
+    });
+
+    it('rejects every plugin on an edge host', () => {
+        class EdgeHost extends Pluggable<'http', 'edge'> {
+            public readonly config = {} as Config;
+            public readonly rateLimiter: IRateLimiter = new MemoryRateLimiter();
+            public readonly bus: Bus;
+            constructor() {
+                super(new CoordinatedShutdown(), new CoordinatedStartup());
+                this.bus = new Bus(this);
+            }
+            public static resetHost(): void {
+                Pluggable.reset();
+            }
+        }
+        EdgeHost.resetHost();
+        const host = new EdgeHost();
+
+        // @ts-expect-error edge plugins arrive post-v1, an unscoped plugin is rejected too
+        host.attach('any', NeedsScoped);
+    });
+
+    it('rejects every plugin when the host runtime is not narrowed to one value', () => {
+        // an http host lands here when its config type is the whole union, leaving 'edge' in BotRt
+        class WideHost extends Pluggable<'http', Runtime> {
+            public readonly config = {} as Config;
+            public readonly rateLimiter: IRateLimiter = new MemoryRateLimiter();
+            public readonly bus: Bus;
+            constructor() {
+                super(new CoordinatedShutdown(), new CoordinatedStartup());
+                this.bus = new Bus(this);
+            }
+            public static resetHost(): void {
+                Pluggable.reset();
+            }
+        }
+        WideHost.resetHost();
+        const host = new WideHost();
+
+        // @ts-expect-error a host that might be edge takes no plugins
+        host.attach('any', NeedsScoped);
+    });
+
+    it('rejects a class that carries no plugin brand', () => {
+        const host = new TestHost();
+
+        // every PluginLike member except the two symbol slots
+        class Impostor {
+            public logger = new Logger('Impostor');
+            public init(): Promise<void> {
+                return Promise.resolve();
+            }
+            public ready(): Promise<void> {
+                return Promise.resolve();
+            }
+            public dispose(): Promise<void> {
+                return Promise.resolve();
+            }
+            public onHmr(): Promise<void> {
+                return Promise.resolve();
+            }
+        }
+
+        // @ts-expect-error Impostor lacks the two symbol slots
+        host.attach('impostor', Impostor);
+    });
+});

--- a/packages/core/tests/node/pluggable-attach.test.ts
+++ b/packages/core/tests/node/pluggable-attach.test.ts
@@ -50,7 +50,7 @@ class TestPlugin extends Plugin {
     public onDispose?: () => void;
 }
 
-class TestHost extends Pluggable {
+class TestHost extends Pluggable<'gateway', 'server'> {
     public readonly config: Config;
     public readonly rateLimiter: IRateLimiter = new MemoryRateLimiter();
     public readonly bus: Bus;

--- a/packages/core/tests/plugin/options.test.ts
+++ b/packages/core/tests/plugin/options.test.ts
@@ -28,9 +28,9 @@ class Narrowed extends Plugin<{ transport: 'gateway'; runtime: 'server' }> {
 }
 
 describe('plugin brands', () => {
-    it('defaults both axis brands to both', () => {
-        expectTypeOf<Defaults['__transport']>().toEqualTypeOf<'both' | undefined>();
-        expectTypeOf<Defaults['__runtime']>().toEqualTypeOf<'both' | undefined>();
+    it('defaults both axis brands to any', () => {
+        expectTypeOf<Defaults['__transport']>().toEqualTypeOf<'any' | undefined>();
+        expectTypeOf<Defaults['__runtime']>().toEqualTypeOf<'any' | undefined>();
     });
 
     it('carries the declared axis literals', () => {

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -27,7 +27,7 @@ import type { SeedcordInstance } from '@seedcord/types/internal';
  * The gateway bot host. Opens a discord.js gateway session, discovers handlers, and runs
  * coordinated startup and shutdown. Attach plugins with `attach()`.
  */
-export class Seedcord extends Pluggable implements Core, SeedcordInstance {
+export class Seedcord extends Pluggable<'gateway', 'server'> implements Core, SeedcordInstance {
     // the CLI reads these to detect and augment the instance
     /** @internal */
     public readonly [SeedcordBrand] = true;

--- a/packages/gateway/src/bot/decorators/Middlewares.ts
+++ b/packages/gateway/src/bot/decorators/Middlewares.ts
@@ -44,7 +44,7 @@ export interface MiddlewareMetadata {
  * Interaction middleware cannot specify event filters.
  *
  * @param type - Middleware kind from {@link MiddlewareType}
- * @param priority - Ordering value where lower runs earlier. {@default `0`}
+ * @param priority - Ordering value where lower runs earlier. {@default `0` }
  * @param options - Additional registration options
  *
  * @decorator

--- a/packages/gateway/tests/plugin-attach-scopes.test.ts
+++ b/packages/gateway/tests/plugin-attach-scopes.test.ts
@@ -1,0 +1,52 @@
+import { Plugin } from '@seedcord/core/plugin';
+import { Logger } from '@seedcord/logger';
+import { describe, it, expect } from 'vitest';
+
+import type { Seedcord } from '@src/Seedcord';
+
+class Anywhere extends Plugin {
+    public logger = new Logger('Anywhere');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class GatewayOnly extends Plugin<{ transport: 'gateway' }> {
+    public logger = new Logger('GatewayOnly');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class HttpOnly extends Plugin<{ transport: 'http' }> {
+    public logger = new Logger('HttpOnly');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class EdgeOnly extends Plugin<{ runtime: 'edge' }> {
+    public logger = new Logger('EdgeOnly');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+// compile-only. tc is the assertion, and an unused @ts-expect-error fails it.
+function probeAccepts(bot: Seedcord): void {
+    bot.attach('anywhere', Anywhere);
+    bot.attach('gw', GatewayOnly);
+}
+
+function probeRejects(bot: Seedcord): void {
+    // @ts-expect-error HttpOnly declares transport 'http'
+    bot.attach('http', HttpOnly);
+    // @ts-expect-error EdgeOnly declares runtime 'edge', a gateway bot is always server
+    bot.attach('edge', EdgeOnly);
+}
+
+describe('gateway attach scopes', () => {
+    it('pins the host to the gateway transport and the server runtime', () => {
+        expect([probeAccepts, probeRejects]).toHaveLength(2);
+    });
+});

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -41,6 +41,8 @@ const DEFAULT_PORT = 3000;
 const SERVER_SHUTDOWN_TIMEOUT_MS = 5000;
 const DRAIN_TIMEOUT_MS = 10_000;
 
+type RuntimeOfConfig<Cfg extends HttpConfig> = Cfg extends { runtime: 'edge' } ? 'edge' : 'server';
+
 /**
  * The HTTP-interactions bot host, a long-running node server around the engine.
  *
@@ -48,7 +50,10 @@ const DRAIN_TIMEOUT_MS = 10_000;
  * `start(port)`, and runs coordinated shutdown with an in-flight drain. The edge deploy path calls
  * `createSeedcord` from a generated entry.
  */
-export class Seedcord extends Pluggable implements Core, SeedcordInstance {
+export class Seedcord<Cfg extends HttpConfig = HttpConfig>
+    extends Pluggable<'http', RuntimeOfConfig<Cfg>>
+    implements Core, SeedcordInstance
+{
     // the CLI reads these to detect and augment the instance
     /** @internal */
     public readonly [SeedcordBrand] = true;
@@ -78,7 +83,7 @@ export class Seedcord extends Pluggable implements Core, SeedcordInstance {
     private requestedPort = DEFAULT_PORT;
     private fetchedUsername?: string | undefined;
 
-    constructor(public readonly config: HttpConfig) {
+    constructor(public readonly config: Cfg) {
         super(new CoordinatedShutdown(), new CoordinatedStartup());
 
         installNodeDefaults(config.logger);
@@ -119,7 +124,7 @@ export class Seedcord extends Pluggable implements Core, SeedcordInstance {
     /**
      * Starts the host and runs the startup tasks.
      *
-     * @param port - The port the interaction server binds. {@default `3000`}
+     * @param port - The port the interaction server binds. {@default `3000` }
      */
     public async start(port = DEFAULT_PORT): Promise<this> {
         this.requestedPort = port;

--- a/packages/http/tests/node/plugin-attach-scopes.test.ts
+++ b/packages/http/tests/node/plugin-attach-scopes.test.ts
@@ -1,0 +1,50 @@
+import { Plugin } from '@seedcord/core/plugin';
+import { Logger } from '@seedcord/logger';
+import { describe, it, expect } from 'vitest';
+
+import type { HttpEdgeConfig, HttpServerConfig } from '@interfaces/Config';
+import type { Seedcord } from '@src/node/Seedcord';
+
+class Anywhere extends Plugin {
+    public logger = new Logger('Anywhere');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class HttpOnly extends Plugin<{ transport: 'http' }> {
+    public logger = new Logger('HttpOnly');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+class GatewayOnly extends Plugin<{ transport: 'gateway' }> {
+    public logger = new Logger('GatewayOnly');
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+function probeServerAccepts(bot: Seedcord<HttpServerConfig>): void {
+    bot.attach('anywhere', Anywhere);
+    bot.attach('http', HttpOnly);
+}
+
+function probeServerRejects(bot: Seedcord<HttpServerConfig>): void {
+    // @ts-expect-error GatewayOnly declares transport 'gateway'
+    bot.attach('gw', GatewayOnly);
+}
+
+function probeEdgeRejectsEverything(bot: Seedcord<HttpEdgeConfig>): void {
+    // @ts-expect-error edge plugins arrive post-v1
+    bot.attach('anywhere', Anywhere);
+    // @ts-expect-error edge plugins arrive post-v1
+    bot.attach('http', HttpOnly);
+}
+
+describe('http attach scopes', () => {
+    it('reads the runtime off the config literal the host is constructed with', () => {
+        expect([probeServerAccepts, probeServerRejects, probeEdgeRejectsEverything]).toHaveLength(3);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin attachment now validates transport and runtime compatibility with the host.
  * Plugins can declare transport, runtime, and required capabilities independently.
  * Added support for the `'any'` scope for transport and runtime settings.
  * HTTP server configurations now preserve runtime-specific plugin compatibility.

* **Documentation**
  * Expanded lifecycle task documentation and clarified plugin attachment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->