### PR TITLE
fix: small things left in gateway and http parity

### DIFF
--- a/.changeset/gateway-modal-source-guard.md
+++ b/.changeset/gateway-modal-source-guard.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': patch
+---
+
+`ModalHandler` carries `update` and `deferUpdate` guards, matching http. A modal opened from a command reports the missing source message before the ack state, and the failed write no longer publishes `responseAttempted`.

--- a/.changeset/get-confirmation-handler.md
+++ b/.changeset/get-confirmation-handler.md
@@ -1,0 +1,7 @@
+---
+'@seedcord/gateway': minor
+---
+
+**BREAKING:** `getConfirmation` takes the handler as its first argument. Pass `this` where you passed `this.event`.
+
+The prompt now sends through the handler's own sender, so it carries the dispatch route id and publishes to the bus.

--- a/.changeset/http-log-silences.md
+++ b/.changeset/http-log-silences.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/http': patch
+---
+
+`errors.logSilences` now turns off the per-`Silence` debug line on http, matching gateway. The field was read on gateway only.

--- a/packages/gateway/src/bot/confirm/getConfirmation.ts
+++ b/packages/gateway/src/bot/confirm/getConfirmation.ts
@@ -2,13 +2,12 @@ import { ButtonBuilder, TextDisplayBuilder } from '@discordjs/builders';
 import { BuilderComponent, RowComponent } from '@seedcord/core';
 import { ButtonStyle, ComponentType } from 'discord.js';
 
-import { ReplySender } from '@bot/ReplySender';
-import { interactionRoute } from '@miscellaneous/extractErrorResponse';
-
 import { CONFIRM_DEF } from './reserved';
 
+import type { ReplySender } from '@bot/ReplySender';
 import type { ReplyResponse } from '@seedcord/types';
 import type { NonModalInteraction } from '@src/handlers/interactionTypes';
+import type { RepliableHandler } from '@src/handlers/RepliableHandler';
 import type { ButtonInteraction, Message } from 'discord.js';
 import type { Promisable } from 'type-fest';
 
