### PR TITLE
feat: adapt the dev tui to terminal size

### DIFF
--- a/.changeset/dev-terminal-fit.md
+++ b/.changeset/dev-terminal-fit.md
@@ -1,0 +1,5 @@
+---
+'seedcord': patch
+---
+
+`seedcord dev` adapts to the terminal size. A short terminal collapses the filter chips, and a shorter one replaces the sidebar with a single status line.

--- a/.github/skills/release-version/SKILL.md
+++ b/.github/skills/release-version/SKILL.md
@@ -66,7 +66,7 @@ git commit -am "chore(release): version packages"
 git push origin main                 # or open a PR if main is branch-protected, then merge it
 ```
 
-Wait for the `main` publish workflow to finish green, because CI does the actual publish. Then:
+Then **wait for the `main` publish workflow to finish green**, because CI does the actual publish. The `Protect Publishers` ruleset requires a PR with one approval on `main`. Push directly with a bypass, or run the same steps on a branch and merge the PR.
 
 ```sh
 npm dist-tag ls seedcord             # latest now points at the clean X.Y.Z
@@ -80,7 +80,8 @@ Bring the clean version back and re-enter pre mode for the next cycle.
 git switch next && git pull
 git merge main                       # brings the clean versions and changelogs
 pnpm changeset pre enter next        # re-enter pre mode
-git commit -am "chore: re-enter pre mode"
+git add .changeset/pre.json          # pre enter writes a new file, -a would skip it
+git commit -m "chore: re-enter pre mode"
 git push origin next
 ```
 

--- a/packages/core/src/node/HealthCheck.ts
+++ b/packages/core/src/node/HealthCheck.ts
@@ -66,16 +66,14 @@ export class HealthCheck {
             server.on('error', onListenError);
 
             server.once('listening', () => {
-                // Swap the listen-time reject handler for a logging one: keeping it would reject an
-                // already-settled promise on a late error, and removing it without a replacement
-                // would crash the process on an unhandled 'error' event.
+                // a late error would reject an already-settled promise, and no 'error' listener at all crashes the process
                 server.removeListener('error', onListenError);
                 server.on('error', (err) => this.logger.error('Health check server error', err));
 
-                // the server binds all interfaces, the log shows an address a browser can open
+                // binds all interfaces, so log an address a browser can open
                 const address = this.host ?? 'localhost';
                 this.logger.info(
-                    `${paint.mint.bold('✓')} Health check server listening on ${paint.sky(`http://${address}:${this.port}${this.path}`)}`
+                    `${paint.mint.bold('✔︎')} Health check server listening on ${paint.sky(`http://${address}:${this.port}${this.path}`)}`
                 );
                 resolve();
             });

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -187,7 +187,7 @@ const messages = {
     [SeedcordErrorCode.CliTsxImportFailed]: (entryPath: string, reason: string) =>
         `Failed to import ${entryPath} via tsx: ${reason}`,
     [SeedcordErrorCode.CliImportFailed]: (entryPath: string, nativeReason: string, fallbackReason: string) =>
-        `Failed to import ${entryPath}: ${nativeReason} Fallback via jiti also failed: ${fallbackReason}`,
+        `Failed to import ${entryPath}: ${nativeReason} (the jiti fallback also failed: ${fallbackReason})`,
     [SeedcordErrorCode.CliInstanceInvalid]: () =>
         'Seedcord instance must default export an object with a start() method.',
     [SeedcordErrorCode.CliStartFailed]: (instancePath: string, reason: string) =>

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -185,18 +185,18 @@ const messages = {
         `Entry file ${entryPath} must reside inside configured root ${root}.`,
     [SeedcordErrorCode.CliEntryNotFound]: (entryPath: string) => `Cannot find entry file at ${entryPath}.`,
     [SeedcordErrorCode.CliTsxImportFailed]: (entryPath: string, reason: string) =>
-        `Failed to import ${entryPath} via tsx: ${reason}.`,
+        `Failed to import ${entryPath} via tsx: ${reason}`,
     [SeedcordErrorCode.CliImportFailed]: (entryPath: string, nativeReason: string, fallbackReason: string) =>
-        `Failed to import ${entryPath}: ${nativeReason}. Fallback via jiti also failed: ${fallbackReason}.`,
+        `Failed to import ${entryPath}: ${nativeReason} Fallback via jiti also failed: ${fallbackReason}`,
     [SeedcordErrorCode.CliInstanceInvalid]: () =>
         'Seedcord instance must default export an object with a start() method.',
     [SeedcordErrorCode.CliStartFailed]: (instancePath: string, reason: string) =>
-        `Failed to start Seedcord from ${instancePath}: ${reason}.`,
+        `Failed to start Seedcord from ${instancePath}: ${reason}`,
     [SeedcordErrorCode.CliBuildTsconfigNotFound]: (hint: string) =>
         `Unable to resolve a tsconfig for builds (${hint}). Provide build.tsconfig or add tsconfig.build.json / tsconfig.json.`,
     [SeedcordErrorCode.CliBuildFailed]: (diagnostics: string) => `TypeScript build failed:\n${diagnostics}`,
     [SeedcordErrorCode.CliBootstrapWriteFailed]: (targetPath: string, reason: string) =>
-        `Failed to write bootstrap file at ${targetPath}: ${reason}.`,
+        `Failed to write bootstrap file at ${targetPath}: ${reason}`,
     [SeedcordErrorCode.CliConfigInvalidTsconfig]: () => 'Config `tsconfig` must be a string when provided.',
     [SeedcordErrorCode.CliConfigInvalidHmr]: () => 'Config `hmr` must be an object when provided.',
     [SeedcordErrorCode.CliConfigInvalidHmrRestart]: () =>
@@ -205,7 +205,7 @@ const messages = {
     [SeedcordErrorCode.CliCodegenDuplicateRoute]: (route: string, firstFile: string, secondFile: string) =>
         `Two commands resolve to the same slash route \`${route}\`. Defined in ${firstFile} and ${secondFile}. Rename one.`,
     [SeedcordErrorCode.CliCodegenCommandsDirUnreadable]: (dir: string, reason: string) =>
