### PR TITLE
feat: http command registry

### DIFF
--- a/.changeset/http-command-deploy.md
+++ b/.changeset/http-command-deploy.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/http': minor
+'@seedcord/errors': patch
+---
+
+An http bot on `runtime: 'server'` deploys the commands at `bot.commands.path` during startup and fills the `Commands` accessor, matching gateway. The application id resolves over REST, since http holds no gateway session to read it from.

--- a/knip.json
+++ b/knip.json
@@ -89,6 +89,7 @@
         "packages/gateway": {},
         "packages/http": {
             "ignore": [
+                "tests/node/commands/fixtures/**",
                 "tests/node/discovery/fixtures/**",
                 "tests/node/discovery/duplicates/**"
             ]

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -41,8 +41,7 @@ const messages = {
     [SeedcordErrorCode.CoreDirectoryUnreadable]: (dir: string) => `${dir} could not be read.`,
     [SeedcordErrorCode.CorePluginReservedChannel]: (key: string) =>
         `Plugin key "${key}" is a channel the framework logs on. Pick another key.`,
-    [SeedcordErrorCode.CoreApplicationUnavailable]: () =>
-        "Commands cannot deploy until the bot's application id resolves.",
+    [SeedcordErrorCode.CoreApplicationUnavailable]: () => "The bot's application id could not be resolved.",
     [SeedcordErrorCode.CoreAccessorUnresolved]: (accessor: string, key: string) =>
         `${accessor}.${key} has no value yet. ${accessor} fills during startup, and a read at the top of a file runs before that.`,
 

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -42,7 +42,7 @@ const messages = {
     [SeedcordErrorCode.CorePluginReservedChannel]: (key: string) =>
         `Plugin key "${key}" is a channel the framework logs on. Pick another key.`,
     [SeedcordErrorCode.CoreApplicationUnavailable]: () =>
-        'Commands cannot deploy before the client resolves its application. This runs after login.',
+        "Commands cannot deploy until the bot's application id resolves.",
     [SeedcordErrorCode.CoreAccessorUnresolved]: (accessor: string, key: string) =>
         `${accessor}.${key} has no value yet. ${accessor} fills during startup, and a read at the top of a file runs before that.`,
 

--- a/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
@@ -169,12 +169,6 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
         });
     }
 