@@ -124,10 +123,10 @@ async function settle(sender: ReplySender, message: Message, outcome: Outcome | 
 /**
  * Shows a confirm/cancel prompt with built-in Confirm and Cancel buttons and resolves to `true` only if the
  * invoking user clicks confirm. A cancel click or a timeout resolves to `false`. Gate the action behind it
- * with an early return. A failed prompt send throws into the fault boundary. Not usable from a
- * {@link ModalHandler}, the `interaction` parameter excludes a modal submit at compile time.
+ * with an early return. A failed prompt send throws into the fault boundary. A {@link ModalHandler} is
+ * excluded at compile time.
  *
- * @param interaction - The repliable interaction to prompt on, `this.event` inside a non-modal handler.
+ * @param handler - The handler to prompt from, `this` inside a non-modal handler.
  * @param prompt - The message shown above the Confirm and Cancel buttons.
  * @param options - Ephemeral flag, timeout, the built-in buttons' labels and style, and the optional
  *   `onConfirm`/`onCancel`/`onTimeout` outcome replies that edit the prompt in place.
@@ -141,33 +140,33 @@ async function settle(sender: ReplySender, message: Message, outcome: Outcome | 
  * class BanHandler extends SlashHandler<'ban'> {
  *     async execute() {
  *         const target = this.options.getUser('target', true);
- *         if (!(await getConfirmation(this.event, `Ban ${target.tag}? This cannot be undone.`))) return;
+ *         if (!(await getConfirmation(this, `Ban ${target.tag}? This cannot be undone.`))) return;
  *         await this.event.guild?.members.ban(target.id);
  *     }
  * }
  * ```
  */
 export function getConfirmation(
-    interaction: NonModalInteraction,
+    handler: RepliableHandler<NonModalInteraction>,
     prompt: string,
     options?: DefaultConfirmOptions
 ): Promise<boolean>;
 /**
  * Shows a confirm/cancel prompt you build yourself and resolves to `true` only if the invoking user clicks
  * confirm. The factory receives the two minted button ids. Set them on your own buttons. A cancel click or a
- * timeout resolves to `false`. A failed prompt send throws into the fault boundary. Not usable from a
- * {@link ModalHandler}.
+ * timeout resolves to `false`. A failed prompt send throws into the fault boundary. A {@link ModalHandler} is
+ * excluded at compile time.
  *
- * @param interaction - The repliable interaction to prompt on, `this.event` inside a non-modal handler.
+ * @param handler - The handler to prompt from, `this` inside a non-modal handler.
  * @param prompt - A factory given the minted `{ confirm, cancel }` ids that returns the reply to show. Build
- *   it with the kit `BuilderComponent`/`RowComponent` wrappers, not raw discord.js builders.
+ *   it with the `BuilderComponent` and `RowComponent` wrappers.
  * @param options - Ephemeral flag, timeout, and the optional `onConfirm`/`onCancel`/`onTimeout` outcome
  *   replies that edit the prompt in place.
  * @returns `true` if confirmed, `false` on cancel or timeout.
  *
  * @remarks
- * The prompt is collected in-process, so it does not survive a bot restart. Without an outcome hook, deliver
- * a result after confirming with a fresh `interaction.followUp(...)`, the prompt is already gone.
+ * The prompt is collected in-process, so it does not survive a bot restart. Without an outcome hook the
+ * prompt is gone once the user confirms, so deliver the result with a fresh `this.followUp(...)`.
  *
  * @example
  * ```ts
@@ -197,7 +196,7 @@ export function getConfirmation(
  *
  * const target = this.options.getUser('target', true);
  * const confirmed = await getConfirmation(
- *     this.event,
+ *     this,
  *     (ids) => ({ components: [new BanPrompt(`Ban ${target.tag}?`).component, new ConfirmRow(ids).component] }),
  *     { onConfirm: { components: [new BanPrompt(`Banned ${target.tag}.`).component] } }
  * );
@@ -205,19 +204,20 @@ export function getConfirmation(
  * ```
  */
 export function getConfirmation(
-    interaction: NonModalInteraction,
+    handler: RepliableHandler<NonModalInteraction>,
     prompt: (ids: { confirm: string; cancel: string }) => Promisable<ReplyResponse>,
     options?: ConfirmOptions
 ): Promise<boolean>;
 export async function getConfirmation(
-    interaction: NonModalInteraction,
+    handler: RepliableHandler<NonModalInteraction>,
     prompt: ConfirmPrompt,
     options?: DefaultConfirmOptions
 ): Promise<boolean> {
     const { ephemeral = true, timeoutMs = DEFAULT_TIMEOUT_MS } = options ?? {};
 
     const response = typeof prompt === 'string' ? defaultPrompt(prompt, options) : await prompt(CONFIRM_IDS);
-    const sender = new ReplySender(interaction, interactionRoute(interaction));
+    const interaction = handler.getEvent();
+    const sender = handler.getSender();
     const message = await sender.send(response, { ephemeral });
 
     const winner = await collectChoice(message, interaction.user.id, timeoutMs);

--- a/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
@@ -1,6 +1,11 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
 import { ComponentHandler } from './ComponentHandler';
 
+import type { SentMessage } from '@bot/ReplySender';
 import type { AnyCustomId } from '@seedcord/core/internal';
+import type { ReplyResponse } from '@seedcord/types';
 import type { CacheType, ModalSubmitInteraction } from 'discord.js';
 
 /**
@@ -33,4 +38,22 @@ export abstract class ModalHandler<
     // phantom, never set at runtime.
     /** @internal */
     declare readonly __component?: 'modal';
+
+    /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
+    protected override update(response: ReplyResponse | string): Promise<SentMessage> {
+        this.ensureSourceMessage('update');
+        return super.update(response);
+    }
+
+    /** Acknowledge the submit without changing the source message. Throws when a command opened the modal. */
+    protected override deferUpdate(): Promise<void> {
+        this.ensureSourceMessage('deferUpdate');
+        return super.deferUpdate();
+    }
+
+    // discord omits the message when a command opened the modal, so update and deferUpdate have no target
+    private ensureSourceMessage(method: string): void {
+        if (this.event.isFromMessage()) return;
+        throw new SeedcordError(SeedcordErrorCode.ReplyUpdateWithoutSource, [method, this.routeId]);
+    }
 }

--- a/packages/gateway/src/miscellaneous/extractErrorResponse.ts
+++ b/packages/gateway/src/miscellaneous/extractErrorResponse.ts
@@ -116,8 +116,8 @@ function causeLine(error: Error): string {
 }
 
 function reportRawFault(error: Error, core: Core, origin: ErrorOrigin, uuid: UUID): void {
-    // outside the throttle, so the uuid on the user's card always resolves to a log line
     const showStack = core.config.errors?.errorStack ?? false;
+    // outside the throttle, so the uuid on the user's card always resolves to a log line
     if (showStack) logger.error(uuid, error);
     else logger.error(`${uuid} | ${error.message}${causeLine(error)}`);
 
@@ -171,19 +171,17 @@ function faultKey(origin: ErrorOrigin, error: Error): string {
     return `autocomplete:${name}`;
 }
 
-/** The stable route id of a repliable interaction, its slash route path, command name, or customId prefix. */
-export function interactionRoute(interaction: Repliables): string {
+function interactionRoute(interaction: Repliables): string {
     if (interaction.isChatInputCommand()) return slashRouteOf(interaction);
     if (interaction.isContextMenuCommand()) return interaction.commandName;
     if (interaction.isButton() || interaction.isAnySelectMenu() || interaction.isModalSubmit()) {
-        // || not ??, an empty prefix (a too-short routeKey) must fall back to the full wire
+        // || so an empty prefix (a too-short routeKey) falls back to the full wire
         return prefixOf(interaction.customId) || interaction.customId;
     }
     return 'interaction';
 }
 
 function buildInteractionSource(interaction: Repliables): InteractionFaultSource {
-    // the full slash route (with subcommand) so two subcommands of one parent do not share a key
     const command = interaction.isChatInputCommand()
         ? slashRouteOf(interaction)
         : interaction.isContextMenuCommand()

--- a/packages/gateway/tests/bot/getConfirmation.test.ts
+++ b/packages/gateway/tests/bot/getConfirmation.test.ts
@@ -1,15 +1,26 @@
 import { ContainerBuilder } from '@discordjs/builders';
+import { PublishDefault } from '@seedcord/core/internal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getConfirmation } from '@bot/confirm';
 import { CONFIRM_DEF } from '@bot/confirm/reserved';
+import { ReplySender } from '@bot/ReplySender';
 
 import type { DefaultConfirmOptions } from '@bot/confirm';
+import type { ButtonHandler } from '@handlers/interaction/components/ButtonHandler';
+import type { ModalHandler } from '@handlers/interaction/components/ModalHandler';
+import type { Bus } from '@seedcord/core';
 import type { ReplyResponse } from '@seedcord/types';
 import type { NonModalInteraction } from '@src/handlers/interactionTypes';
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import type { RepliableHandler } from '@src/handlers/RepliableHandler';
 
 type Prompt = string | ((ids: { confirm: string; cancel: string }) => ReplyResponse);
+// justified: collapses the overloads so one call site can forward either a string or a factory prompt
+type ConfirmCall = (
+    handler: RepliableHandler<NonModalInteraction>,
+    prompt: Prompt,
+    options?: DefaultConfirmOptions
+) => Promise<boolean>;
 
 const confirmWire = CONFIRM_DEF.encode({ choice: 'confirm' });
 const cancelWire = CONFIRM_DEF.encode({ choice: 'cancel' });
@@ -60,14 +71,29 @@ describe('getConfirmation', () => {
         mockMessage.awaitMessageComponent.mockResolvedValue(winner(confirmWire));
     });
 
-    // justified: the fixture implements only the interaction surface getConfirmation reads, and the cast
-    // collapses the overloads so the helper can forward either a string or a factory prompt.
+    // justified: the fixture implements only the surface getConfirmation reads off a handler
+    function handlerFor(source: object, routeId = 'confirm-test', bus?: Bus): RepliableHandler<NonModalInteraction> {
+        const interaction = source as NonModalInteraction;
+        const sender = new ReplySender(interaction, routeId, bus);
+        return {
+            getEvent: () => interaction,
+            getSender: () => sender
+        } as unknown as RepliableHandler<NonModalInteraction>;
+    }
+
     const run = (prompt: Prompt, options?: DefaultConfirmOptions): Promise<boolean> =>
-        (getConfirmation as (i: NonModalInteraction, p: Prompt, o?: DefaultConfirmOptions) => Promise<boolean>)(
-            event as unknown as NonModalInteraction,
-            prompt,
-            options
-        );
+        (getConfirmation as ConfirmCall)(handlerFor(event), prompt, options);
+
+    it('sends the prompt through the handler sender, so the publish carries the handler routeId', async () => {
+        const publish = vi.fn();
+        // justified: the sender reads only the publish slot off the bus
+        const bus = { [PublishDefault]: publish } as unknown as Bus;
+
+        await (getConfirmation as ConfirmCall)(handlerFor(event, 'slash:ban', bus), v2Prompt);
+
+        const sent = publish.mock.calls.find(([key]) => key === 'responseAttempted');
+        expect(sent?.[1]).toMatchObject({ routeId: 'slash:ban' });
+    });
 
     it('resolves true when the user confirms', async () => {
         await expect(run(v2Prompt)).resolves.toBe(true);
@@ -164,7 +190,7 @@ describe('getConfirmation', () => {
                 user: { id: userId },
                 reply: vi.fn().mockResolvedValue({ resource: { message } })
             };
-            return getConfirmation(ev as unknown as NonModalInteraction, v2Prompt);
+            return (getConfirmation as ConfirmCall)(handlerFor(ev, `slash:${userId}`), v2Prompt);
         }
         const [a, b] = await Promise.all([flow(confirmWire, 'userA'), flow(cancelWire, 'userB')]);
         expect(a).toBe(true);
@@ -174,13 +200,13 @@ describe('getConfirmation', () => {
 
 // type-level checks, validated by tc. the runtime body only anchors the file.
 describe('getConfirmation typing', () => {
-    it('accepts a non-modal interaction and rejects a modal submit', () => {
-        function probe(button: ButtonInteraction, modal: ModalSubmitInteraction): void {
+    it('accepts a non-modal handler and rejects a modal handler', () => {
+        function probe(button: ButtonHandler<never>, modal: ModalHandler<never>): void {
             void getConfirmation(button, 'sure?');
             void getConfirmation(button, () => ({ components: [new ContainerBuilder()] }), {
                 onConfirm: { components: [new ContainerBuilder()] }
             });
-            // @ts-expect-error getConfirmation excludes a modal-submit interaction
+            // @ts-expect-error getConfirmation excludes a modal handler
             void getConfirmation(modal, 'sure?');
         }
 

--- a/packages/gateway/tests/handlers/bases.test.ts
+++ b/packages/gateway/tests/handlers/bases.test.ts
@@ -126,8 +126,7 @@ describe('ModalHandler base', () => {
         }
     }
 
-    it('inherits update and rejects a command-opened modal with 1504 before any djs call', async () => {
-        // a modal opened from a command has no source message, so update throws through the sender's narrowing
+    it('rejects update on a command-opened modal before any djs call', async () => {
         const mock = mockInteraction({ isMessageComponent: false, isModalSubmit: true, isFromMessage: false });
 
         await expect(new Save(asModal(mock), core).execute()).rejects.toSatisfy((e: unknown) =>
@@ -140,6 +139,34 @@ describe('ModalHandler base', () => {
         const mock = mockInteraction({ isMessageComponent: false, isModalSubmit: true, isFromMessage: true });
         await new Save(asModal(mock), core).execute();
         expect(mock.update).toHaveBeenCalledOnce();
+    });
+
+    it('rejects deferUpdate on a command-opened modal before any djs call', async () => {
+        class Ack extends ModalHandler<never> {
+            async execute(): Promise<void> {
+                await this.deferUpdate();
+            }
+        }
+        const mock = mockInteraction({ isMessageComponent: false, isModalSubmit: true, isFromMessage: false });
+
+        await expect(new Ack(asModal(mock), core).execute()).rejects.toSatisfy((e: unknown) =>
+            isSeedcordError(e, 'SeedcordError', SeedcordErrorCode.ReplyUpdateWithoutSource)
+        );
+        expect(mock.deferUpdate).not.toHaveBeenCalled();
+    });
+
+    // the missing source outranks the ack state, matching http where the handler checks before the sender runs
+    it('names the missing source on a command-opened modal that already replied', async () => {
+        const mock = mockInteraction({
+            isMessageComponent: false,
+            isModalSubmit: true,
+            isFromMessage: false,
+            replied: true
+        });
+
+        await expect(new Save(asModal(mock), core).execute()).rejects.toSatisfy((e: unknown) =>
+            isSeedcordError(e, 'SeedcordError', SeedcordErrorCode.ReplyUpdateWithoutSource)
+        );
     });
 });
 

--- a/packages/http/src/dispatch/dispatchInteraction.ts
+++ b/packages/http/src/dispatch/dispatchInteraction.ts
@@ -134,7 +134,9 @@ async function handleRawFault(error: Error, uuid: RenderContext['uuid'], scope: 
 
 async function handleFault(caught: unknown, scope: FaultScope): Promise<void> {
     if (caught instanceof Silence) {
-        if (caught.reason !== undefined) logger().debug(`Silence: ${caught.reason}`);
+        if (caught.reason !== undefined && (scope.core.config.errors?.logSilences ?? true)) {
+            logger().debug(`Silence: ${caught.reason}`);
+        }
         return;
     }
 
@@ -247,8 +249,8 @@ async function loadHandlerCtor(
 
 /**
  * Runs the pre-ack phase for a matched interaction. Loads the route's handler class, constructs it, and
- * runs its gates, and the sender posts any refusal. Returns the post-ack execute continuation, or null
- * when a gate refuses or nothing can run.
+ * runs its gates. The sender posts any refusal. Returns the post-ack execute continuation, or null when a
+ * gate refuses or nothing can run.
  */
 export async function dispatchInteraction(args: DispatchArgs): Promise<(() => Promise<void>) | null> {
     const { match, payload, core } = args;
@@ -288,8 +290,8 @@ export async function dispatchInteraction(args: DispatchArgs): Promise<(() => Pr
     };
 }
 
-// autocomplete has no reply target, @Gated rejects it at compile time, this is the runtime backstop.
-// null when the gates passed. the caller answers the refusal, so one code path reports and replies
+// autocomplete has no reply target, so @Gated rejects it at compile time and this is the runtime backstop.
+// the caller answers the refusal, so one code path reports and replies
 async function gateRefusal(
     ctor: HandlerCtor,
     match: ResolvedRoute,

--- a/packages/http/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ModalHandler.ts
@@ -25,19 +25,19 @@ export abstract class ModalHandler<Defs extends readonly AnyCustomId[]> extends 
     /** @internal */
     declare readonly __component?: 'modal';
 
-    /** Rewrite the message this modal was opened from (only when a component opened it). */
+    /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
     protected override update(response: ReplyResponse | string): Promise<SentMessage> {
         this.ensureSourceMessage('update');
         return super.update(response);
     }
 
-    /** Silently acknowledge, leaving the source message untouched. */
+    /** Acknowledge the submit without changing the source message. Throws when a command opened the modal. */
     protected override deferUpdate(): Promise<void> {
         this.ensureSourceMessage('deferUpdate');
         return super.deferUpdate();
     }
 
-    // discord omits message when a command opened the modal, the source verbs have no target then
+    // discord omits the message when a command opened the modal, so update and deferUpdate have no target
     private ensureSourceMessage(method: string): void {
         if (this.event.message) return;
         throw new SeedcordError(SeedcordErrorCode.ReplyUpdateWithoutSource, [method, this.routeId]);

--- a/packages/http/tests/node/dispatch/fault-boundary.test.ts
+++ b/packages/http/tests/node/dispatch/fault-boundary.test.ts
@@ -1,5 +1,6 @@
 import { DiscordAPIError } from '@discordjs/rest';
 import { Fault, Notice, Silence } from '@seedcord/core';
+import { Logger } from '@seedcord/logger';
 import { MessageFlags } from 'discord-api-types/v10';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -33,7 +34,7 @@ const rest = vi.hoisted(() => {
     return { instances, FakeRest };
 });
 
-// the factory must not import project modules, vitest loads factory imports in a mock-bypass
+// the factory must not import project modules, because vitest loads factory imports in a mock-bypass
 // context that would cache the engine graph unmocked
 vi.mock('@discordjs/rest', async (importOriginal) => ({
     ...(await importOriginal<object>()),
@@ -103,6 +104,47 @@ describe('fault boundary', () => {
         await ctx.settled();
 
         expect(postedBodies()).toHaveLength(1);
+    });
+
+    it('debug-logs a Silence reason by default', async () => {
+        class Quiet extends SlashHandler<never> {
+            async execute(): Promise<void> {
+                await Promise.resolve();
+                throw new Silence('user dismissed');
+            }
+        }
+        const debug = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+        const { signer, handle } = await readyEngine(manifestOf('quiet', Quiet));
+        const ctx = capturingCtx();
+
+        await handle(await signedRequest(signer, slashPayload('quiet')), ctx);
+        await ctx.settled();
+
+        expect(debug).toHaveBeenCalledWith('Silence: user dismissed');
+        debug.mockRestore();
+    });
+
+    it('omits the Silence debug line when logSilences is false', async () => {
+        const config: Config = {
+            bot: { interactions: { path: null }, commands: { path: null } },
+            subscribers: { path: null },
+            errors: { logSilences: false }
+        };
+        class Quiet extends SlashHandler<never> {
+            async execute(): Promise<void> {
+                await Promise.resolve();
+                throw new Silence('user dismissed');
+            }
+        }
+        const debug = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+        const { signer, handle } = await readyEngine(manifestOf('quiet', Quiet), config);
+        const ctx = capturingCtx();
+
+        await handle(await signedRequest(signer, slashPayload('quiet')), ctx);
+        await ctx.settled();
+
+        expect(debug).not.toHaveBeenCalledWith('Silence: user dismissed');
+        debug.mockRestore();
     });
 
     it('sends a post-ack Notice card as a follow-up when already replied', async () => {
@@ -214,7 +256,7 @@ describe('fault boundary', () => {
         const ctx = capturingCtx();
 
         await handle(await signedRequest(signer, slashPayload('broken')), ctx);
-        // the card send dies on a dead interaction token
+        // the card send fails on a dead interaction token
         rest.instances[0]?.post.mockRejectedValueOnce(apiError(10_062));
         releaseExecute(null);
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confirmation prompts now use their handler context, preserving the correct response route.
  * Added safeguards for modal updates and deferred updates when no source message is available.
* **Bug Fixes**
  * Prevented failed responses from being reported as attempted.
  * Improved handling of command-opened modal submissions with clearer errors.
* **Configuration**
  * HTTP silence-reason debug logs can now be disabled through `errors.logSilences`, which is enabled by default.
* **Breaking Changes**
  * Updated `getConfirmation` callers must pass the handler instead of its interaction event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->