-        `Could not read the commands directory ${dir} during codegen. ${reason}.`,
+        `Could not read the commands directory ${dir} during codegen. ${reason}`,
     [SeedcordErrorCode.CliCodegenDuplicateContextMenu]: (
         kind: string,
         name: string,
@@ -214,7 +214,7 @@ const messages = {
     ) =>
         `Two ${kind} context-menu commands share the name \`${name}\`. Defined in ${firstFile} and ${secondFile}. Rename one.`,
     [SeedcordErrorCode.CliCleanAppFetchFailed]: (reason: string) =>
-        `Could not resolve the application from the bot token. ${reason}.`,
+        `Could not resolve the application from the bot token. ${reason}`,
     [SeedcordErrorCode.CliCleanNoGuilds]: () =>
         'No guilds given. Pass --guild <ids...> or --all-guilds. Global commands are never touched.',
     [SeedcordErrorCode.CliCleanPurgeAllGuilds]: () =>

--- a/packages/seedcord/src/commands/dev/DevRunner.ts
+++ b/packages/seedcord/src/commands/dev/DevRunner.ts
@@ -114,7 +114,7 @@ class SeedcordDevSession {
         this.instance?.startup.abort();
 
         if (this.startupPromise) {
-            // startup.abort() was triggered above. await the rejection and suppress it to maintain shutdown order
+            // suppress the abort rejection to keep shutdown ordered
             try {
                 await this.startupPromise;
             } catch {
@@ -221,7 +221,7 @@ export class DevRunner {
     private async handleError(error: unknown): Promise<void> {
         this.store.setPhase('error');
         this.store.setError(Error.isError(error) ? error : new Error(String(error)));
-        this.store.setStatus('Error occurred. Press r to restart.');
+        this.store.setStatus('Press r to restart.');
         this.store.setBusy(false);
         await this.waitForSignal();
         this.store.setBusy(true);
@@ -254,14 +254,14 @@ export class DevRunner {
         this.currentSession?.refreshCommands(shouldRefresh);
     }
 
-    // an accepted refresh means command files changed, regenerate the typed registry so tsc picks up the new option types
+    // an accepted refresh means command files changed, so regenerate the registry for tsc to pick up the new option types
     private async regenerateRegistry(): Promise<void> {
         if (this.isRegenerating) return;
         this.isRegenerating = true;
         try {
             await this.codegen.run(false);
         } catch (error: unknown) {
-            // codegen throws, log here and keep the dev session running
+            // codegen throws, so log here and keep the dev session running
             this.codegenLogger.error('Command registry regeneration failed', error);
         } finally {
             this.isRegenerating = false;

--- a/packages/seedcord/src/ui/DevApp.tsx
+++ b/packages/seedcord/src/ui/DevApp.tsx
@@ -1,16 +1,19 @@
-import { Box, measureElement, useInput, useWindowSize } from 'ink';
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Box, useInput, useWindowSize } from 'ink';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { INITIAL_CURSOR } from '@ui/filterCursor';
 import { useDevState } from '@ui/hooks/useDevState';
 import { useLogs } from '@ui/hooks/useLogs';
+import { useMeasuredHeight } from '@ui/hooks/useMeasuredHeight';
 import { useRailWidth } from '@ui/hooks/useRailWidth';
 import { useScroll } from '@ui/hooks/useScroll';
 import { useUptime } from '@ui/hooks/useUptime';
 import { dispatchHotkey } from '@ui/hotkeys';
 import { DevLayout } from '@ui/layout/DevLayout';
 import { expandRows, rowKey } from '@ui/logRows';
+import { noticesOf } from '@ui/notices';
 import { LogStore } from '@ui/stores/LogStore';
+import { tierFor } from '@ui/tier';
 
 import type { LogLevel } from '@seedcord/logger';
 import type { DevStore } from '@ui/stores/DevStore';
@@ -36,10 +39,13 @@ export function DevApp(props: DevAppProps): ReactElement {
     const [cursor, setCursor] = useState(INITIAL_CURSOR);
 
     const logBoxRef = useRef<DOMElement | null>(null);
-    const [logBoxHeight, setLogBoxHeight] = useState(0);
+    const logBoxHeight = useMeasuredHeight(logBoxRef);
 
     const railRef = useRef<DOMElement | null>(null);
     const railWidth = useRailWidth(railRef, state.phase, rows, columns);
+
+    const tier = tierFor(rows, columns);
+    const notices = noticesOf(state);
 
     const logs = useLogs(enabled, enabledLevels);
     const logRows = useMemo(() => expandRows(logs), [logs]);
@@ -48,15 +54,6 @@ export function DevApp(props: DevAppProps): ReactElement {
     const uptimeMs = useUptime(state);
 
     const interactive = !state.isBusy || state.restartRequired;
-
-    // re-measure on anything that changes the box height, a resize, a notification card, or the scroll header
-    // toggling between its scroll status and nothing while following
-    useLayoutEffect(() => {
-        if (!logBoxRef.current) return;
-        const measured = measureElement(logBoxRef.current).height;
-        // eslint-disable-next-line @eslint-react/set-state-in-effect -- Ink layout is only measurable after render, so this sets the scroll-window height
-        setLogBoxHeight((prev) => (prev === measured ? prev : measured));
-    }, [rows, columns, state.error, state.restartRequired, state.commandUpdatePrompt, scroll.following]);
 
     useInput((input, key) => {
         dispatchHotkey({
@@ -72,6 +69,7 @@ export function DevApp(props: DevAppProps): ReactElement {
             setEnabledLevels,
             cursor,
             setCursor,
+            filtersOpen: tier === 'full',
             onQuit: props.onQuit,
             onDisconnect: props.onDisconnect,
             onRestart: props.onRestart,
@@ -97,12 +95,15 @@ export function DevApp(props: DevAppProps): ReactElement {
         <Box flexDirection="column" width={columns} height={rows} overflow="hidden">
             <DevLayout
                 state={state}
+                tier={tier}
+                notices={notices}
                 railRef={railRef}
                 railWidth={railWidth}
                 logBoxRef={logBoxRef}
                 scroll={scroll}
                 viewportHeight={viewportHeight}
                 measured={logBoxHeight > 0}
+                columns={columns}
                 enabled={enabled}
                 enabledLevels={enabledLevels}
                 cursor={cursor}

--- a/packages/seedcord/src/ui/components/ErrorDisplay.tsx
+++ b/packages/seedcord/src/ui/components/ErrorDisplay.tsx
@@ -18,12 +18,10 @@ export function ErrorDisplay({ error }: ErrorDisplayProps): ReactElement {
     const hidden = frames.length - preview.length;
 
     return (
-        <Box flexDirection="column" borderStyle="round" borderColor={ui.bad} padding={1}>
-            <Box marginTop={-1}>
-                <Text color={ui.bad} bold>
-                    Error: {error.name}
-                </Text>
-            </Box>
+        <Box flexDirection="column" borderStyle="round" borderColor={ui.bad} paddingX={1}>
+            <Text color={ui.bad} bold>
+                Error: {error.name}
+            </Text>
             <Text>{error.message}</Text>
             {preview.length > 0 && (
                 <Box marginTop={1} flexDirection="column">

--- a/packages/seedcord/src/ui/components/StatusBadge.tsx
+++ b/packages/seedcord/src/ui/components/StatusBadge.tsx
@@ -2,27 +2,31 @@ import { Text } from 'ink';
 import Spinner from 'ink-spinner';
 import React from 'react';
 
-import { PHASE_META } from '@ui/stores/devPhase';
+import { isStreaming, PHASE_META } from '@ui/stores/devPhase';
+
+import { BlinkDot } from './primitives/BlinkDot';
 
 import type { DevPhase } from '@ui/stores/devPhase';
 import type { ReactElement } from 'react';
 
 interface StatusBadgeProps {
     readonly phase: DevPhase;
+    readonly glyph?: 'phase' | 'live';
 }
 
-function Glyph({ phase }: { phase: DevPhase }): ReactElement {
+function Glyph({ phase, glyph }: Required<StatusBadgeProps>): ReactElement {
     const meta = PHASE_META[phase];
+    if (glyph === 'live') return isStreaming(phase) ? <BlinkDot /> : <Text>{meta.icon}</Text>;
     if (meta.kind === 'spinner') return <Spinner type="balloon2" />;
     if (meta.kind === 'arc') return <Spinner type="toggle4" />;
     return <Text>{meta.icon}</Text>;
 }
 
-export function StatusBadge({ phase }: StatusBadgeProps): ReactElement {
+export function StatusBadge({ phase, glyph = 'phase' }: StatusBadgeProps): ReactElement {
     const meta = PHASE_META[phase];
     return (
         <Text color={meta.color} bold>
-            <Glyph phase={phase} /> {meta.label}
+            <Glyph phase={phase} glyph={glyph} /> {meta.label}
         </Text>
     );
 }

--- a/packages/seedcord/src/ui/components/primitives/BlinkDot.tsx
+++ b/packages/seedcord/src/ui/components/primitives/BlinkDot.tsx
@@ -1,0 +1,13 @@
+import { Text, useAnimation } from 'ink';
+import React from 'react';
+
+import { ui } from '@ui/palette';
+
+import type { ReactElement } from 'react';
+
+const BLINK_MS = 530;
+
+export function BlinkDot(): ReactElement {
+    const { frame } = useAnimation({ interval: BLINK_MS });
+    return <Text color={ui.bad}>{frame % 2 === 0 ? '●' : ' '}</Text>;
+}

--- a/packages/seedcord/src/ui/components/primitives/FilterChips.tsx
+++ b/packages/seedcord/src/ui/components/primitives/FilterChips.tsx
@@ -17,6 +17,18 @@ interface FilterChipsProps {
     readonly enabledChannels: ReadonlySet<string>;
     readonly enabledLevels: ReadonlySet<LogLevel>;
     readonly cursor: FilterCursor | null;
+    readonly open: boolean;
+}
+
+function Heading({ label, open }: { label: string; open: boolean }): ReactElement {
+    return (
+        <Text>
+            <Text color={ui.accent} bold>
+                {open ? '▾' : '▸'}
+            </Text>
+            <Text color={ui.muted}> {label}</Text>
+        </Text>
+    );
 }
 
 function Chip({
@@ -46,7 +58,13 @@ function Chip({
 }
 
 // empty enabled set means all
-export function FilterChips({ channels, enabledChannels, enabledLevels, cursor }: FilterChipsProps): ReactElement {
+export function FilterChips({
+    channels,
+    enabledChannels,
+    enabledLevels,
+    cursor,
+    open
+}: FilterChipsProps): ReactElement {
     const allChannels = enabledChannels.size === 0;
     const allLevels = enabledLevels.size === 0;
     const channelFocus = focusedIn(cursor, 'channels', channels.length);
@@ -54,35 +72,40 @@ export function FilterChips({ channels, enabledChannels, enabledLevels, cursor }
 
     return (
         <Box flexDirection="column">
-            <Text bold color={ui.heading}>
-                - channels
-            </Text>
-            <Box marginLeft={2} flexWrap="wrap">
-                {channels.map((channel, index) => (
-                    <Chip
-                        key={channel}
-                        label={channel}
-                        on={allChannels || enabledChannels.has(channel)}
-                        color={channelColor(channel)}
-                        focused={channelFocus === index}
-                    />
-                ))}
-            </Box>
+            {open ? null : (
+                <Text dimColor wrap="truncate">
+                    ⇅ resize to see filters
+                </Text>
+            )}
+            <Heading label="channels" open={open} />
+            {open ? (
+                <Box marginLeft={2} flexWrap="wrap">
+                    {channels.map((channel, index) => (
+                        <Chip
+                            key={channel}
+                            label={channel}
+                            on={allChannels || enabledChannels.has(channel)}
+                            color={channelColor(channel)}
+                            focused={channelFocus === index}
+                        />
+                    ))}
+                </Box>
+            ) : null}
 
-            <Text bold color={ui.heading}>
-                - levels
-            </Text>
-            <Box marginLeft={2} flexWrap="wrap">
-                {FILTER_LEVELS.map((level, index) => (
-                    <Chip
-                        key={level}
-                        label={level}
-                        on={allLevels || enabledLevels.has(level)}
-                        color={LEVEL_COLOR[level]}
-                        focused={levelFocus === index}
-                    />
-                ))}
-            </Box>
+            <Heading label="levels" open={open} />
+            {open ? (
+                <Box marginLeft={2} flexWrap="wrap">
+                    {FILTER_LEVELS.map((level, index) => (
+                        <Chip
+                            key={level}
+                            label={level}
+                            on={allLevels || enabledLevels.has(level)}
+                            color={LEVEL_COLOR[level]}
+                            focused={levelFocus === index}
+                        />
+                    ))}
+                </Box>
+            ) : null}
         </Box>
     );
 }

--- a/packages/seedcord/src/ui/components/primitives/Hotkeys.tsx
+++ b/packages/seedcord/src/ui/components/primitives/Hotkeys.tsx
@@ -1,18 +1,11 @@
 import { Box, Text } from 'ink';
 import React from 'react';
 
-import { Rule } from '@ui/components/primitives/Rule';
 import { ui } from '@ui/palette';
 import { isSessionLive } from '@ui/stores/devPhase';
 
 import type { DevPhase } from '@ui/stores/devPhase';
 import type { ReactElement } from 'react';
-
-interface HotkeyBarProps {
-    readonly phase: DevPhase;
-    readonly interactive: boolean;
-    readonly following: boolean;
-}
 
 interface HotkeyProps {
     readonly keyLabel: string;
@@ -22,7 +15,6 @@ interface HotkeyProps {
 }
 
 function Hotkey({ keyLabel, action, enabled = true, highlight = false }: HotkeyProps): ReactElement {
-    // a disabled row goes faint on both the key and the action, so it recedes as a unit
     const keyColor = !enabled ? ui.faint : highlight ? ui.warn : ui.accent;
     const actionColor = enabled ? ui.muted : ui.faint;
     return (
@@ -35,38 +27,33 @@ function Hotkey({ keyLabel, action, enabled = true, highlight = false }: HotkeyP
     );
 }
 
-// Highlight r in the phases the user recovers from with a restart.
 const RESTART_HINT_PHASES = new Set<DevPhase>(['restart-required', 'disconnected', 'error']);
 
-function SessionKeys({
-    phase,
-    interactive,
-    following
-}: {
-    phase: DevPhase;
-    interactive: boolean;
-    following: boolean;
-}): ReactElement {
+interface SessionKeysProps {
+    readonly phase: DevPhase;
+    readonly interactive: boolean;
+    readonly following: boolean;
+}
+
+export function SessionKeys({ phase, interactive, following }: SessionKeysProps): ReactElement {
     return (
-        <>
+        <Box flexDirection="column">
             <Hotkey keyLabel="q" action="quit" />
             <Hotkey keyLabel="r" action="restart" enabled={interactive} highlight={RESTART_HINT_PHASES.has(phase)} />
             <Hotkey keyLabel="d" action="disconnect" enabled={interactive && isSessionLive(phase)} />
             <Hotkey keyLabel="l" action="clear" enabled={interactive} />
             <Hotkey keyLabel="↑↓" action="scroll" />
             <Hotkey keyLabel="t/b" action="top/bottom" highlight={!following} />
-        </>
+        </Box>
     );
 }
 
-export function HotkeyBar({ phase, interactive, following }: HotkeyBarProps): ReactElement {
+export function FilterKeys(): ReactElement {
     return (
-        <Box flexDirection="column" flexWrap="wrap">
-            <SessionKeys phase={phase} interactive={interactive} following={following} />
-            <Rule />
-            <Hotkey keyLabel="←→" action="move" />
+        <Box flexDirection="column">
+            <Hotkey keyLabel="←→" action="select" />
             <Hotkey keyLabel="tab" action="group" />
-            <Hotkey keyLabel="space" action="solo" />
+            <Hotkey keyLabel="space" action="filter" />
             <Hotkey keyLabel="o" action="toggle" />
         </Box>
     );

--- a/packages/seedcord/src/ui/components/primitives/NotificationStack.tsx
+++ b/packages/seedcord/src/ui/components/primitives/NotificationStack.tsx
@@ -1,27 +1,21 @@
 import { Box } from 'ink';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { CommandRefreshPrompt } from '../CommandRefreshPrompt';
-import { ErrorDisplay } from '../ErrorDisplay';
-import { RestartRequiredCard } from '../RestartRequiredCard';
-
+import type { Notice } from '@ui/notices';
 import type { ReactElement } from 'react';
 
 interface NotificationStackProps {
-    readonly error: Error | null;
-    readonly restartRequired: boolean;
-    readonly prompt: readonly string[] | null;
+    readonly notices: readonly Notice[];
 }
 
-// Notification cards docked below the logs. Renders nothing when idle, so it adds no rows.
-export function NotificationStack({ error, restartRequired, prompt }: NotificationStackProps): ReactElement | null {
-    if (!error && !restartRequired && !prompt) return null;
+export function NotificationStack({ notices }: NotificationStackProps): ReactElement | null {
+    if (notices.length === 0) return null;
 
     return (
         <Box flexShrink={0} flexDirection="column">
-            {error ? <ErrorDisplay error={error} /> : null}
-            {restartRequired ? <RestartRequiredCard /> : null}
-            {prompt ? <CommandRefreshPrompt files={[...prompt]} /> : null}
+            {notices.map((notice) => (
+                <Fragment key={notice.key}>{notice.card}</Fragment>
+            ))}
         </Box>
     );
 }

--- a/packages/seedcord/src/ui/components/primitives/ScrollableLogView.tsx
+++ b/packages/seedcord/src/ui/components/primitives/ScrollableLogView.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { channelColor } from '@ui/channelColor';
 import { Rule } from '@ui/components/primitives/Rule';
 import { formatClock } from '@ui/format';
+import { ui } from '@ui/palette';
 import { LogStore } from '@ui/stores/LogStore';
 
 import type { LogLevel } from '@seedcord/logger';
@@ -12,7 +13,10 @@ import type { LogRow } from '@ui/logRows';
 import type { LogEntry } from '@ui/stores/LogStore';
 import type { ReactElement } from 'react';
 
-const MIN_LOG_LINES = 3;
+// an error is a head line plus stack frames, and fewer rows shows almost none of it
+const MIN_LOG_LINES = 5;
+
+export const NO_ROOM = 'Need more room for logs.';
 const DOT = '⏺';
 const BAR = '▌';
 const GUIDE = '│';
@@ -106,9 +110,11 @@ export function ScrollableLogView({ visible, viewportHeight, measured }: Scrolla
 
     if (viewportHeight < MIN_LOG_LINES) {
         return (
-            <Text color="yellow" wrap="truncate">
-                Terminal too small to show logs.
-            </Text>
+            <Box flexGrow={1} alignItems="center" justifyContent="center" overflow="hidden">
+                <Text color={ui.warn} bold wrap="truncate">
+                    {NO_ROOM}
+                </Text>
+            </Box>
         );
     }
 

--- a/packages/seedcord/src/ui/components/primitives/Sidebar.tsx
+++ b/packages/seedcord/src/ui/components/primitives/Sidebar.tsx
@@ -1,15 +1,16 @@
-import { Box, Text, useAnimation } from 'ink';
+import { Box, Text } from 'ink';
 import React from 'react';
 
 import { formatUptime } from '@ui/format';
-import { ui } from '@ui/palette';
 import { isStreaming } from '@ui/stores/devPhase';
 import { LogStore } from '@ui/stores/LogStore';
 
 import { Banner } from '../Banner';
 import { StatusBadge } from '../StatusBadge';
+import { BlinkDot } from './BlinkDot';
 import { FilterChips } from './FilterChips';
-import { HotkeyBar } from './HotkeyBar';
+import { FilterKeys, SessionKeys } from './Hotkeys';
+import { Rule } from './Rule';
 
 import type { LogLevel } from '@seedcord/logger';
 import type { FilterCursor } from '@ui/filterCursor';
@@ -17,24 +18,12 @@ import type { DevState } from '@ui/stores/DevStore';
 import type { DOMElement } from 'ink';
 import type { ReactElement, Ref } from 'react';
 
-const MAX_RAIL = 40;
+export const MAX_RAIL = 40;
 
 const META_LABEL_WIDTH = 5;
 
 // the dev default writes one combined file into this folder
 const LOG_DIR = 'logs/';
-
-const BLINK_MS = 530;
-
-function LiveDot(): ReactElement {
-    const { frame } = useAnimation({ interval: BLINK_MS });
-    return (
-        <Text>
-            <Text color={ui.bad}>{frame % 2 === 0 ? '●' : ' '}</Text>
-            <Text dimColor> live</Text>
-        </Text>
-    );
-}
 
 interface SidebarProps {
     readonly state: DevState;
@@ -45,6 +34,7 @@ interface SidebarProps {
     readonly interactive: boolean;
     readonly cursor: FilterCursor;
     readonly width: number | null;
+    readonly filtersOpen: boolean;
     readonly ref?: Ref<DOMElement>;
 }
 
@@ -68,7 +58,7 @@ function StatusBlock({ state, uptimeMs }: { state: DevState; uptimeMs: number | 
     );
 }
 
-// flexShrink={0} on every section keeps each at its natural height, without it a short terminal overlaps rows
+// flexShrink={0} on every section holds its natural height. A short terminal overlaps rows without it
 export function Sidebar({
     state,
     enabled,
@@ -78,6 +68,7 @@ export function Sidebar({
     interactive,
     cursor,
     width,
+    filtersOpen,
     ref
 }: SidebarProps): ReactElement {
     return (
@@ -102,14 +93,29 @@ export function Sidebar({
                     enabledChannels={enabled}
                     enabledLevels={enabledLevels}
                     cursor={cursor}
+                    open={filtersOpen}
                 />
             </Box>
-            <Box flexShrink={0} marginTop={1}>
-                <HotkeyBar phase={state.phase} interactive={interactive} following={following} />
+            {filtersOpen ? (
+                <Box flexShrink={0} marginTop={1} flexDirection="column">
+                    <FilterKeys />
+                    <Rule />
+                </Box>
+            ) : null}
+            {/* the rule already separates the two key groups, so the blank row is only for the collapsed form */}
+            <Box flexShrink={0} marginTop={filtersOpen ? 0 : 1}>
+                <SessionKeys phase={state.phase} interactive={interactive} following={following} />
             </Box>
             <Box flexGrow={1} />
             <Box flexShrink={0} justifyContent="flex-end">
-                {isStreaming(state.phase) ? <LiveDot /> : <Text dimColor>○ idle</Text>}
+                {isStreaming(state.phase) ? (
+                    <Text>
+                        <BlinkDot />
+                        <Text dimColor> live</Text>
+                    </Text>
+                ) : (
+                    <Text dimColor>○ idle</Text>
+                )}
             </Box>
         </Box>
     );

--- a/packages/seedcord/src/ui/components/primitives/StatusLine.tsx
+++ b/packages/seedcord/src/ui/components/primitives/StatusLine.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from 'ink';
+import React from 'react';
+
+import { ui } from '@ui/palette';
+
+import { Banner } from '../Banner';
+import { StatusBadge } from '../StatusBadge';
+
+import type { Notice } from '@ui/notices';
+import type { DevState } from '@ui/stores/DevStore';
+import type { ReactElement } from 'react';
+
+const HINT = '⇅ resize for full ui';
+
+// below this the right slot would crowd out the summary, and the phase chip still shows the state
+const RIGHT_COLUMNS = 64;
+
+interface StatusLineProps {
+    readonly state: DevState;
+    readonly notices: readonly Notice[];
+    readonly columns: number;
+}
+
+/** The single row standing in for the rail once the terminal is too small to hold it. */
+export function StatusLine({ state, notices, columns }: StatusLineProps): ReactElement {
+    const [top, ...rest] = notices;
+
+    return (
+        <Box flexShrink={0} justifyContent="space-between">
+            <Box flexShrink={1} overflow="hidden">
+                <Text wrap="truncate">
+                    <Banner version={null} /> <StatusBadge phase={state.phase} glyph="live" />
+                    {top?.summary ? <Text dimColor> · </Text> : null}
+                    {top?.summary ? <Text color={ui.warn}>{top.summary}</Text> : null}
+                    {rest.length > 0 ? <Text dimColor> · +{rest.length}</Text> : null}
+                </Text>
+            </Box>
+            {columns < RIGHT_COLUMNS ? null : (
+                // flexShrink 0 and the margin keep the key readable against a summary that fills the row
+                <Box flexShrink={0} marginLeft={2}>
+                    {top ? (
+                        <Text bold color={ui.accent}>
+                            {top.action}
+                        </Text>
+                    ) : (
+                        <Text dimColor>{HINT}</Text>
+                    )}
+                </Box>
+            )}
+        </Box>
+    );
+}

--- a/packages/seedcord/src/ui/components/primitives/StatusLine.tsx
+++ b/packages/seedcord/src/ui/components/primitives/StatusLine.tsx
@@ -12,8 +12,8 @@ import type { ReactElement } from 'react';
 
 const HINT = '⇅ resize for full ui';
 
-// below this the right slot would crowd out the summary, and the phase chip still shows the state
-const RIGHT_COLUMNS = 64;
+// below this the hint would crowd out the summary, and it stays optional either way
+const HINT_COLUMNS = 64;
 
 interface StatusLineProps {
     readonly state: DevState;
@@ -35,18 +35,16 @@ export function StatusLine({ state, notices, columns }: StatusLineProps): ReactE
                     {rest.length > 0 ? <Text dimColor> · +{rest.length}</Text> : null}
                 </Text>
             </Box>
-            {columns < RIGHT_COLUMNS ? null : (
-                // flexShrink 0 and the margin keep the key readable against a summary that fills the row
-                <Box flexShrink={0} marginLeft={2}>
-                    {top ? (
-                        <Text bold color={ui.accent}>
-                            {top.action}
-                        </Text>
-                    ) : (
-                        <Text dimColor>{HINT}</Text>
-                    )}
-                </Box>
-            )}
+            {/* flexShrink 0 and the margin keep the key readable against a summary that fills the row */}
+            <Box flexShrink={0} marginLeft={2}>
+                {top ? (
+                    <Text bold color={ui.accent}>
+                        {top.action}
+                    </Text>
+                ) : null}
+                {/* the action always renders, since a prompt swallows every key and this row is its only affordance */}
+                {!top && columns >= HINT_COLUMNS ? <Text dimColor>{HINT}</Text> : null}
+            </Box>
         </Box>
     );
 }

--- a/packages/seedcord/src/ui/hooks/useMeasuredHeight.ts
+++ b/packages/seedcord/src/ui/hooks/useMeasuredHeight.ts
@@ -1,0 +1,26 @@
+import { measureElement } from 'ink';
+import { useLayoutEffect, useState } from 'react';
+
+import type { DOMElement } from 'ink';
+import type { RefObject } from 'react';
+
+/**
+ * The rendered height of a box, 0 until the first measurement lands.
+ *
+ * No dep array. A box moves for reasons its caller cannot enumerate, and one of them can be derived from the
+ * height itself, which rules out a dependency list. The equality bail is what keeps the per-render measurement
+ * from forming an update chain.
+ */
+export function useMeasuredHeight(ref: RefObject<DOMElement | null>): number {
+    const [height, setHeight] = useState(0);
+
+    // eslint-disable-next-line @eslint-react/exhaustive-deps, react-hooks/exhaustive-deps -- see the doc above
+    useLayoutEffect(() => {
+        if (!ref.current) return;
+        const next = measureElement(ref.current).height;
+        // eslint-disable-next-line @eslint-react/set-state-in-effect -- Ink layout is only measurable after render
+        setHeight((prev) => (prev === next ? prev : next));
+    });
+
+    return height;
+}

--- a/packages/seedcord/src/ui/hotkeys.ts
+++ b/packages/seedcord/src/ui/hotkeys.ts
@@ -47,6 +47,7 @@ interface HotkeyContext {
     readonly setEnabledLevels: (next: ReadonlySet<LogLevel>) => void;
     readonly cursor: FilterCursor;
     readonly setCursor: (next: FilterCursor) => void;
+    readonly filtersOpen: boolean; // to disable hotkeys that would otherwise move the cursor when the filter chips are closed
     readonly onQuit?: (() => Promise<void> | void) | undefined;
     readonly onDisconnect?: (() => Promise<void> | void) | undefined;
     readonly onRestart?: (() => Promise<void> | void) | undefined;
@@ -97,6 +98,8 @@ function applyAtCursor(
 }
 
 function handleFilters(ctx: HotkeyContext): boolean {
+    if (!ctx.filtersOpen) return false;
+
     const channels = LogStore.instance.getChannels();
     const move = (dir: CursorMove): void =>
         ctx.setCursor(moveCursor(ctx.cursor, dir, channels.length, FILTER_LEVELS.length));

--- a/packages/seedcord/src/ui/layout/DevLayout.tsx
+++ b/packages/seedcord/src/ui/layout/DevLayout.tsx
@@ -3,27 +3,34 @@ import React from 'react';
 
 import { LogHeader } from '@ui/components/primitives/LogHeader';
 import { NotificationStack } from '@ui/components/primitives/NotificationStack';
+import { Rule } from '@ui/components/primitives/Rule';
 import { ScrollableLogView } from '@ui/components/primitives/ScrollableLogView';
 import { Sidebar } from '@ui/components/primitives/Sidebar';
+import { StatusLine } from '@ui/components/primitives/StatusLine';
 
 import type { LogLevel } from '@seedcord/logger';
 import type { FilterCursor } from '@ui/filterCursor';
 import type { ScrollApi } from '@ui/hooks/useScroll';
 import type { LogRow } from '@ui/logRows';
+import type { Notice } from '@ui/notices';
 import type { DevState } from '@ui/stores/DevStore';
+import type { Tier } from '@ui/tier';
 import type { DOMElement } from 'ink';
 import type { ReactElement, Ref } from 'react';
 
 export interface DevLayoutProps {
     readonly state: DevState;
-    // measured once per run and held until the next restart, null before the measurement completes
+    readonly tier: Tier;
+    readonly notices: readonly Notice[];
     readonly railRef: Ref<DOMElement>;
+    // measured once per run and held until the next restart, null before the measurement completes
     readonly railWidth: number | null;
     // the shell measures this box to size the scroll window. it must be attached or the viewport is empty
     readonly logBoxRef: Ref<DOMElement>;
     readonly scroll: ScrollApi<LogRow>;
     readonly viewportHeight: number;
     readonly measured: boolean;
+    readonly columns: number;
     readonly enabled: ReadonlySet<string>;
     readonly enabledLevels: ReadonlySet<LogLevel>;
     readonly cursor: FilterCursor;
@@ -33,22 +40,26 @@ export interface DevLayoutProps {
 
 // notification cards render below the logs so stack traces have room
 export function DevLayout(props: DevLayoutProps): ReactElement {
-    const { state, railRef, railWidth, logBoxRef, scroll, viewportHeight, measured } = props;
-    const { enabled, enabledLevels, cursor, interactive, uptimeMs } = props;
+    const { state, tier, notices, railRef, railWidth, logBoxRef, scroll, viewportHeight, measured } = props;
+    const { columns, enabled, enabledLevels, cursor, interactive, uptimeMs } = props;
+    const railed = tier === 'full' || tier === 'compact';
 
     return (
         <Box flexGrow={1}>
-            <Sidebar
-                ref={railRef}
-                state={state}
-                enabled={enabled}
-                enabledLevels={enabledLevels}
-                uptimeMs={uptimeMs}
-                following={scroll.following}
-                interactive={interactive}
-                cursor={cursor}
-                width={railWidth}
-            />
+            {railed ? (
+                <Sidebar
+                    ref={railRef}
+                    state={state}
+                    enabled={enabled}
+                    enabledLevels={enabledLevels}
+                    uptimeMs={uptimeMs}
+                    following={scroll.following}
+                    interactive={interactive}
+                    cursor={cursor}
+                    width={railWidth}
+                    filtersOpen={tier === 'full'}
+                />
+            ) : null}
             <Box
                 flexDirection="column"
                 flexGrow={1}
@@ -58,18 +69,18 @@ export function DevLayout(props: DevLayoutProps): ReactElement {
                 borderTop={false}
                 borderRight={false}
                 borderBottom={false}
-                paddingLeft={1}
+                borderLeft={railed}
+                paddingLeft={railed ? 1 : 0}
                 overflow="hidden"
             >
+                {railed ? null : <StatusLine state={state} notices={notices} columns={columns} />}
+                {railed ? null : <Rule />}
                 <LogHeader following={scroll.following} below={scroll.below} />
-                <Box ref={logBoxRef} flexGrow={1} overflow="hidden">
+                {/* the notification stack is unbounded, so the pane keeps a row back for its own message */}
+                <Box ref={logBoxRef} flexGrow={1} minHeight={1} overflow="hidden">
                     <ScrollableLogView visible={scroll.visible} viewportHeight={viewportHeight} measured={measured} />
                 </Box>
-                <NotificationStack
-                    error={state.error}
-                    restartRequired={state.restartRequired}
-                    prompt={state.commandUpdatePrompt}
-                />
+                {railed ? <NotificationStack notices={notices} /> : null}
             </Box>
         </Box>
     );

--- a/packages/seedcord/src/ui/notices.tsx
+++ b/packages/seedcord/src/ui/notices.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { CommandRefreshPrompt } from '@ui/components/CommandRefreshPrompt';
+import { ErrorDisplay } from '@ui/components/ErrorDisplay';
+import { RestartRequiredCard } from '@ui/components/RestartRequiredCard';
+
+import type { DevState } from '@ui/stores/DevStore';
+import type { ReactElement } from 'react';
+
+type NoticeKey = 'commands' | 'error' | 'restart';
+
+export interface Notice {
+    readonly key: NoticeKey;
+    /** Description shown on the status line's left side. */
+    readonly summary: string;
+    /** What to press. */
+    readonly action: string;
+    readonly card: ReactElement;
+}
+
+const RESTART = 'press r to restart';
+
+/** Every pending notice, ranked with the one that blocks a decision first. */
+export function noticesOf(state: DevState): readonly Notice[] {
+    const notices: Notice[] = [];
+
+    if (state.commandUpdatePrompt) {
+        const count = state.commandUpdatePrompt.length;
+        notices.push({
+            key: 'commands',
+            summary: `${count} command${count === 1 ? '' : 's'} updated`,
+            action: 'refresh? y/n',
+            card: <CommandRefreshPrompt files={[...state.commandUpdatePrompt]} />
+        });
+    }
+
+    if (state.error) {
+        notices.push({
+            key: 'error',
+            summary: state.error.message, // status line only has room for one line
+            action: RESTART,
+            card: <ErrorDisplay error={state.error} />
+        });
+    }
+
+    if (state.restartRequired) {
+        notices.push({ key: 'restart', summary: '', action: RESTART, card: <RestartRequiredCard /> });
+    }
+
+    return notices;
+}

--- a/packages/seedcord/src/ui/palette.ts
+++ b/packages/seedcord/src/ui/palette.ts
@@ -1,7 +1,6 @@
 // truecolor palette for the dev-TUI's own chrome (headings, hotkeys, status), so it renders the same in
 // every terminal. the bot's log lines carry their own colors.
 export const ui = {
-    heading: '#7aa2f7',
     accent: '#7dcfff',
     muted: '#9aa0b3',
     faint: '#565c6b',

--- a/packages/seedcord/src/ui/stores/devPhase.ts
+++ b/packages/seedcord/src/ui/stores/devPhase.ts
@@ -9,14 +9,12 @@ export function isSessionLive(phase: DevPhase): boolean {
     return phase === 'running' || phase === 'restart-required';
 }
 
-// Phases where the process is up and emitting logs (in restart-required it is up but stale), so the live
-// dot blinks. disconnected, error, and quitting produce no logs and read as idle.
+// up and emitting logs (restart-required is up but stale), which is what the live dot blinks for
 export function isStreaming(phase: DevPhase): boolean {
     return phase === 'starting' || phase === 'running' || phase === 'restart-required';
 }
 
-// How the status glyph animates: a one-shot spinner for transient phases, a steady looping arc while the
-// session is live, or a static icon for resting states.
+// spinner runs once, arc loops
 type PhaseGlyph = 'spinner' | 'arc' | 'static';
 
 export interface PhaseMeta {
@@ -31,6 +29,6 @@ export const PHASE_META = {
     running: { label: 'running', icon: '●', color: ui.good, kind: 'arc' },
     'restart-required': { label: 'restart required', icon: '◆', color: ui.warn, kind: 'static' },
     disconnected: { label: 'offline', icon: '○', color: ui.muted, kind: 'static' },
-    error: { label: 'error', icon: '✖', color: ui.bad, kind: 'static' },
+    error: { label: 'error', icon: '✘', color: ui.bad, kind: 'static' },
     quitting: { label: 'quitting', icon: '◐', color: ui.muted, kind: 'spinner' }
 } as const satisfies Record<DevPhase, PhaseMeta>;

--- a/packages/seedcord/src/ui/tier.ts
+++ b/packages/seedcord/src/ui/tier.ts
@@ -1,0 +1,17 @@
+/** How much of the dev UI the terminal has room for. */
+export type Tier = 'full' | 'compact' | 'logs';
+
+// measured against the real rail with every framework channel plus headroom. Sidebar.test re-measures, so a
+// new rail section fails there before it clips at runtime.
+export const FULL_ROWS = 29;
+export const COMPACT_ROWS = 20;
+
+// the rail at its widest, plus the columns a log line uses for its prefix and a readable message
+export const RAIL_COLUMNS = 80;
+
+export function tierFor(rows: number, columns: number): Tier {
+    if (columns < RAIL_COLUMNS) return 'logs';
+    if (rows >= FULL_ROWS) return 'full';
+    if (rows >= COMPACT_ROWS) return 'compact';
+    return 'logs';
+}

--- a/packages/seedcord/tests/ui/DevApp.test.tsx
+++ b/packages/seedcord/tests/ui/DevApp.test.tsx
@@ -1,9 +1,19 @@
-import { render } from 'ink-testing-library';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { NO_ROOM } from '@ui/components/primitives/ScrollableLogView';
 import { DevApp } from '@ui/DevApp';
 import { DevStore } from '@ui/stores/DevStore';
+import { LogStore } from '@ui/stores/LogStore';
+
+import { renderAt } from './renderAt';
+import { settled, stableFrame } from './settled';
+
+import type { LogRecord } from '@seedcord/logger';
+
+const FULL = { rows: 40, columns: 120 };
+const COMPACT = { rows: 20, columns: 120 };
+const LOGS = { rows: 12, columns: 120 };
 
 function runningStore(): DevStore {
     const store = new DevStore();
@@ -13,17 +23,107 @@ function runningStore(): DevStore {
     return store;
 }
 
-describe('DevApp render smoke', () => {
-    it('renders without throwing', () => {
-        const store = runningStore();
-        const { lastFrame, unmount } = render(<DevApp store={store} onReady={() => undefined} />);
+// three cards at once is what leaves the log pane with nothing
+function squeezedStore(): DevStore {
+    const store = runningStore();
+    store.setError(new Error('boom'));
+    store.apply({ type: 'restart-required' });
+    store.apply({ type: 'command-update-prompt', files: ['a.ts', 'b.ts', 'c.ts', 'd.ts'] });
+    return store;
+}
+
+function view(size: { rows: number; columns: number }, store = runningStore()): ReturnType<typeof renderAt> {
+    return renderAt(<DevApp store={store} onReady={() => undefined} />, size);
+}
+
+function logOn(channel: string): LogRecord {
+    return { level: 'info', message: `from ${channel}`, label: 'Bot', channel, timestamp: 1_700_000_000_000 };
+}
+
+describe('DevApp tiers', () => {
+    it('renders the whole rail on a roomy terminal', async () => {
+        const { lastFrame, unmount } = view(FULL);
+        await settled(() => expect(lastFrame()).toContain('toggle'));
 
         const frame = lastFrame();
-        expect(frame).toBeTruthy();
         expect(frame).toContain('seedcord');
         expect(frame).toContain('running');
-        expect(frame).toContain('toggle');
+        expect(frame).toContain('▾ channels');
 
         unmount();
     });
-});
+
+    it('collapses the filters and their keys when the rail stops fitting whole', async () => {
+        const { lastFrame, unmount } = view(COMPACT);
+        await settled(() => expect(lastFrame()).toContain('▸ channels'));
+
+        const frame = lastFrame();
+        expect(frame).toContain('quit');
+        expect(frame).not.toContain('toggle');
+
+        unmount();
+    });
+
+    it('replaces the rail with the status line once the collapsed form stops fitting', async () => {
+        const { lastFrame, unmount } = view(LOGS);
+        await settled(() => expect(lastFrame()).toContain('resize'));
+
+        const frame = lastFrame();
+        expect(frame).toContain('seedcord');
+        expect(frame).toContain('running');
+        expect(frame).not.toContain('channels');
+        expect(frame).not.toContain('quit');
+
+        unmount();
+    });
+
+    it('names the pending notice on the status line', async () => {
+        const store = runningStore();
+        store.apply({ type: 'command-update-prompt', files: ['a.ts', 'b.ts'] });
+        const { lastFrame, unmount } = view(LOGS, store);
+
+        await settled(() => expect(lastFrame()).toContain('2 commands updated'));
+        unmount();
+    });
+
+    it('follows the terminal back up through the tiers', async () => {
+        const { lastFrame, resize, unmount } = view(LOGS);
+        await settled(() => expect(lastFrame()).toContain('resize'));
+
+        resize(FULL);
+        await settled(() => expect(lastFrame()).toContain('▾ channels'));
+
+        expect(lastFrame()).not.toContain('resize');
+        unmount();
+    });
+
+    // the chips are hidden below full, so a keypress that filters them changes what the pane shows with
+    // nothing on screen to explain it
+    it('ignores the filter keys once the chips are hidden', async () => {
+        const view = renderAt(<DevApp store={runningStore()} onReady={() => undefined} />, COMPACT);
+        await settled(() => expect(view.lastFrame()).toContain('▸ channels'));
+
+        for (const record of ['bot', 'hmr'].map(logOn)) LogStore.instance.onLog(record);
+        await LogStore.instance.flush();
+        await settled(() => expect(view.lastFrame()).toContain('from hmr'));
+
+        view.press(' ');
+        expect(await stableFrame(view.lastFrame)).toContain('from hmr');
+
+        view.unmount();
+    });
+
+    // the stack can take every row the log column has, so the pane keeps one back for its own message
+    it('always says something in the log pane', async () => {
+        const store = squeezedStore();
+
+        for (let rows = 20; rows <= 34; rows++) {
+            const squeezed = view({ rows, columns: 120 }, store);
+            const frame = await stableFrame(squeezed.lastFrame);
+            squeezed.unmount();
+
+            const spoke = frame.includes(NO_ROOM) || frame.includes('Waiting for logs');
+            expect(`${rows}:${String(spoke)}`).toBe(`${rows}:true`);
+        }
+    });
+}, 30_000);

--- a/packages/seedcord/tests/ui/ErrorDisplay.test.tsx
+++ b/packages/seedcord/tests/ui/ErrorDisplay.test.tsx
@@ -1,0 +1,17 @@
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ErrorDisplay } from '@ui/components/ErrorDisplay';
+
+const BOTTOM = '╰';
+
+describe('ErrorDisplay', () => {
+    it('closes the border directly under its last line', () => {
+        const lines = (render(<ErrorDisplay error={new Error('boom')} />).lastFrame() ?? '').split('\n');
+        const action = lines.findIndex((line) => line.includes('press r to restart'));
+
+        expect(action).toBeGreaterThan(0);
+        expect(lines[action + 1]).toContain(BOTTOM);
+    });
+});

--- a/packages/seedcord/tests/ui/FilterChips.test.tsx
+++ b/packages/seedcord/tests/ui/FilterChips.test.tsx
@@ -1,0 +1,48 @@
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { FilterChips } from '@ui/components/primitives/FilterChips';
+import { INITIAL_CURSOR } from '@ui/filterCursor';
+
+const CHANNELS = ['bot', 'hmr', 'gates'];
+
+describe('FilterChips', () => {
+    it('renders the chips under an open caret', () => {
+        const { lastFrame } = render(
+            <FilterChips
+                channels={CHANNELS}
+                enabledChannels={new Set()}
+                enabledLevels={new Set()}
+                cursor={INITIAL_CURSOR}
+                open
+            />
+        );
+
+        const frame = lastFrame() ?? '';
+        expect(frame).toContain('▾ channels');
+        expect(frame).toContain('▾ levels');
+        expect(frame).toContain('gates');
+        expect(frame).toContain('trace');
+    });
+
+    it('keeps only the two headings when collapsed', () => {
+        const { lastFrame } = render(
+            <FilterChips
+                channels={CHANNELS}
+                enabledChannels={new Set()}
+                enabledLevels={new Set()}
+                cursor={INITIAL_CURSOR}
+                open={false}
+            />
+        );
+
+        const frame = lastFrame() ?? '';
+        expect(frame).toContain('⇅ resize to see filters');
+        expect(frame).toContain('▸ channels');
+        expect(frame).toContain('▸ levels');
+        expect(frame).not.toContain('gates');
+        expect(frame).not.toContain('trace');
+        expect(frame.split('\n')).toHaveLength(3);
+    });
+});

--- a/packages/seedcord/tests/ui/ScrollableLogView.test.tsx
+++ b/packages/seedcord/tests/ui/ScrollableLogView.test.tsx
@@ -2,7 +2,7 @@ import { render } from 'ink-testing-library';
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ScrollableLogView } from '@ui/components/primitives/ScrollableLogView';
+import { NO_ROOM, ScrollableLogView } from '@ui/components/primitives/ScrollableLogView';
 import { expandRows } from '@ui/logRows';
 import { LogStore } from '@ui/stores/LogStore';
 
@@ -91,5 +91,10 @@ describe('ScrollableLogView', () => {
     it('renders nothing until measured', () => {
         const { lastFrame } = render(<ScrollableLogView visible={[]} viewportHeight={10} measured={false} />);
         expect((lastFrame() ?? '').trim()).toBe('');
+    });
+
+    it('reports a viewport with too few rows to carry a log line', () => {
+        const { lastFrame } = render(<ScrollableLogView visible={[]} viewportHeight={2} measured />);
+        expect(lastFrame() ?? '').toContain(NO_ROOM);
     });
 });

--- a/packages/seedcord/tests/ui/Sidebar.test.tsx
+++ b/packages/seedcord/tests/ui/Sidebar.test.tsx
@@ -1,0 +1,119 @@
+import { Box, Text, measureElement } from 'ink';
+import { render } from 'ink-testing-library';
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Sidebar } from '@ui/components/primitives/Sidebar';
+import { INITIAL_CURSOR } from '@ui/filterCursor';
+import { DevStore } from '@ui/stores/DevStore';
+import { LogStore } from '@ui/stores/LogStore';
+import { COMPACT_ROWS, FULL_ROWS } from '@ui/tier';
+
+import { settled } from './settled';
+
+import type { LogRecord } from '@seedcord/logger';
+import type { DevState } from '@ui/stores/DevStore';
+import type { DOMElement } from 'ink';
+import type { ReactElement } from 'react';
+
+// every channel the framework logs on, which is the tallest the chip list gets without plugins
+const FRAMEWORK_CHANNELS = [
+    'default',
+    'bot',
+    'lifecycle',
+    'health',
+    'interactions',
+    'events',
+    'commands',
+    'subscribers',
+    'errors',
+    'gates',
+    'plugins',
+    'hmr',
+    'cli',
+    'tsc'
+];
+
+function runningState(): DevState {
+    const store = new DevStore();
+    store.setPhase('running');
+    store.setBusy(false);
+    store.setStatus('Connected as TestBot');
+    return store.getState();
+}
+const RUNNING = runningState();
+
+// the readout renders outside the measured rail, so it never changes the size it reports
+function Harness({ filtersOpen }: { readonly filtersOpen: boolean }): ReactElement {
+    const railRef = useRef<DOMElement | null>(null);
+    const [size, setSize] = useState('pending');
+
+    // eslint-disable-next-line @eslint-react/exhaustive-deps, react-hooks/exhaustive-deps -- the equality bail below is what keeps the update chain from forming
+    useLayoutEffect(() => {
+        if (!railRef.current) return;
+        const { height, width } = measureElement(railRef.current);
+
+        setSize((prev) => (prev === `${height}x${width}` ? prev : `${height}x${width}`));
+    });
+
+    return (
+        <Box flexDirection="column">
+            <Box flexDirection="row">
+                <Sidebar
+                    ref={railRef}
+                    state={RUNNING}
+                    enabled={new Set()}
+                    enabledLevels={new Set()}
+                    uptimeMs={12_000}
+                    following={true}
+                    interactive={true}
+                    cursor={INITIAL_CURSOR}
+                    width={null}
+                    filtersOpen={filtersOpen}
+                />
+            </Box>
+            <Text>size:{size}</Text>
+        </Box>
+    );
+}
+
+function read(frame: string | undefined): { rows: number; columns: number } {
+    const match = /size:(?<rows>\d+)x(?<columns>\d+)/u.exec(frame ?? '');
+    return { rows: Number(match?.groups?.rows ?? 0), columns: Number(match?.groups?.columns ?? 0) };
+}
+
+describe('Sidebar', () => {
+    afterEach(() => LogStore.instance.clear());
+
+    async function measure(filtersOpen: boolean): Promise<{ rows: number; columns: number }> {
+        for (const channel of FRAMEWORK_CHANNELS) {
+            LogStore.instance.onLog({
+                level: 'info',
+                message: 'x',
+                label: 'Bot',
+                channel,
+                timestamp: 1_700_000_000_000
+            } satisfies LogRecord);
+        }
+        await LogStore.instance.flush();
+
+        const view = render(<Harness filtersOpen={filtersOpen} />);
+        await settled(() => expect(read(view.lastFrame()).rows).toBeGreaterThan(0));
+        const size = read(view.lastFrame());
+        view.unmount();
+        return size;
+    }
+
+    // the tier thresholds are authored constants, and this is what keeps them honest as the rail changes
+    it('fits the open rail inside the full tier', async () => {
+        const { rows } = await measure(true);
+
+        expect(rows).toBeLessThanOrEqual(FULL_ROWS);
+    });
+
+    it('fits the collapsed rail inside the compact tier', async () => {
+        const { rows } = await measure(false);
+
+        expect(rows).toBeLessThanOrEqual(COMPACT_ROWS);
+    });
+}, 20_000);

--- a/packages/seedcord/tests/ui/StatusLine.test.tsx
+++ b/packages/seedcord/tests/ui/StatusLine.test.tsx
@@ -1,0 +1,66 @@
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { StatusLine } from '@ui/components/primitives/StatusLine';
+import { noticesOf } from '@ui/notices';
+import { DevStore } from '@ui/stores/DevStore';
+
+function running(): DevStore {
+    const store = new DevStore();
+    store.setPhase('running');
+    store.setBusy(false);
+    return store;
+}
+
+function frameOf(store: DevStore, columns = 120): string {
+    return (
+        render(
+            <StatusLine state={store.getState()} notices={noticesOf(store.getState())} columns={columns} />
+        ).lastFrame() ?? ''
+    );
+}
+
+describe('StatusLine', () => {
+    it('carries the brand, the phase, and the resize hint', () => {
+        const frame = frameOf(running());
+
+        expect(frame).toContain('seedcord');
+        expect(frame).toContain('running');
+        expect(frame).toContain('resize');
+    });
+
+    it('renders the top notice with its keys', () => {
+        const store = running();
+        store.apply({ type: 'command-update-prompt', files: ['a.ts', 'b.ts'] });
+
+        expect(frameOf(store)).toContain('2 commands updated');
+    });
+
+    it('counts the notices it has no room to name', () => {
+        const store = running();
+        store.setError(new Error('boom'));
+        store.apply({ type: 'command-update-prompt', files: ['a.ts'] });
+
+        const frame = frameOf(store);
+        expect(frame).toContain('1 command updated');
+        expect(frame).toContain('+1');
+    });
+
+    it('drops the resize hint when the width runs out', () => {
+        expect(frameOf(running(), 30)).not.toContain('resize');
+    });
+
+    it('keeps the action beside a summary too long for the row', () => {
+        const store = running();
+        store.setError(new Error('connect ECONNREFUSED 127.0.0.1:27017 while opening the pool'));
+
+        const frame = frameOf(store, 70);
+        expect(frame).toContain('press r to restart');
+        expect(frame).toContain('connect ECONNREFUSED');
+    });
+
+    it('renders on one row', () => {
+        expect(frameOf(running()).split('\n')).toHaveLength(1);
+    });
+});

--- a/packages/seedcord/tests/ui/StatusLine.test.tsx
+++ b/packages/seedcord/tests/ui/StatusLine.test.tsx
@@ -51,6 +51,15 @@ describe('StatusLine', () => {
         expect(frameOf(running(), 30)).not.toContain('resize');
     });
 
+    it('keeps the action on a terminal too narrow for the hint', () => {
+        const store = running();
+        store.apply({ type: 'command-update-prompt', files: ['a.ts'] });
+
+        const frame = frameOf(store, 50);
+        expect(frame).not.toContain('resize');
+        expect(frame).toContain('y/n');
+    });
+
     it('keeps the action beside a summary too long for the row', () => {
         const store = running();
         store.setError(new Error('connect ECONNREFUSED 127.0.0.1:27017 while opening the pool'));

--- a/packages/seedcord/tests/ui/hooks/useMeasuredHeight.test.tsx
+++ b/packages/seedcord/tests/ui/hooks/useMeasuredHeight.test.tsx
@@ -1,0 +1,57 @@
+import { Box, Text } from 'ink';
+import { render } from 'ink-testing-library';
+import React, { useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useMeasuredHeight } from '@ui/hooks/useMeasuredHeight';
+
+import { settled } from '../settled';
+
+import type { DOMElement } from 'ink';
+import type { ReactElement } from 'react';
+
+// the readout renders outside the measured box, so it never changes the height it reports
+function Harness({ lines, mounted = true }: { readonly lines: number; readonly mounted?: boolean }): ReactElement {
+    const boxRef = useRef<DOMElement | null>(null);
+    const height = useMeasuredHeight(boxRef);
+
+    return (
+        <Box flexDirection="column">
+            {mounted ? (
+                <Box ref={boxRef} flexDirection="column" flexShrink={0}>
+                    {Array.from({ length: lines }, (_, index) => (
+                        <Text key={index}>row</Text>
+                    ))}
+                </Box>
+            ) : null}
+            <Text>h:{height}</Text>
+        </Box>
+    );
+}
+
+describe('useMeasuredHeight', () => {
+    it('holds 0 until the first measurement lands', async () => {
+        const { lastFrame, unmount } = render(<Harness lines={3} mounted={false} />);
+
+        await settled(() => expect(lastFrame()).toContain('h:0'));
+        unmount();
+    });
+
+    it('reports the height the box renders at', async () => {
+        const { lastFrame, unmount } = render(<Harness lines={3} />);
+
+        await settled(() => expect(lastFrame()).toContain('h:3'));
+        unmount();
+    });
+
+    // the terminal size holds still here, so a dependency list keyed on it would miss this
+    it('follows the height when the box content changes', async () => {
+        const { lastFrame, rerender, unmount } = render(<Harness lines={3} />);
+        await settled(() => expect(lastFrame()).toContain('h:3'));
+
+        rerender(<Harness lines={7} />);
+
+        await settled(() => expect(lastFrame()).toContain('h:7'));
+        unmount();
+    });
+}, 20_000);

--- a/packages/seedcord/tests/ui/hooks/useRailWidth.test.tsx
+++ b/packages/seedcord/tests/ui/hooks/useRailWidth.test.tsx
@@ -5,11 +5,13 @@ import { describe, expect, it } from 'vitest';
 
 import { useRailWidth } from '@ui/hooks/useRailWidth';
 
+import { settled } from '../settled';
+
 import type { DevPhase } from '@ui/stores/devPhase';
 import type { DOMElement } from 'ink';
 import type { ReactElement } from 'react';
 
-// a row parent keeps the rail at its natural content width, and the readout sits outside the measured box
+// a row parent keeps the rail at its natural content width, and the readout renders outside the measured box
 function Harness({ phase, label }: { readonly phase: DevPhase; readonly label: string }): ReactElement {
     const railRef = useRef<DOMElement | null>(null);
     const width = useRailWidth(railRef, phase, 24, 80);
@@ -23,52 +25,40 @@ function Harness({ phase, label }: { readonly phase: DevPhase; readonly label: s
     );
 }
 
-// lets the layout effect's state update commit before reading the frame
-const flush = async (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
-
 describe('useRailWidth', () => {
     it('holds no width before the session runs', async () => {
         const { lastFrame, unmount } = render(<Harness phase="starting" label="abcde" />);
-        await flush();
-
-        expect(lastFrame()).toContain('w:null');
+        await settled(() => expect(lastFrame()).toContain('w:null'));
         unmount();
     });
 
     it('locks the rail width at the first running render', async () => {
         const { lastFrame, rerender, unmount } = render(<Harness phase="starting" label="abcde" />);
-        await flush();
+        await settled(() => expect(lastFrame()).toContain('w:null'));
 
         rerender(<Harness phase="running" label="abcde" />);
-        await flush();
-
-        expect(lastFrame()).toContain('w:5');
+        await settled(() => expect(lastFrame()).toContain('w:5'));
         unmount();
     });
 
     it('holds the lock while the session stays running', async () => {
         const { lastFrame, rerender, unmount } = render(<Harness phase="running" label="abcde" />);
-        await flush();
+        await settled(() => expect(lastFrame()).toContain('w:5'));
 
         rerender(<Harness phase="running" label="abcdefghij" />);
-        await flush();
-
-        expect(lastFrame()).toContain('w:5');
+        await settled(() => expect(lastFrame()).toContain('w:5'));
         unmount();
     });
 
     it('resets and re-measures across a restart', async () => {
         const { lastFrame, rerender, unmount } = render(<Harness phase="running" label="abcde" />);
-        await flush();
-        expect(lastFrame()).toContain('w:5');
+        await settled(() => expect(lastFrame()).toContain('w:5'));
 
         rerender(<Harness phase="starting" label="abcdefghij" />);
-        await flush();
+        await settled(() => expect(lastFrame()).toContain('w:null'));
 
         rerender(<Harness phase="running" label="abcdefghij" />);
-        await flush();
-
-        expect(lastFrame()).toContain('w:10');
+        await settled(() => expect(lastFrame()).toContain('w:10'));
         unmount();
     });
 }, 10_000);

--- a/packages/seedcord/tests/ui/hotkeys.test.ts
+++ b/packages/seedcord/tests/ui/hotkeys.test.ts
@@ -45,6 +45,7 @@ function makeCtx(overrides: Partial<Ctx>): Ctx {
         setEnabledLevels: vi.fn(),
         cursor: INITIAL_CURSOR,
         setCursor: vi.fn(),
+        filtersOpen: true,
         ...overrides
     } as unknown as Ctx;
 }
@@ -68,6 +69,20 @@ describe('dispatchHotkey channel filters', () => {
         dispatchHotkey(makeCtx({ input: ' ', cursor: INITIAL_CURSOR, setEnabled }));
 
         expect(setEnabled).toHaveBeenCalledWith(new Set(['alpha']));
+    });
+
+    // the chips render only in the full tier, and a filter applied without them is invisible
+    it('ignores the filter keys while the chips are closed', async () => {
+        await seedChannel('alpha');
+        const setEnabled = vi.fn();
+        const setCursor = vi.fn();
+
+        for (const input of [' ', 'o']) {
+            dispatchHotkey(makeCtx({ input, filtersOpen: false, setEnabled, setCursor }));
+        }
+
+        expect(setEnabled).not.toHaveBeenCalled();
+        expect(setCursor).not.toHaveBeenCalled();
     });
 
     it('restores all on space when the focused channel is already solo', async () => {

--- a/packages/seedcord/tests/ui/notices.test.tsx
+++ b/packages/seedcord/tests/ui/notices.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { noticesOf } from '@ui/notices';
+import { DevStore } from '@ui/stores/DevStore';
+
+import type { DevState } from '@ui/stores/DevStore';
+
+function running(): DevStore {
+    const store = new DevStore();
+    store.setPhase('running');
+    store.setBusy(false);
+    return store;
+}
+
+const keysOf = (state: DevState): string[] => noticesOf(state).map((notice) => notice.key);
+
+describe('noticesOf', () => {
+    it('reports nothing while the session is clean', () => {
+        expect(noticesOf(running().getState())).toHaveLength(0);
+    });
+
+    it('words the command prompt with its count and its keys', () => {
+        const store = running();
+        store.apply({ type: 'command-update-prompt', files: ['a.ts', 'b.ts', 'c.ts', 'd.ts'] });
+
+        expect(noticesOf(store.getState())[0]?.summary).toBe('4 commands updated');
+    });
+
+    it('singularises a one-file prompt', () => {
+        const store = running();
+        store.apply({ type: 'command-update-prompt', files: ['a.ts'] });
+
+        expect(noticesOf(store.getState())[0]?.summary).toBe('1 command updated');
+    });
+
+    it('ranks the prompt above an error', () => {
+        const store = running();
+        store.setError(new Error('boom'));
+        store.apply({ type: 'command-update-prompt', files: ['a.ts'] });
+
+        expect(keysOf(store.getState())).toStrictEqual(['commands', 'error']);
+    });
+
+    // the runner sets the phase and the notice together, so filtering on the phase drops the card entirely
+    it('keeps the error notice while the phase reads error', () => {
+        const store = running();
+        store.setPhase('error');
+        store.setError(new Error('boom'));
+
+        expect(keysOf(store.getState())).toStrictEqual(['error']);
+    });
+
+    it('keeps the restart notice while the phase reads restart-required', () => {
+        const store = running();
+        store.apply({ type: 'restart-required' });
+
+        expect(keysOf(store.getState())).toStrictEqual(['restart']);
+    });
+
+    it('names the key each notice answers to', () => {
+        const store = running();
+        store.setError(new Error('boom'));
+        store.apply({ type: 'restart-required' });
+        store.apply({ type: 'command-update-prompt', files: ['a.ts'] });
+
+        expect(noticesOf(store.getState()).map((notice) => notice.action)).toStrictEqual([
+            'refresh? y/n',
+            'press r to restart',
+            'press r to restart'
+        ]);
+    });
+
+    it('summarises an error with its message alone', () => {
+        const store = running();
+        store.setError(new Error('connect ECONNREFUSED 127.0.0.1:27017'));
+
+        expect(noticesOf(store.getState())[0]?.summary).toBe('connect ECONNREFUSED 127.0.0.1:27017');
+    });
+
+    it('leaves the restart summary empty', () => {
+        const store = running();
+        store.apply({ type: 'restart-required' });
+
+        expect(noticesOf(store.getState())[0]?.summary).toBe('');
+    });
+});

--- a/packages/seedcord/tests/ui/renderAt.tsx
+++ b/packages/seedcord/tests/ui/renderAt.tsx
@@ -1,0 +1,87 @@
+import { EventEmitter } from 'node:events';
+
+import { render } from 'ink';
+
+import type { ReactElement } from 'react';
+
+// ink-testing-library hardcodes 100 columns and reads real rows from terminal-size, so size assertions render
+// through here
+class SizedStdout extends EventEmitter {
+    private last = '';
+
+    public constructor(
+        public columns: number,
+        public rows: number
+    ) {
+        super();
+    }
+
+    public readonly write = (frame: string): void => {
+        this.last = frame;
+    };
+
+    public readonly lastFrame = (): string => this.last;
+
+    public readonly resize = (size: { rows: number; columns: number }): void => {
+        this.rows = size.rows;
+        this.columns = size.columns;
+        this.emit('resize');
+    };
+}
+
+class StubStdin extends EventEmitter {
+    public readonly isTTY = true;
+    private pending: string | null = null;
+
+    public setEncoding(): void {}
+    public setRawMode(): void {}
+    public resume(): void {}
+    public pause(): void {}
+    public ref(): void {}
+    public unref(): void {}
+
+    public read(): string | null {
+        const { pending } = this;
+        this.pending = null;
+        return pending;
+    }
+
+    // ink reads through both paths depending on the terminal, so feed both
+    public readonly send = (input: string): void => {
+        this.pending = input;
+        this.emit('readable');
+        this.emit('data', input);
+    };
+}
+
+export interface RenderAtResult {
+    readonly lastFrame: () => string;
+    readonly resize: (size: { rows: number; columns: number }) => void;
+    readonly press: (input: string) => void;
+    readonly unmount: () => void;
+}
+
+export function renderAt(tree: ReactElement, size: { rows: number; columns: number }): RenderAtResult {
+    const stdout = new SizedStdout(size.columns, size.rows);
+    const stdin = new StubStdin();
+
+    const instance = render(tree, {
+        // eslint-disable-next-line no-restricted-syntax -- ink's option types require net.Socket subtypes, and these stubs carry every member it reads
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        // eslint-disable-next-line no-restricted-syntax -- same, for the stdin useInput attaches to
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false
+    });
+
+    return {
+        lastFrame: () => stdout.lastFrame(),
+        resize: stdout.resize,
+        press: stdin.send,
+        unmount: () => {
+            instance.unmount();
+            instance.cleanup();
+        }
+    };
+}

--- a/packages/seedcord/tests/ui/settled.ts
+++ b/packages/seedcord/tests/ui/settled.ts
@@ -1,0 +1,23 @@
+import { expect, vi } from 'vitest';
+
+// a single macrotask tick clears ink's layout effect on an idle machine and races once the whole workspace
+// runs its suites at once
+export async function settled(assertion: () => void): Promise<void> {
+    await vi.waitFor(assertion, { timeout: 5000, interval: 10 });
+}
+
+// three identical polls mean the effect passes ran out, two would also match the reads that land before the
+// first commit
+const STABLE_READS = 3;
+
+export async function stableFrame(read: () => string): Promise<string> {
+    let previous: string | null = null;
+    let repeats = 0;
+    await settled(() => {
+        const current = read();
+        repeats = current !== '' && current === previous ? repeats + 1 : 0;
+        previous = current;
+        expect(repeats).toBeGreaterThanOrEqual(STABLE_READS);
+    });
+    return read();
+}

--- a/packages/seedcord/tests/ui/tier.test.ts
+++ b/packages/seedcord/tests/ui/tier.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_RAIL } from '@ui/components/primitives/Sidebar';
+import { COMPACT_ROWS, FULL_ROWS, RAIL_COLUMNS, tierFor } from '@ui/tier';
+
+// a log line spends about 28 columns on its prefix, and a message needs a dozen more to read
+const MIN_LOG_COLUMNS = 40;
+
+describe('tierFor', () => {
+    it('gives the full layout a roomy terminal', () => {
+        expect(tierFor(40, 120)).toBe('full');
+    });
+
+    it('collapses the filters once the rail stops fitting whole', () => {
+        expect(tierFor(28, 120)).toBe('compact');
+    });
+
+    it('drops the rail once the collapsed form stops fitting', () => {
+        expect(tierFor(19, 120)).toBe('logs');
+    });
+
+    it('drops the rail on a narrow terminal at any height', () => {
+        expect(tierFor(40, 79)).toBe('logs');
+    });
+
+    // the rail is capped at MAX_RAIL, so the column threshold has to leave a log line room beside it
+    it('leaves the log pane room beside the widest rail', () => {
+        expect(RAIL_COLUMNS - MAX_RAIL).toBeGreaterThanOrEqual(MIN_LOG_COLUMNS);
+    });
+
+    // the exact thresholds, so an off-by-one in any comparison fails here
+    it('treats each threshold as inclusive', () => {
+        expect(tierFor(FULL_ROWS, 120)).toBe('full');
+        expect(tierFor(COMPACT_ROWS, 120)).toBe('compact');
+        expect(tierFor(40, RAIL_COLUMNS)).toBe('full');
+    });
+});

--- a/plugins/kysely-postgres/src/KyselyMigrationManager.ts
+++ b/plugins/kysely-postgres/src/KyselyMigrationManager.ts
@@ -265,12 +265,12 @@ export class KyselyMigrationManager {
 
         for (const result of results) {
             if (result.status === 'Success') {
-                this.ctx.logger.info(`${chalk.green('✓')} ${chalk.bold(result.migrationName)}`);
+                this.ctx.logger.info(`${chalk.green('✔︎')} ${chalk.bold(result.migrationName)}`);
                 continue;
             }
 
             if (result.status === 'Error') {
-                this.ctx.logger.error(`${chalk.red('✗')} ${chalk.bold(result.migrationName)}`);
+                this.ctx.logger.error(`${chalk.red('✘')} ${chalk.bold(result.migrationName)}`);
                 continue;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `seedcord dev` now adapts its layout to available terminal space.
  * Filter controls collapse in compact terminals, while the sidebar becomes a status line in very short terminals.
  * Added clearer status summaries, notice counts, resize guidance, and live activity indicators.

* **Improvements**
  * Improved error and insufficient-space displays for better readability.
  * Refined CLI and migration status symbols and error-message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->