-    /**
-     * Warns for each command route with no registered `@SlashRoute` handler, which would fall through to
-     * UnhandledRepliable at runtime. A bot may route commands outside the registry, so this does not throw.
-     *
-     * @internal
-     */
     public warnUnhandledRoutes(commandLeaves: Iterable<string>): void {
         for (const route of commandLeaves) {
             if (!this.slashMap.has(route)) {
@@ -185,12 +179,6 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
         }
     }
 
-    /**
-     * Warns for each context-menu command with no matching handler, which would fall through to UnhandledRepliable
-     * at runtime. Checked per kind since a user and a message command can share a name.
-     *
-     * @internal
-     */
     public warnUnhandledContextMenuRoutes(leaves: ContextMenuLeaves): void {
         for (const name of leaves.user) {
             if (!this.userContextMenuMap.has(name)) {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -71,6 +71,7 @@
         "@seedcord/rate-limiter": "workspace:*",
         "@seedcord/types": "workspace:*",
         "@seedcord/utils": "workspace:*",
+        "chalk": "catalog:deps",
         "discord-api-types": "catalog:deps",
         "envapt": "catalog:deps",
         "type-fest": "catalog:deps"

--- a/packages/http/src/applicationId.ts
+++ b/packages/http/src/applicationId.ts
@@ -1,0 +1,22 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+import { Routes } from 'discord-api-types/v10';
+
+import type { REST } from '@discordjs/rest';
+import type { APIApplication } from 'discord-api-types/v10';
+
+/**
+ * Reads the bot's own application id over REST. A gateway host takes it off the logged-in client, and
+ * an http host has no session to read it from.
+ *
+ * @internal
+ */
+export async function fetchApplicationId(rest: REST): Promise<string> {
+    try {
+        // justified: the discord api contract for this route
+        const application = (await rest.get(Routes.currentApplication())) as APIApplication;
+        return application.id;
+    } catch (error) {
+        throw new SeedcordError(SeedcordErrorCode.CoreApplicationUnavailable, { cause: error });
+    }
+}

--- a/packages/http/src/emojis/EmojiInjector.ts
+++ b/packages/http/src/emojis/EmojiInjector.ts
@@ -4,9 +4,11 @@ import { SeedcordError } from '@seedcord/errors/internal';
 import { Logger } from '@seedcord/logger';
 import { Routes } from 'discord-api-types/v10';
 
+import { fetchApplicationId } from '@src/applicationId';
+
 import type { Core } from '@interfaces/Core';
 import type { EmojiMap } from '@seedcord/types';
-import type { APIApplication, APIEmoji, APIMessageComponentEmoji } from 'discord-api-types/v10';
+import type { APIEmoji, APIMessageComponentEmoji } from 'discord-api-types/v10';
 
 /** A resolved emoji. Renders as `<:name:id>` in message content, or `<a:name:id>` when animated. */
 export interface ResolvedEmoji extends APIMessageComponentEmoji {
@@ -60,7 +62,11 @@ export const Emojis = guardedAccessor('Emojis', emojiStorage) as InjectedEmojiMa
 export class EmojiInjector {
     private readonly logger = new Logger('Emojis', { channel: 'bot' });
 
-    constructor(private readonly core: Core) {}
+    constructor(
+        private readonly core: Core,
+        // the host passes its memoized one so a boot that also deploys commands resolves the id once
+        private readonly applicationId: () => Promise<string> = () => fetchApplicationId(core.rest)
+    ) {}
 
     public async init(): Promise<void> {
         clearStore(emojiStorage);
@@ -93,9 +99,9 @@ export class EmojiInjector {
 
     private async applicationEmojis(failures: string[]): Promise<Map<string, APIEmoji>> {
         try {
-            // justified: the discord api contract for these two routes
-            const application = (await this.core.rest.get(Routes.currentApplication())) as APIApplication;
-            const listed = (await this.core.rest.get(Routes.applicationEmojis(application.id))) as {
+            const appId = await this.applicationId();
+            // justified: the discord api contract for this route
+            const listed = (await this.core.rest.get(Routes.applicationEmojis(appId))) as {
                 items: APIEmoji[];
             };
             return byName(listed.items);

--- a/packages/http/src/node/InteractionDispatcher.ts
+++ b/packages/http/src/node/InteractionDispatcher.ts
@@ -2,9 +2,10 @@ import { HmrModuleHandler } from '@seedcord/core/hmr';
 import { interactionRoutesOf, InteractionMetadataKey, InteractionRoutes } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
-import { Logger } from '@seedcord/logger';
+import { Logger, paint } from '@seedcord/logger';
 import { formatFilePath } from '@seedcord/utils';
 import { traverseDirectory } from '@seedcord/utils/node';
+import chalk from 'chalk';
 import { Envapter } from 'envapt';
 
 import { AutocompleteHandler } from '@handlers/interaction/AutocompleteHandler';
@@ -14,6 +15,7 @@ import { EMPTY_MANIFEST } from '@src/manifest/RouteManifest';
 
 import type { HandlerConstructor } from '@handlers/constructors';
 import type { Initializeable } from '@seedcord/core';
+import type { ContextMenuLeaves } from '@seedcord/core/internal';
 import type { HmrAware, HmrUpdateEvent } from '@seedcord/types';
 import type { ResolvedRoute, RouteMap, RouteMaps } from '@src/dispatch/resolve';
 
@@ -89,6 +91,22 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
     /** @internal */
     public async onHmr(event: HmrUpdateEvent): Promise<void> {
         await this.hmrHandler?.handle(event);
+    }
+
+    public warnUnhandledRoutes(commandLeaves: Iterable<string>): void {
+        this.warnMissing(commandLeaves, this.maps.slash, 'Slash route', '@SlashRoute');
+    }
+
+    public warnUnhandledContextMenuRoutes(leaves: ContextMenuLeaves): void {
+        this.warnMissing(leaves.user, this.maps.userContextMenu, 'User context menu', '@ContextMenuRoute');
+        this.warnMissing(leaves.message, this.maps.messageContextMenu, 'Message context menu', '@ContextMenuRoute');
+    }
+
+    private warnMissing(names: Iterable<string>, map: RouteMap, label: string, decorator: string): void {
+        for (const name of names) {
+            if (map.has(name)) continue;
+            this.logger.warn(`${label} ${paint.sky.bold(name)} has no registered ${chalk.bold(decorator)} handler.`);
+        }
     }
 
     private isHandler(value: unknown): value is HandlerConstructor {

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -79,7 +79,8 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
     private readonly interactions?: InteractionDispatcher;
     private readonly commandRegistry?: CommandRegistry;
     private appId?: string;
-    private readonly emojiInjector = new EmojiInjector(this);
+    private appIdPromise?: Promise<string>;
+    private readonly emojiInjector = new EmojiInjector(this, () => this.applicationId());
     private readonly healthCheck?: HealthCheck | undefined;
     private readonly hmrManager: HmrManager;
     private readonly logger = new Logger('Server', { channel: 'bot' });
@@ -191,7 +192,7 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
             // one task, because tasks within a phase run concurrently and the deploy reads the id
             this.startup.addTask(StartupPhase.Login, 'command-deploy', async () => {
                 await commandRegistry.init();
-                this.appId = await fetchApplicationId(this.rest);
+                this.appId = await this.applicationId();
                 await commandRegistry.setCommands();
                 interactions?.warnUnhandledRoutes(commandRegistry.routeLeaves());
                 interactions?.warnUnhandledContextMenuRoutes(commandRegistry.contextMenuLeaves());
@@ -228,6 +229,12 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
 
     private authenticate(): void {
         this.rest.setToken(validateDiscordToken(Envapter.get('DISCORD_BOT_TOKEN')));
+    }
+
+    // the promise is stored, so two concurrent Login tasks share one fetch
+    private applicationId(): Promise<string> {
+        this.appIdPromise ??= fetchApplicationId(this.rest);
+        return this.appIdPromise;
     }
 
     // the registry deploys on a hot reload too, after the startup task resolved this

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -193,6 +193,8 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
                 await commandRegistry.init();
                 this.appId = await fetchApplicationId(this.rest);
                 await commandRegistry.setCommands();
+                interactions?.warnUnhandledRoutes(commandRegistry.routeLeaves());
+                interactions?.warnUnhandledContextMenuRoutes(commandRegistry.contextMenuLeaves());
             });
         }
 

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -3,8 +3,9 @@ import { createServer } from 'node:http';
 
 import { REST } from '@discordjs/rest';
 import { Bus } from '@seedcord/core';
-import { HmrManager, setBotColor } from '@seedcord/core/internal';
+import { CommandInjector, HmrManager, setBotColor } from '@seedcord/core/internal';
 import {
+    CommandRegistry,
     CoordinatedShutdown,
     CoordinatedStartup,
     HealthCheck,
@@ -13,7 +14,8 @@ import {
     StartupPhase,
     SubscriberLoader
 } from '@seedcord/core/node/internal';
-import { validateDiscordToken } from '@seedcord/errors/internal';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError, validateDiscordToken } from '@seedcord/errors/internal';
 import { Logger, LoggerChannelRegistry, paint } from '@seedcord/logger';
 import { installNodeDefaults } from '@seedcord/logger/node';
 import { MemoryRateLimiter } from '@seedcord/rate-limiter';
@@ -21,6 +23,7 @@ import { SeedcordBrand } from '@seedcord/types/internal';
 import { Routes } from 'discord-api-types/v10';
 import { Envapter } from 'envapt';
 
+import { fetchApplicationId } from '@src/applicationId';
 import { buildRouteMaps } from '@src/dispatch/resolve';
 import { EmojiInjector } from '@src/emojis/EmojiInjector';
 import { buildEngine } from '@src/engine';
@@ -74,6 +77,8 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
     private readonly subscribers: SubscriberLoader;
 
     private readonly interactions?: InteractionDispatcher;
+    private readonly commandRegistry?: CommandRegistry;
+    private appId?: string;
     private readonly emojiInjector = new EmojiInjector(this);
     private readonly healthCheck?: HealthCheck | undefined;
     private readonly hmrManager: HmrManager;
@@ -95,6 +100,21 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
 
         if (this.config.bot.interactions.path) {
             this.interactions = new InteractionDispatcher(this.config.bot.interactions.path);
+        }
+
+        const commandsDir = this.config.bot.commands.path;
+        if (commandsDir) {
+            const injector = new CommandInjector();
+            // onDeployed only fires at deploy time, so registry is assigned by then
+            const registry: CommandRegistry = new CommandRegistry({
+                dir: commandsDir,
+                rest: this.rest,
+                applicationId: () => this.requireApplicationId(),
+                onDeployed: (result) => {
+                    injector.inject(result, registry.allCommands());
+                }
+            });
+            this.commandRegistry = registry;
         }
 
         this.rateLimiter = config.store ?? new MemoryRateLimiter();
@@ -166,6 +186,16 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
         // needs the token from Configuration, and must finish before Ready opens the server to interactions
         this.startup.addTask(StartupPhase.Login, 'emoji-injection', () => this.emojiInjector.init());
 
+        const { commandRegistry } = this;
+        if (commandRegistry) {
+            // one task, because tasks within a phase run concurrently and the deploy reads the id
+            this.startup.addTask(StartupPhase.Login, 'command-deploy', async () => {
+                await commandRegistry.init();
+                this.appId = await fetchApplicationId(this.rest);
+                await commandRegistry.setCommands();
+            });
+        }
+
         this.startup.addTask(StartupPhase.Ready, 'http-server', () => this.listen());
 
         if (!Envapter.isTest) {
@@ -185,6 +215,7 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
     private registerHmrAwareModules(): void {
         this.startup.addTask(StartupPhase.Configuration, 'hmr-registration', async () => {
             if (this.interactions) this.hmrManager.register(this.interactions);
+            if (this.commandRegistry) this.hmrManager.register(this.commandRegistry);
             this.hmrManager.register(this.subscribers);
             for (const plugin of this.plugins) {
                 this.hmrManager.register(plugin);
@@ -195,6 +226,12 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
 
     private authenticate(): void {
         this.rest.setToken(validateDiscordToken(Envapter.get('DISCORD_BOT_TOKEN')));
+    }
+
+    // the registry deploys on a hot reload too, after the startup task resolved this
+    private requireApplicationId(): string {
+        if (!this.appId) throw new SeedcordError(SeedcordErrorCode.CoreApplicationUnavailable);
+        return this.appId;
     }
 
     private async listen(): Promise<void> {

--- a/packages/http/tests/node/applicationId.test.ts
+++ b/packages/http/tests/node/applicationId.test.ts
@@ -1,0 +1,38 @@
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
+import { Routes } from 'discord-api-types/v10';
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchApplicationId } from '@src/applicationId';
+
+import type { REST } from '@discordjs/rest';
+
+// justified: the helper reads only rest.get
+function restWith(get: ReturnType<typeof vi.fn>): REST {
+    return { get } as unknown as REST;
+}
+
+describe('fetchApplicationId', () => {
+    it('reads the id off the current-application route', async () => {
+        const get = vi.fn().mockResolvedValue({ id: 'app-1' });
+
+        await expect(fetchApplicationId(restWith(get))).resolves.toBe('app-1');
+        expect(get).toHaveBeenCalledWith(Routes.currentApplication());
+    });
+
+    it('translates a REST failure into CoreApplicationUnavailable', async () => {
+        const failure = new Error('401 unauthorized');
+
+        await expect(fetchApplicationId(restWith(vi.fn().mockRejectedValue(failure)))).rejects.toSatisfy((e: unknown) =>
+            isSeedcordError(e, 'SeedcordError', SeedcordErrorCode.CoreApplicationUnavailable)
+        );
+    });
+
+    it('keeps the original failure as the cause', async () => {
+        const failure = new Error('401 unauthorized');
+
+        await expect(fetchApplicationId(restWith(vi.fn().mockRejectedValue(failure)))).rejects.toHaveProperty(
+            'cause',
+            failure
+        );
+    });
+});

--- a/packages/http/tests/node/commands/fixtures/Ping.ts
+++ b/packages/http/tests/node/commands/fixtures/Ping.ts
@@ -1,0 +1,9 @@
+import { BuilderComponent, RegisterCommand } from '@seedcord/core';
+
+@RegisterCommand('global')
+export class Ping extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+        this.instance.setName('ping').setDescription('Replies with pong');
+    }
+}

--- a/packages/http/tests/node/commands/route-guard.test.ts
+++ b/packages/http/tests/node/commands/route-guard.test.ts
@@ -31,7 +31,10 @@ describe('warnUnhandledRoutes', () => {
         dispatcher.warnUnhandledRoutes(['ping', 'admin/ban']);
 
         expect(warn).toHaveBeenCalledOnce();
-        expect(String(warn.mock.calls[0]?.[0])).toContain('admin/ban');
+        const message = String(warn.mock.calls[0]?.[0]);
+        expect(message).toContain('Slash route');
+        expect(message).toContain('admin/ban');
+        expect(message).toContain('@SlashRoute');
     });
 
     it('stays quiet when every route is registered', () => {
@@ -66,6 +69,9 @@ describe('warnUnhandledContextMenuRoutes', () => {
         dispatcher.warnUnhandledContextMenuRoutes({ user: new Set(['Report']), message: new Set(['Report']) });
 
         expect(warn).toHaveBeenCalledOnce();
-        expect(String(warn.mock.calls[0]?.[0])).toContain('Message context menu');
+        const message = String(warn.mock.calls[0]?.[0]);
+        expect(message).toContain('Message context menu');
+        expect(message).toContain('Report');
+        expect(message).toContain('@ContextMenuRoute');
     });
 });

--- a/packages/http/tests/node/commands/route-guard.test.ts
+++ b/packages/http/tests/node/commands/route-guard.test.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { InteractionDispatcher } from '@src/node/InteractionDispatcher';
+
+import type { ResolvedRoute } from '@src/dispatch/resolve';
+
+const HANDLERS_DIR = path.resolve(__dirname, '../discovery/fixtures/handlers');
+
+function row(kind: ResolvedRoute['kind'], key: string): ResolvedRoute {
+    // justified: the guard reads map membership only, never the loader
+    return { kind, routeId: `${kind}:${key}`, load: () => Promise.resolve(null) };
+}
+
+function dispatcherWith(seed: (d: InteractionDispatcher) => void): {
+    dispatcher: InteractionDispatcher;
+    warn: ReturnType<typeof vi.fn>;
+} {
+    const dispatcher = new InteractionDispatcher(HANDLERS_DIR);
+    seed(dispatcher);
+    const warn = vi.fn();
+    Object.assign(dispatcher.logger, { warn });
+    return { dispatcher, warn };
+}
+
+describe('warnUnhandledRoutes', () => {
+    it('warns for a deployed route with no registered handler', () => {
+        const { dispatcher, warn } = dispatcherWith((d) => d.maps.slash.set('ping', row('slash', 'ping')));
+
+        dispatcher.warnUnhandledRoutes(['ping', 'admin/ban']);
+
+        expect(warn).toHaveBeenCalledOnce();
+        expect(String(warn.mock.calls[0]?.[0])).toContain('admin/ban');
+    });
+
+    it('stays quiet when every route is registered', () => {
+        const { dispatcher, warn } = dispatcherWith((d) => d.maps.slash.set('ping', row('slash', 'ping')));
+
+        dispatcher.warnUnhandledRoutes(['ping']);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+});
+
+describe('warnUnhandledContextMenuRoutes', () => {
+    it('checks each kind against its own map', () => {
+        const { dispatcher, warn } = dispatcherWith((d) => {
+            d.maps.userContextMenu.set('View Profile', row('userContextMenu', 'View Profile'));
+        });
+
+        dispatcher.warnUnhandledContextMenuRoutes({
+            user: new Set(['View Profile']),
+            message: new Set(['Report'])
+        });
+
+        expect(warn).toHaveBeenCalledOnce();
+        expect(String(warn.mock.calls[0]?.[0])).toContain('Report');
+    });
+
+    it('warns per kind for a name registered only on the other kind', () => {
+        const { dispatcher, warn } = dispatcherWith((d) => {
+            d.maps.userContextMenu.set('Report', row('userContextMenu', 'Report'));
+        });
+
+        dispatcher.warnUnhandledContextMenuRoutes({ user: new Set(['Report']), message: new Set(['Report']) });
+
+        expect(warn).toHaveBeenCalledOnce();
+        expect(String(warn.mock.calls[0]?.[0])).toContain('Message context menu');
+    });
+});

--- a/packages/http/tests/node/commands/startup.test.ts
+++ b/packages/http/tests/node/commands/startup.test.ts
@@ -53,7 +53,11 @@ afterEach(async () => {
 // REST's verb methods sit far up its prototype chain, where vi.spyOn resolves get and reports put
 // as undefined. assigning own properties shadows both.
 function stubRest(host: Seedcord): { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> } {
-    const get = vi.fn((route: string) => (route === Routes.currentApplication() ? { id: APP } : {}));
+    const get = vi.fn((route: string) => {
+        if (route === Routes.currentApplication()) return { id: APP };
+        if (route === Routes.applicationEmojis(APP)) return { items: [{ name: 'confirm', id: '111' }] };
+        return {};
+    });
     const put = vi.fn().mockResolvedValue([{ id: 'cmd-1', name: 'ping', type: ApplicationCommandType.ChatInput }]);
     Object.assign(host.rest, { get, put });
     return { get, put };
@@ -104,6 +108,19 @@ describe('command deploy during http startup', () => {
 
         expect([...(slash.mock.calls[0]?.[0] ?? [])]).toContain('ping');
         expect(menus).toHaveBeenCalledOnce();
+    });
+
+    it('resolves the application id once when emojis and commands both need it', async () => {
+        const host = new Seedcord({
+            ...config(COMMANDS_DIR),
+            bot: { ...config(COMMANDS_DIR).bot, emojis: { Confirm: 'confirm' } }
+        });
+        live = host;
+        const { get } = stubRest(host);
+
+        await host.start(0);
+
+        expect(get.mock.calls.filter((call) => call[0] === Routes.currentApplication())).toHaveLength(1);
     });
 
     it('touches no command route when no commands path is configured', async () => {

--- a/packages/http/tests/node/commands/startup.test.ts
+++ b/packages/http/tests/node/commands/startup.test.ts
@@ -5,6 +5,7 @@ import { ApplicationCommandType, Routes } from 'discord-api-types/v10';
 import { Envapter, merge, PortableSource } from 'envapt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { InteractionDispatcher } from '@src/node/InteractionDispatcher';
 import { Seedcord } from '@src/node/Seedcord';
 
 import { createSigner } from '../../helpers/ed25519';
@@ -13,15 +14,16 @@ import { VALID_TOKEN } from '../../helpers/fixtures';
 import type { HttpConfig } from '@src/interfaces/Config';
 
 const COMMANDS_DIR = path.resolve(__dirname, './fixtures');
+const HANDLERS_DIR = path.resolve(__dirname, '../discovery/fixtures/handlers');
 const APP = 'app-1';
 
 // justified: the generated Commands map is empty in tests, so entries read through a plain record
 const commands = Commands as Record<string, { id: string; mention: string } | undefined>;
 
-function config(commandsPath: string | null): HttpConfig {
+function config(commandsPath: string | null, interactionsPath: string | null = null): HttpConfig {
     return {
         bot: {
-            interactions: { path: null },
+            interactions: interactionsPath === null ? { path: null } : { path: interactionsPath },
             commands: commandsPath === null ? { path: null } : { path: commandsPath }
         },
         subscribers: { path: null },
@@ -89,6 +91,19 @@ describe('command deploy during http startup', () => {
         await host.start(0);
 
         expect(get).toHaveBeenCalledWith(Routes.currentApplication());
+    });
+
+    it('checks the deployed routes against the registered handlers', async () => {
+        const slash = vi.spyOn(InteractionDispatcher.prototype, 'warnUnhandledRoutes');
+        const menus = vi.spyOn(InteractionDispatcher.prototype, 'warnUnhandledContextMenuRoutes');
+        const host = new Seedcord(config(COMMANDS_DIR, HANDLERS_DIR));
+        live = host;
+        stubRest(host);
+
+        await host.start(0);
+
+        expect([...(slash.mock.calls[0]?.[0] ?? [])]).toContain('ping');
+        expect(menus).toHaveBeenCalledOnce();
     });
 
     it('touches no command route when no commands path is configured', async () => {

--- a/packages/http/tests/node/commands/startup.test.ts
+++ b/packages/http/tests/node/commands/startup.test.ts
@@ -1,0 +1,104 @@
+import path from 'node:path';
+
+import { Commands } from '@seedcord/core';
+import { ApplicationCommandType, Routes } from 'discord-api-types/v10';
+import { Envapter, merge, PortableSource } from 'envapt';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Seedcord } from '@src/node/Seedcord';
+
+import { createSigner } from '../../helpers/ed25519';
+import { VALID_TOKEN } from '../../helpers/fixtures';
+
+import type { HttpConfig } from '@src/interfaces/Config';
+
+const COMMANDS_DIR = path.resolve(__dirname, './fixtures');
+const APP = 'app-1';
+
+// justified: the generated Commands map is empty in tests, so entries read through a plain record
+const commands = Commands as Record<string, { id: string; mention: string } | undefined>;
+
+function config(commandsPath: string | null): HttpConfig {
+    return {
+        bot: {
+            interactions: { path: null },
+            commands: commandsPath === null ? { path: null } : { path: commandsPath }
+        },
+        subscribers: { path: null },
+        healthCheck: false
+    };
+}
+
+let live: Seedcord | undefined;
+
+beforeEach(async () => {
+    // @ts-expect-error singleton reset between tests
+    Seedcord.reset();
+    const signer = await createSigner();
+    Envapter.useSource(
+        merge(
+            new PortableSource(process.env),
+            new PortableSource({ DISCORD_PUBLIC_KEY: signer.publicKeyHex, DISCORD_BOT_TOKEN: VALID_TOKEN })
+        )
+    );
+});
+
+afterEach(async () => {
+    await live?.shutdown.run(0, false);
+    live = undefined;
+});
+
+// REST's verb methods sit far up its prototype chain, where vi.spyOn resolves get and reports put
+// as undefined. assigning own properties shadows both.
+function stubRest(host: Seedcord): { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> } {
+    const get = vi.fn((route: string) => (route === Routes.currentApplication() ? { id: APP } : {}));
+    const put = vi.fn().mockResolvedValue([{ id: 'cmd-1', name: 'ping', type: ApplicationCommandType.ChatInput }]);
+    Object.assign(host.rest, { get, put });
+    return { get, put };
+}
+
+describe('command deploy during http startup', () => {
+    it('deploys the scanned commands to the global route', async () => {
+        const host = new Seedcord(config(COMMANDS_DIR));
+        live = host;
+        const { put } = stubRest(host);
+
+        await host.start(0);
+
+        expect(put).toHaveBeenCalledOnce();
+        expect(put.mock.calls[0]?.[0]).toBe(Routes.applicationCommands(APP));
+        expect((put.mock.calls[0]?.[1] as { body: { name: string }[] }).body[0]?.name).toBe('ping');
+    });
+
+    it('injects the deployed id into the Commands accessor', async () => {
+        const host = new Seedcord(config(COMMANDS_DIR));
+        live = host;
+        stubRest(host);
+
+        await host.start(0);
+
+        expect(commands.ping?.id).toBe('cmd-1');
+        expect(commands.ping?.mention).toBe('</ping:cmd-1>');
+    });
+
+    it('resolves the application id over REST, since http has no gateway session', async () => {
+        const host = new Seedcord(config(COMMANDS_DIR));
+        live = host;
+        const { get } = stubRest(host);
+
+        await host.start(0);
+
+        expect(get).toHaveBeenCalledWith(Routes.currentApplication());
+    });
+
+    it('touches no command route when no commands path is configured', async () => {
+        const host = new Seedcord(config(null));
+        live = host;
+        const { get, put } = stubRest(host);
+
+        await host.start(0);
+
+        expect(put).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalledWith(Routes.currentApplication());
+    });
+});

--- a/packages/http/tests/node/emojis/EmojiInjector.test.ts
+++ b/packages/http/tests/node/emojis/EmojiInjector.test.ts
@@ -100,7 +100,7 @@ describe('EmojiInjector', () => {
         const caught = await new EmojiInjector(core).init().catch((error: unknown) => error);
 
         expect(isSeedcordError(caught, 'SeedcordError', SeedcordErrorCode.ConfigEmojiUnresolved)).toBe(true);
-        expect(String(caught)).toContain('Missing Access');
+        expect(String(caught)).toContain('application id could not be resolved');
     });
 
     it('collects a guild fetch failure with its cause', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -976,6 +976,9 @@ importers:
       '@seedcord/utils':
         specifier: workspace:*
         version: link:../utils
+      chalk:
+        specifier: catalog:deps
+        version: 5.6.2
       discord-api-types:
         specifier: ^0.38.51
         version: 0.38.51
@@ -12890,7 +12893,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12906,7 +12909,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP bots now deploy configured commands automatically when starting.
  * Deployed command IDs and mentions are available to handlers.
  * Application IDs are resolved through REST and reused for command deployment and application emoji access.
  * Startup warnings identify deployed commands or context-menu routes without registered handlers.

* **Bug Fixes**
  * Improved errors when the application ID cannot be resolved, including clearer emoji-related failure messages.

* **Tests**
  * Added coverage for command deployment, route validation, application ID resolution, and emoji behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->