### PR TITLE
feat: reply file shape

### DIFF
--- a/.changeset/types-off-discord-js.md
+++ b/.changeset/types-off-discord-js.md
@@ -3,3 +3,5 @@
 ---
 
 **BREAKING:** `@seedcord/types` no longer depends on discord.js. `ReplyResponse` and its parts are structural types over `discord-api-types`.
+
+**BREAKING:** `ReplyFile` is now `{ data: Uint8Array; name: string; description?; title? }`, which sends on either transport. the Gateway transport does still accept Djs' `AttachmentBuilder` though.

--- a/.changeset/types-off-discord-js.md
+++ b/.changeset/types-off-discord-js.md
@@ -3,5 +3,3 @@
 ---
 
 **BREAKING:** `@seedcord/types` no longer depends on discord.js. `ReplyResponse` and its parts are structural types over `discord-api-types`.
-
-**BREAKING:** `files` entries take `{ attachment: Buffer | string; name?; description? }`. A discord.js `AttachmentBuilder`, `Attachment`, or a node `Stream` no longer assigns.

--- a/packages/core/src/handlers/RepliableHandler.ts
+++ b/packages/core/src/handlers/RepliableHandler.ts
@@ -12,13 +12,15 @@ import type { DispatchContext } from '@src/dispatch/DispatchContext';
  * @typeParam Event - The repliable interaction type this handler processes
  * @typeParam TCore - The transport's Core
  * @typeParam TMessage - The transport's created-message lens
+ * @typeParam TNative - The transport's own file forms, beyond the portable `ReplyFile`
  * @typeParam TSender - The transport's reply sender
  */
 export abstract class RepliableHandler<
     Event,
     TCore extends CoreBase,
     TMessage extends { id: string },
-    TSender extends BaseReplySender<TMessage>
+    TNative,
+    TSender extends BaseReplySender<TMessage, TNative>
 > extends BaseHandler<Event, TCore> {
     protected readonly sender: TSender;
     protected readonly routeId: string;
@@ -38,7 +40,7 @@ export abstract class RepliableHandler<
     }
 
     /** Send the initial response, exactly once. */
-    protected reply(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    protected reply(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         return this.sender.reply(response, opts);
     }
 
@@ -48,25 +50,25 @@ export abstract class RepliableHandler<
     }
 
     /** Send a new message once the interaction is acknowledged. */
-    protected followUp(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    protected followUp(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         return this.sender.followUp(response, opts);
     }
 
     /** Rewrite the initial reply or deferred placeholder. The targeted form rewrites a message a prior send returned. */
-    protected edit(response: ReplyResponse | string): Promise<TMessage>;
-    protected edit(target: TMessage, response: ReplyResponse | string): Promise<TMessage>;
+    protected edit(response: ReplyResponse<TNative> | string): Promise<TMessage>;
+    protected edit(target: TMessage, response: ReplyResponse<TNative> | string): Promise<TMessage>;
     protected edit(
-        targetOrResponse: TMessage | ReplyResponse | string,
-        maybeResponse?: ReplyResponse | string
+        targetOrResponse: TMessage | ReplyResponse<TNative> | string,
+        maybeResponse?: ReplyResponse<TNative> | string
     ): Promise<TMessage> {
         // justified: the overloads narrow targetOrResponse to a response once maybeResponse is absent
-        if (maybeResponse === undefined) return this.sender.edit(targetOrResponse as ReplyResponse | string);
+        if (maybeResponse === undefined) return this.sender.edit(targetOrResponse as ReplyResponse<TNative> | string);
         // justified: the overloads narrow targetOrResponse to a target message once maybeResponse is defined
         return this.sender.edit(targetOrResponse as TMessage, maybeResponse);
     }
 
     /** Routes to reply, followUp, or edit based on the current ack state. */
-    protected send(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    protected send(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         return this.sender.send(response, opts);
     }
 

--- a/packages/core/src/reply/BaseReplySender.ts
+++ b/packages/core/src/reply/BaseReplySender.ts
@@ -25,11 +25,11 @@ export interface ModalLike {
  * state and ack trace. Each transport binds `TMessage` to its created-message lens and supplies the
  * writers.
  */
-export abstract class BaseReplySender<TMessage extends { id: string }> {
+export abstract class BaseReplySender<TMessage extends { id: string }, TNative = never> {
     private state: AckState;
     // the only ids a targeted edit accepts
     private readonly sent = new Set<string>();
-    // the cause carries the first ack's stack so a double-ack names both lines
+    // the cause carries the first ack's stack so a double-ack reports both lines
     private ackedBy?: AckTrace;
 
     protected constructor(
@@ -53,7 +53,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         return await attemptWrite(this.telemetry, this.routeId, method, startedAt, write);
     }
 
-    public async reply(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    public async reply(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         this.checkLegality('reply');
         const startedAt = performance.now();
         const created = await this.attempt('reply', startedAt, () => this.writeReply(response, opts));
@@ -85,7 +85,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
      * is the source message, editable only through a bare `update` or `edit`. A targeted `edit` or `delete`
      * of it throws the foreign-target error.
      */
-    public async update(response: ReplyResponse | string): Promise<TMessage> {
+    public async update(response: ReplyResponse<TNative> | string): Promise<TMessage> {
         this.checkLegality('update');
         const startedAt = performance.now();
         // in deferred-update the source message is @original and the ack-legality check above already passed
@@ -101,7 +101,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         return message;
     }
 
-    public async followUp(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    public async followUp(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         this.checkLegality('followUp');
         const startedAt = performance.now();
         const created = await this.attempt('followUp', startedAt, () => this.writeFollowUp(response, opts));
@@ -110,18 +110,18 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         return message;
     }
 
-    public edit(response: ReplyResponse | string): Promise<TMessage>;
-    public edit(target: TMessage, response: ReplyResponse | string): Promise<TMessage>;
+    public edit(response: ReplyResponse<TNative> | string): Promise<TMessage>;
+    public edit(target: TMessage, response: ReplyResponse<TNative> | string): Promise<TMessage>;
     public async edit(
-        targetOrResponse: TMessage | ReplyResponse | string,
-        maybeResponse?: ReplyResponse | string
+        targetOrResponse: TMessage | ReplyResponse<TNative> | string,
+        maybeResponse?: ReplyResponse<TNative> | string
     ): Promise<TMessage> {
         this.checkLegality('edit');
         const startedAt = performance.now();
         if (maybeResponse === undefined) {
             // justified: the overloads narrow targetOrResponse to a response once maybeResponse is absent
             const edited = await this.attempt('edit', startedAt, () =>
-                this.editOriginal(targetOrResponse as ReplyResponse | string)
+                this.editOriginal(targetOrResponse as ReplyResponse<TNative> | string)
             );
             this.report('edit', startedAt, 'sent', edited.id);
             return edited;
@@ -157,7 +157,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
     }
 
     /** Routes to the verb the current ack state permits. Every state has a route, so the illegal-ack throw is unreachable. */
-    public async send(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage> {
+    public async send(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {
         const target = sendTarget(this.state);
         if (target === 'reply') return await this.reply(response, opts);
         if (target === 'edit') return await this.edit(response);
@@ -182,7 +182,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         this.report('showModal', startedAt, 'sent', null);
     }
 
-    protected serialize(response: ReplyResponse | string): SerializedReply {
+    protected serialize(response: ReplyResponse<TNative> | string): SerializedReply<TNative> {
         return serializeReply(response, this.routeId);
     }
 
@@ -191,13 +191,13 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         return created;
     }
 
-    // a with_response callback always returns the created message, this guards a wire-contract gap
+    // a with_response callback always returns the created message, so this guards a wire-contract gap
     private requireMessage(created: TMessage | undefined, method: 'reply' | 'update'): TMessage {
         if (!created) throw new SeedcordError(SeedcordErrorCode.ReplyCallbackMissingMessage, [method, this.routeId]);
         return created;
     }
 
-    private async editOriginal(response: ReplyResponse | string): Promise<TMessage> {
+    private async editOriginal(response: ReplyResponse<TNative> | string): Promise<TMessage> {
         const edited = await this.writeEditOriginal(response);
         // after a deferUpdate the source message is @original, which this interaction did not send
         if (this.state !== 'deferred-update') this.remember(edited);
@@ -213,16 +213,19 @@ export abstract class BaseReplySender<TMessage extends { id: string }> {
         this.ackedBy = new AckTrace(method);
     }
 
-    // the modal-submit backstop, gateway overrides, the base call is a no-op elsewhere
+    // gateway overrides this to reject a modal-submit source
     protected guardModalSource(): void {}
 
-    protected abstract writeReply(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage | undefined>;
+    protected abstract writeReply(
+        response: ReplyResponse<TNative> | string,
+        opts?: SendOpts
+    ): Promise<TMessage | undefined>;
     protected abstract writeDefer(opts?: DeferOpts): Promise<void>;
     protected abstract writeDeferUpdate(): Promise<void>;
-    protected abstract writeUpdate(response: ReplyResponse | string): Promise<TMessage | undefined>;
-    protected abstract writeFollowUp(response: ReplyResponse | string, opts?: SendOpts): Promise<TMessage>;
-    protected abstract writeEditOriginal(response: ReplyResponse | string): Promise<TMessage>;
-    protected abstract writeEditTarget(targetId: string, response: ReplyResponse | string): Promise<TMessage>;
+    protected abstract writeUpdate(response: ReplyResponse<TNative> | string): Promise<TMessage | undefined>;
+    protected abstract writeFollowUp(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage>;
+    protected abstract writeEditOriginal(response: ReplyResponse<TNative> | string): Promise<TMessage>;
+    protected abstract writeEditTarget(targetId: string, response: ReplyResponse<TNative> | string): Promise<TMessage>;
     protected abstract writeDeleteOriginal(): Promise<void>;
     protected abstract writeDeleteTarget(targetId: string): Promise<void>;
     protected abstract writeModal(data: APIModalInteractionResponseCallbackData): Promise<void>;

--- a/packages/core/src/reply/serializeReply.ts
+++ b/packages/core/src/reply/serializeReply.ts
@@ -6,14 +6,17 @@ import type { ReplyResponse } from '@seedcord/types';
 import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
 
 /** Serialized message data the transport wire writers consume. */
-export interface SerializedReply {
+export interface SerializedReply<TNative = never> {
     readonly components: APIMessageTopLevelComponent[];
     readonly allowedMentions?: ReplyResponse['allowedMentions'];
-    readonly files?: ReplyResponse['files'];
+    readonly files?: ReplyResponse<TNative>['files'];
 }
 
 /** Wraps a string in a TextDisplay component. */
-export function serializeReply(response: ReplyResponse | string, routeId: string): SerializedReply {
+export function serializeReply<TNative>(
+    response: ReplyResponse<TNative> | string,
+    routeId: string
+): SerializedReply<TNative> {
     if (typeof response === 'string') {
         try {
             return { components: [new TextDisplayBuilder().setContent(response).toJSON()] };

--- a/packages/core/src/subscribers/bases/WebhookSender.ts
+++ b/packages/core/src/subscribers/bases/WebhookSender.ts
@@ -3,24 +3,18 @@ import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { Routes } from 'discord-api-types/v10';
 
+import type { ReplyFile } from '@seedcord/types';
 import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
 
 const HTTP_NOT_FOUND = 404;
 const HTTP_UNAUTHORIZED = 401;
 
-/**
- * A file attached to a webhook report.
- */
-export interface WebhookFile {
-    name: string;
-    description: string;
-    /** A `Buffer` still satisfies this, it extends `Uint8Array`. */
-    data: Uint8Array | string;
+/** A file attached to a webhook report. */
+export interface WebhookFile extends ReplyFile {
+    readonly description: string;
 }
 
-/**
- * The payload {@link WebhookSender.send} posts.
- */
+/** The payload {@link WebhookSender.send} posts. */
 export interface WebhookSendOptions {
     flags: number;
     username: string;
@@ -39,7 +33,7 @@ export class WebhookSender {
 
     constructor(url: string) {
         const match = /\/webhooks\/(\d+)\/([\w$-]+)$/.exec(url);
-        // the url is a secret, the error message never carries it
+        // the url is a secret, so the error message never carries it
         if (!match?.[1] || !match[2]) throw new SeedcordError(SeedcordErrorCode.ConfigWebhookUrlInvalid, ['The url']);
         this.route = Routes.webhook(match[1], match[2]);
     }
@@ -64,7 +58,7 @@ export class WebhookSender {
         const { flags, username, components, files } = options;
         await this.rest.post(this.route, {
             auth: false,
-            // with_components=true makes discord accept a components-v2 payload, wait=true makes it
+            // with_components=true makes discord accept a components-v2 payload. wait=true makes it
             // return payload errors in the response
             query: new URLSearchParams({ with_components: 'true', wait: 'true' }),
             body: {

--- a/packages/core/src/subscribers/bases/webhookHelpers.ts
+++ b/packages/core/src/subscribers/bases/webhookHelpers.ts
@@ -15,10 +15,10 @@ export function isDiscordWebhookUrl(value: string): boolean {
 
 export function jsonAttachment(name: string, description: string, data: unknown): WebhookFile {
     const content = filterCirculars(data);
-    return { name, description, data: JSON.stringify(content, undefined, 2) };
+    return { name, description, data: new TextEncoder().encode(JSON.stringify(content, undefined, 2)) };
 }
 
-// the report renders inside a ``` fence, break any triple-backtick run to keep it from closing early
+// the report renders inside a ``` fence, so break any triple-backtick run to keep it from closing early
 export function neutralizeFences(text: string): string {
     return text.replaceAll('```', '`​`​`');
 }

--- a/packages/core/tests/reply/serializeReply.test.ts
+++ b/packages/core/tests/reply/serializeReply.test.ts
@@ -43,11 +43,11 @@ describe('serializeReply', () => {
         const response: ReplyResponse = {
             components: [new TextDisplayBuilder().setContent('a')],
             allowedMentions: { parse: ['users'] },
-            files: [{ attachment: 'buf', name: 'f.txt' }]
+            files: [{ data: new Uint8Array([1, 2]), name: 'f.txt' }]
         };
         const result = serializeReply(response, ROUTE);
         expect(result.allowedMentions).toEqual({ parse: ['users'] });
-        expect(result.files).toEqual([{ attachment: 'buf', name: 'f.txt' }]);
+        expect(result.files).toEqual([{ data: new Uint8Array([1, 2]), name: 'f.txt' }]);
     });
 
     it('omits allowedMentions and files when the response has none', () => {

--- a/packages/core/tests/subscribers/bases/webhookHelpers.test.ts
+++ b/packages/core/tests/subscribers/bases/webhookHelpers.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { errorReport } from '@subscribers/bases/webhookHelpers';
+import { errorReport, jsonAttachment } from '@subscribers/bases/webhookHelpers';
+
+describe('jsonAttachment', () => {
+    it('encodes the json to bytes, which is what @discordjs/rest uploads as a file', () => {
+        const file = jsonAttachment('metadata.json', 'error metadata', { userId: '1' });
+
+        expect(file.data).toBeInstanceOf(Uint8Array);
+        expect(new TextDecoder().decode(file.data)).toBe(JSON.stringify({ userId: '1' }, undefined, 2));
+    });
+
+    it('drops circular references so the encode cannot throw', () => {
+        const circular: Record<string, unknown> = { name: 'a' };
+        circular.self = circular;
+
+        expect(() => jsonAttachment('m.json', 'd', circular)).not.toThrow();
+    });
+});
 
 describe('errorReport', () => {
     it('neutralizes triple-backtick fences so the downstream code block cannot break', () => {

--- a/packages/gateway/src/bot/ReplySender.ts
+++ b/packages/gateway/src/bot/ReplySender.ts
@@ -3,9 +3,10 @@ import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { MessageFlags } from 'discord.js';
 
+import type { GatewayFile, GatewayReplyResponse } from '@interfaces/ReplyResponse';
 import type { Bus } from '@seedcord/core';
 import type { AckState } from '@seedcord/core/internal';
-import type { DeferOpts, ReplyResponse, SendOpts } from '@seedcord/types';
+import type { DeferOpts, ReplyFile, SendOpts } from '@seedcord/types';
 import type { Repliables } from '@src/handlers/interactionTypes';
 import type {
     APIModalInteractionResponseCallbackData,
@@ -24,6 +25,20 @@ type SourceInteraction = MessageComponentInteraction | ModalMessageModalSubmitIn
 /** The created message a gateway reply resolves to. */
 export type SentMessage = Message;
 
+function isReplyFile(file: ReplyFile | GatewayFile): file is ReplyFile {
+    return typeof file === 'object' && 'data' in file && ArrayBuffer.isView(file.data);
+}
+
+// discord.js rejects a plain Uint8Array, so convert the bytes to a Buffer
+function toDjsFile(file: ReplyFile | GatewayFile): GatewayFile {
+    if (!isReplyFile(file)) return file;
+    return {
+        attachment: Buffer.from(file.data),
+        name: file.name,
+        ...(file.description !== undefined && { description: file.description })
+    };
+}
+
 // djs flips `replied` on editReply, so per-call derivation would break repeated update() and post-edit
 // send() parity
 function seedState(interaction: Repliables): AckState {
@@ -37,7 +52,7 @@ function seedState(interaction: Repliables): AckState {
  * Writes interaction responses through the discord.js interaction. Construction is internal to the repliable
  * handler bases and the dispatcher.
  */
-export class ReplySender extends BaseReplySender<SentMessage> {
+export class ReplySender extends BaseReplySender<SentMessage, GatewayFile> {
     public constructor(
         private readonly interaction: Repliables,
         routeId: string,
@@ -46,7 +61,10 @@ export class ReplySender extends BaseReplySender<SentMessage> {
         super(routeId, seedState(interaction), bus && { bus, interactionId: interaction.id });
     }
 
-    protected async writeReply(response: ReplyResponse | string, opts?: SendOpts): Promise<SentMessage | undefined> {
+    protected async writeReply(
+        response: GatewayReplyResponse | string,
+        opts?: SendOpts
+    ): Promise<SentMessage | undefined> {
         const result = await this.interaction.reply({
             ...this.replyOptions(response, sendFlags(opts)),
             withResponse: true
@@ -62,21 +80,21 @@ export class ReplySender extends BaseReplySender<SentMessage> {
         await this.sourceInteraction('deferUpdate').deferUpdate();
     }
 
-    protected async writeUpdate(response: ReplyResponse | string): Promise<SentMessage | undefined> {
+    protected async writeUpdate(response: GatewayReplyResponse | string): Promise<SentMessage | undefined> {
         const source = this.sourceInteraction('update');
         const result = await source.update({ ...this.updateOptions(response), withResponse: true });
         return this.createdMessage(result);
     }
 
-    protected async writeFollowUp(response: ReplyResponse | string, opts?: SendOpts): Promise<SentMessage> {
+    protected async writeFollowUp(response: GatewayReplyResponse | string, opts?: SendOpts): Promise<SentMessage> {
         return await this.interaction.followUp(this.replyOptions(response, sendFlags(opts)));
     }
 
-    protected async writeEditOriginal(response: ReplyResponse | string): Promise<SentMessage> {
+    protected async writeEditOriginal(response: GatewayReplyResponse | string): Promise<SentMessage> {
         return await this.interaction.editReply(this.editOptions(response));
     }
 
-    protected async writeEditTarget(targetId: string, response: ReplyResponse | string): Promise<SentMessage> {
+    protected async writeEditTarget(targetId: string, response: GatewayReplyResponse | string): Promise<SentMessage> {
         return await this.interaction.webhook.editMessage(targetId, this.editOptions(response));
     }
 
@@ -117,33 +135,33 @@ export class ReplySender extends BaseReplySender<SentMessage> {
         throw new SeedcordError(SeedcordErrorCode.ReplyUpdateWithoutSource, [method, this.routeId]);
     }
 
-    private replyOptions(response: ReplyResponse | string, flags: number): InteractionReplyOptions {
+    private replyOptions(response: GatewayReplyResponse | string, flags: number): InteractionReplyOptions {
         const reply = this.serialize(response);
         return {
             components: reply.components,
             flags,
             ...(reply.allowedMentions && { allowedMentions: reply.allowedMentions }),
-            ...(reply.files && { files: [...reply.files] })
+            ...(reply.files && { files: reply.files.map(toDjsFile) })
         };
     }
 
-    private editOptions(response: ReplyResponse | string): WebhookMessageEditOptions {
+    private editOptions(response: GatewayReplyResponse | string): WebhookMessageEditOptions {
         const reply = this.serialize(response);
         return {
             components: reply.components,
             flags: MessageFlags.IsComponentsV2,
             ...(reply.allowedMentions && { allowedMentions: reply.allowedMentions }),
-            ...(reply.files && { files: [...reply.files] })
+            ...(reply.files && { files: reply.files.map(toDjsFile) })
         };
     }
 
-    private updateOptions(response: ReplyResponse | string): InteractionUpdateOptions {
+    private updateOptions(response: GatewayReplyResponse | string): InteractionUpdateOptions {
         const reply = this.serialize(response);
         return {
             components: reply.components,
             flags: MessageFlags.IsComponentsV2,
             ...(reply.allowedMentions && { allowedMentions: reply.allowedMentions }),
-            ...(reply.files && { files: [...reply.files] })
+            ...(reply.files && { files: reply.files.map(toDjsFile) })
         };
     }
 

--- a/packages/gateway/src/bot/ReplySender.ts
+++ b/packages/gateway/src/bot/ReplySender.ts
@@ -35,7 +35,8 @@ function toDjsFile(file: ReplyFile | GatewayFile): GatewayFile {
     return {
         attachment: Buffer.from(file.data),
         name: file.name,
-        ...(file.description !== undefined && { description: file.description })
+        ...(file.description !== undefined && { description: file.description }),
+        ...(file.title !== undefined && { title: file.title })
     };
 }
 

--- a/packages/gateway/src/handlers/RepliableHandler.ts
+++ b/packages/gateway/src/handlers/RepliableHandler.ts
@@ -5,6 +5,7 @@ import { ReplySender } from '@bot/ReplySender';
 import type { Repliables } from './interactionTypes';
 import type { SentMessage } from '@bot/ReplySender';
 import type { Core } from '@interfaces/Core';
+import type { GatewayFile } from '@interfaces/ReplyResponse';
 
 /**
  * Shared base the repliable interaction handlers extend.
@@ -19,6 +20,7 @@ export abstract class RepliableHandler<Event extends Repliables> extends CoreRep
     Event,
     Core,
     SentMessage,
+    GatewayFile,
     ReplySender
 > {
     // this chain skips gateway BaseHandler, the only class that defines getEvent, so it re-declares here

--- a/packages/gateway/src/handlers/interaction/components/ComponentHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ComponentHandler.ts
@@ -5,6 +5,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 import { InteractionHandler } from '@handlers/interaction/InteractionHandler';
 
 import type { SentMessage } from '@bot/ReplySender';
+import type { GatewayReplyResponse } from '@interfaces/ReplyResponse';
 import type {
     AnyCustomId,
     DecodedComponentRoute,
@@ -12,7 +13,6 @@ import type {
     MatchArms,
     SingleParams
 } from '@seedcord/core/internal';
-import type { ReplyResponse } from '@seedcord/types';
 import type { AnySelectMenuInteraction, ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import type { Promisable } from 'type-fest';
 
@@ -36,7 +36,7 @@ export abstract class ComponentHandler<Event extends ComponentInteraction, Defs 
     declare readonly __componentDefs?: Defs;
 
     /** Rewrite the source message this component interaction came from. */
-    protected update(response: ReplyResponse | string): Promise<SentMessage> {
+    protected update(response: GatewayReplyResponse | string): Promise<SentMessage> {
         return this.sender.update(response);
     }
 
@@ -92,7 +92,7 @@ export abstract class ComponentHandler<Event extends ComponentInteraction, Defs 
      */
     protected async match<Ret>(arms: MatchArms<Defs, Ret>): Promise<Ret> {
         const { prefix, params } = this.route;
-        // justified: MatchArms is keyed by prefix literals, the Record cast indexes it with the runtime prefix.
+        // justified: MatchArms is keyed by prefix literals, so the Record cast indexes it with the runtime prefix
         const arm = Object.hasOwn(arms, prefix)
             ? (arms as Record<string, (params: Record<string, unknown>) => Promisable<Ret>>)[prefix]
             : undefined;

--- a/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
@@ -4,8 +4,8 @@ import { SeedcordError } from '@seedcord/errors/internal';
 import { ComponentHandler } from './ComponentHandler';
 
 import type { SentMessage } from '@bot/ReplySender';
+import type { GatewayReplyResponse } from '@interfaces/ReplyResponse';
 import type { AnyCustomId } from '@seedcord/core/internal';
-import type { ReplyResponse } from '@seedcord/types';
 import type { CacheType, ModalSubmitInteraction } from 'discord.js';
 
 /**
@@ -40,7 +40,7 @@ export abstract class ModalHandler<
     declare readonly __component?: 'modal';
 
     /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
-    protected override update(response: ReplyResponse | string): Promise<SentMessage> {
+    protected override update(response: GatewayReplyResponse | string): Promise<SentMessage> {
         this.ensureSourceMessage('update');
         return super.update(response);
     }

--- a/packages/gateway/src/interfaces/ReplyResponse.ts
+++ b/packages/gateway/src/interfaces/ReplyResponse.ts
@@ -1,0 +1,24 @@
+import type { ReplyResponse } from '@seedcord/types';
+import type { BaseMessageOptions } from 'discord.js';
+
+/**
+ * Every file form discord.js accepts in a message's `files` field: `AttachmentBuilder`, `Attachment`, a
+ * `Buffer`, a node `Stream`, a path or URL string, and an `{ attachment, name }` payload.
+ */
+export type GatewayFile = NonNullable<BaseMessageOptions['files']>[number];
+
+/**
+ * A reply that may attach files in any form discord.js accepts, on top of the portable `ReplyFile`. The
+ * reply verbs already take this, so name it only to type a variable or a helper's return. A `Notice`
+ * render or a paginator page returns the plain `ReplyResponse`, which takes a `ReplyFile` alone.
+ *
+ * @example
+ * ```ts
+ * // any discord.js file form
+ * await this.reply({
+ *     components: [container],
+ *     files: [new AttachmentBuilder(createReadStream('./report.pdf'), { name: 'report.pdf' })]
+ * });
+ * ```
+ */
+export type GatewayReplyResponse = ReplyResponse<GatewayFile>;

--- a/packages/gateway/src/interfaces/index.ts
+++ b/packages/gateway/src/interfaces/index.ts
@@ -1,2 +1,3 @@
 export type * from './Config';
 export type * from './Core';
+export type * from './ReplyResponse';

--- a/packages/gateway/tests/ReplySender.files.test.ts
+++ b/packages/gateway/tests/ReplySender.files.test.ts
@@ -43,6 +43,32 @@ describe('the portable file', () => {
     });
 });
 
+describe('the attachment metadata', () => {
+    it('carries a title through', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'note.ogg', title: 'Voice note' }]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'note.ogg', title: 'Voice note' }]);
+    });
+
+    it('carries a title and alt text together', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'a.png', title: 'T', description: 'D' }]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'a.png', description: 'D', title: 'T' }]);
+    });
+
+    it('omits title when the file sets none', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'a.png' }]);
+
+        expect(files?.[0]).not.toHaveProperty('title');
+    });
+
+    it('sends a SPOILER_ name through', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'SPOILER_secret.png' }]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'SPOILER_secret.png' }]);
+    });
+});
+
 describe('the discord.js file forms', () => {
     it('passes an AttachmentBuilder through untouched', async () => {
         const builder = new AttachmentBuilder(Buffer.from(BYTES), { name: 'seed.txt' });

--- a/packages/gateway/tests/ReplySender.files.test.ts
+++ b/packages/gateway/tests/ReplySender.files.test.ts
@@ -99,9 +99,10 @@ describe('the discord.js file forms', () => {
     });
 
     it('passes an Attachment a message already carries through untouched', async () => {
+        // justified: Attachment's constructor is private, and typing it keeps the GatewayFile check
         const attachment = Reflect.construct(Attachment, [
             { id: '1', filename: 'a.txt', size: 4, url: 'https://cdn.discordapp.com/a.txt', proxy_url: 'x' }
-        ]) as never;
+        ]) as Attachment;
 
         expect(await replyWith([attachment])).toEqual([attachment]);
     });

--- a/packages/gateway/tests/ReplySender.files.test.ts
+++ b/packages/gateway/tests/ReplySender.files.test.ts
@@ -1,0 +1,151 @@
+import { Readable } from 'node:stream';
+
+import { TextDisplayBuilder } from '@discordjs/builders';
+import { Attachment, AttachmentBuilder } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+
+import { mockInteraction, senderFor } from './utils/senderMock';
+
+import type { GatewayReplyResponse } from '@interfaces/ReplyResponse';
+import type { ReplyResponse } from '@seedcord/types';
+
+const BYTES = new Uint8Array([0x73, 0x65, 0x65, 0x64]);
+const components = [new TextDisplayBuilder().setContent('hi')];
+
+function sentFiles(mock: ReturnType<typeof mockInteraction>): unknown[] | undefined {
+    return (mock.reply.mock.calls[0]?.[0] as { files?: unknown[] }).files;
+}
+
+async function replyWith(files: NonNullable<GatewayReplyResponse['files']>): Promise<unknown[] | undefined> {
+    const mock = mockInteraction();
+    await senderFor(mock).reply({ components, files });
+    return sentFiles(mock);
+}
+
+describe('the portable file', () => {
+    it('reaches discord.js as a Buffer, which is the only byte form it accepts', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'seed.txt' }]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'seed.txt' }]);
+        expect(Buffer.isBuffer((files as { attachment: unknown }[])[0]?.attachment)).toBe(true);
+    });
+
+    it('carries alt text through', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'seed.txt', description: 'four bytes' }]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'seed.txt', description: 'four bytes' }]);
+    });
+
+    it('omits description when the file sets none', async () => {
+        const files = await replyWith([{ data: BYTES, name: 'seed.txt' }]);
+
+        expect(files?.[0]).not.toHaveProperty('description');
+    });
+});
+
+describe('the discord.js file forms', () => {
+    it('passes an AttachmentBuilder through untouched', async () => {
+        const builder = new AttachmentBuilder(Buffer.from(BYTES), { name: 'seed.txt' });
+
+        expect(await replyWith([builder])).toEqual([builder]);
+    });
+
+    it('passes an AttachmentBuilder over a stream through untouched', async () => {
+        const builder = new AttachmentBuilder(Readable.from([Buffer.from(BYTES)]), { name: 'seed.txt' });
+
+        expect(await replyWith([builder])).toEqual([builder]);
+    });
+
+    it('passes a bare Buffer through untouched', async () => {
+        const buffer = Buffer.from(BYTES);
+
+        expect(await replyWith([buffer])).toEqual([buffer]);
+    });
+
+    it('passes a path string through, which discord.js reads off disk', async () => {
+        expect(await replyWith(['./fixture.txt'])).toEqual(['./fixture.txt']);
+    });
+
+    it('passes a bare stream through untouched', async () => {
+        const stream = Readable.from([Buffer.from(BYTES)]);
+
+        expect(await replyWith([stream])).toEqual([stream]);
+    });
+
+    it('passes an Attachment a message already carries through untouched', async () => {
+        const attachment = Reflect.construct(Attachment, [
+            { id: '1', filename: 'a.txt', size: 4, url: 'https://cdn.discordapp.com/a.txt', proxy_url: 'x' }
+        ]) as never;
+
+        expect(await replyWith([attachment])).toEqual([attachment]);
+    });
+
+    it('passes an attachment payload through untouched', async () => {
+        const payload = { attachment: Buffer.from(BYTES), name: 'seed.txt' };
+
+        expect(await replyWith([payload])).toEqual([payload]);
+    });
+
+    it('converts only the portable entry when the two are mixed', async () => {
+        const builder = new AttachmentBuilder(Buffer.from(BYTES), { name: 'b.txt' });
+
+        const files = await replyWith([{ data: BYTES, name: 'a.txt' }, builder]);
+
+        expect(files).toEqual([{ attachment: Buffer.from(BYTES), name: 'a.txt' }, builder]);
+    });
+});
+
+describe('what the types allow', () => {
+    it('accepts a reply a shared notice or page render built, which names the portable type', () => {
+        const shared: ReplyResponse = { components, files: [{ data: BYTES, name: 'a.png' }] };
+        const bound: GatewayReplyResponse = shared;
+
+        expect(bound.files).toHaveLength(1);
+    });
+
+    it('rejects a discord.js file form on the portable type, which a Notice render returns', () => {
+        // @ts-expect-error only GatewayReplyResponse accepts the discord.js forms
+        const response: ReplyResponse = { components, files: [new AttachmentBuilder(Buffer.from(BYTES))] };
+
+        expect(response.files).toHaveLength(1);
+    });
+
+    it('rejects a file with no name', () => {
+        // @ts-expect-error name is required because an unnamed file cannot be referenced by a v2 component
+        const response: GatewayReplyResponse = { components, files: [{ data: BYTES }] };
+
+        expect(response.files).toHaveLength(1);
+    });
+});
+
+describe('the other verbs', () => {
+    it('converts on edit', async () => {
+        const mock = mockInteraction({ deferred: true, ephemeral: false });
+
+        await senderFor(mock).edit({ components, files: [{ data: BYTES, name: 'seed.txt' }] });
+
+        expect((mock.editReply.mock.calls[0]?.[0] as { files?: unknown[] }).files).toEqual([
+            { attachment: Buffer.from(BYTES), name: 'seed.txt' }
+        ]);
+    });
+
+    it('converts on update', async () => {
+        const mock = mockInteraction();
+
+        await senderFor(mock).update({ components, files: [{ data: BYTES, name: 'seed.txt' }] });
+
+        expect((mock.update.mock.calls[0]?.[0] as { files?: unknown[] }).files).toEqual([
+            { attachment: Buffer.from(BYTES), name: 'seed.txt' }
+        ]);
+    });
+
+    it('converts on followUp', async () => {
+        const mock = mockInteraction({ replied: true });
+
+        await senderFor(mock).followUp({ components, files: [{ data: BYTES, name: 'seed.txt' }] });
+
+        expect((mock.followUp.mock.calls[0]?.[0] as { files?: unknown[] }).files).toEqual([
+            { attachment: Buffer.from(BYTES), name: 'seed.txt' }
+        ]);
+    });
+});

--- a/packages/http/src/handlers/RepliableHandler.ts
+++ b/packages/http/src/handlers/RepliableHandler.ts
@@ -21,6 +21,7 @@ export abstract class RepliableHandler<Event extends Repliables> extends CoreRep
     Event,
     Core,
     SentMessage,
+    never,
     ReplySender
 > {
     // core's base keeps event protected, and Paginator.start reads it from outside the class

--- a/packages/http/src/reply/ReplySender.ts
+++ b/packages/http/src/reply/ReplySender.ts
@@ -26,6 +26,7 @@ interface WireAttachment {
     id: number;
     filename: string;
     description?: string;
+    title?: string;
 }
 
 interface MessageBody {
@@ -42,11 +43,12 @@ function wireAllowedMentions(mentions: NonNullable<ReplyResponse['allowedMention
 
 // RawFile has no description field, so alt text goes on the wire attachments entries
 function wireAttachments(files: SerializedReply['files']): WireAttachment[] | null {
-    if (!files?.some((file) => file.description)) return null;
+    if (!files?.some((file) => file.description ?? file.title)) return null;
     return files.map((file, index) => ({
         id: index,
         filename: file.name,
-        ...(file.description && { description: file.description })
+        ...(file.description && { description: file.description }),
+        ...(file.title && { title: file.title })
     }));
 }
 

--- a/packages/http/src/reply/ReplySender.ts
+++ b/packages/http/src/reply/ReplySender.ts
@@ -17,14 +17,14 @@ export interface InteractionRef {
 /** The created message an http reply resolves to (the http `SentMessage` lens). */
 export type SentMessage = APIMessage;
 
-// the framework's allowedMentions keys are camelCase, the wire reads replied_user
+// the framework's allowedMentions keys are camelCase, and the wire reads replied_user
 type WireAllowedMentions = TypedOmit<NonNullable<ReplyResponse['allowedMentions']>, 'repliedUser'> & {
     replied_user?: boolean;
 };
 
 interface WireAttachment {
     id: number;
-    filename?: string;
+    filename: string;
     description?: string;
 }
 
@@ -45,7 +45,7 @@ function wireAttachments(files: SerializedReply['files']): WireAttachment[] | nu
     if (!files?.some((file) => file.description)) return null;
     return files.map((file, index) => ({
         id: index,
-        ...(file.name && { filename: file.name }),
+        filename: file.name,
         ...(file.description && { description: file.description })
     }));
 }
@@ -104,8 +104,8 @@ export class ReplySender extends BaseReplySender<SentMessage> {
 
     protected async writeFollowUp(response: ReplyResponse | string, opts?: SendOpts): Promise<SentMessage> {
         const reply = this.serialize(response);
-        // discord returns the created message for interaction-token followups either way, wait=true
-        // pins that contract explicitly and matches the djs webhook client
+        // discord returns the created message for interaction-token followups either way. wait=true pins
+        // that contract and matches the djs webhook client
         const result = await this.rest.post(Routes.webhook(this.ref.application_id, this.ref.token), {
             body: callbackData(reply, sendFlags(opts)),
             query: new URLSearchParams({ wait: 'true' }),
@@ -163,7 +163,7 @@ export class ReplySender extends BaseReplySender<SentMessage> {
     }
 
     private rawFiles(files: NonNullable<SerializedReply['files']>): RawFile[] {
-        return files.map((file, index) => ({ name: file.name ?? `file-${index}`, data: file.attachment }));
+        return files.map((file) => ({ name: file.name, data: file.data }));
     }
 
     private createdMessage(result: unknown): SentMessage | undefined {

--- a/packages/http/tests/node/reply/ReplySender.files.test.ts
+++ b/packages/http/tests/node/reply/ReplySender.files.test.ts
@@ -79,6 +79,27 @@ describe('the portable file', () => {
     });
 });
 
+describe('the attachment metadata', () => {
+    it('sends a title on the attachments entry', async () => {
+        const rest = await replyWith([{ data: BYTES, name: 'note.ogg', title: 'Voice note' }]);
+
+        expect(sentAttachments(rest)).toEqual([{ id: 0, filename: 'note.ogg', title: 'Voice note' }]);
+    });
+
+    it('sends a title and alt text together', async () => {
+        const rest = await replyWith([{ data: BYTES, name: 'a.png', title: 'T', description: 'D' }]);
+
+        expect(sentAttachments(rest)).toEqual([{ id: 0, filename: 'a.png', description: 'D', title: 'T' }]);
+    });
+
+    it('sends a SPOILER_ name on both the file part and the attachments entry', async () => {
+        const rest = await replyWith([{ data: BYTES, name: 'SPOILER_secret.png', description: 'hidden' }]);
+
+        expect(sentFiles(rest)?.[0]?.name).toBe('SPOILER_secret.png');
+        expect(sentAttachments(rest)).toEqual([{ id: 0, filename: 'SPOILER_secret.png', description: 'hidden' }]);
+    });
+});
+
 describe('what the types reject', () => {
     it('rejects every form @discordjs/rest cannot upload', () => {
         const rejected: ReplyResponse[] = [

--- a/packages/http/tests/node/reply/ReplySender.files.test.ts
+++ b/packages/http/tests/node/reply/ReplySender.files.test.ts
@@ -1,0 +1,123 @@
+import { Readable } from 'node:stream';
+
+import { TextDisplayBuilder } from '@discordjs/builders';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReplySender } from '@reply/ReplySender';
+
+import type { RawFile, REST } from '@discordjs/rest';
+import type { InteractionRef } from '@reply/ReplySender';
+import type { ReplyResponse } from '@seedcord/types';
+
+const BYTES = new Uint8Array([0x73, 0x65, 0x65, 0x64]);
+const ref: InteractionRef = { application_id: '111', id: '222', token: 'tok' };
+const components = [new TextDisplayBuilder().setContent('hi')];
+
+interface RestMock {
+    post: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+}
+
+function restMock(): RestMock {
+    return {
+        post: vi.fn().mockResolvedValue({ resource: { message: { id: 'msg-1' } } }),
+        patch: vi.fn().mockResolvedValue({ id: 'msg-1' })
+    };
+}
+
+// justified: the fixture implements only the REST surface ReplySender reads
+function senderFor(rest: RestMock): ReplySender {
+    return new ReplySender(ref, rest as unknown as REST, 'slash:ban');
+}
+
+function sentFiles(rest: RestMock): RawFile[] | undefined {
+    return (rest.post.mock.calls[0]?.[1] as { files?: RawFile[] }).files;
+}
+
+function sentAttachments(rest: RestMock): unknown[] | undefined {
+    return (rest.post.mock.calls[0]?.[1] as { body: { data?: { attachments?: unknown[] } } }).body.data?.attachments;
+}
+
+async function replyWith(files: NonNullable<ReplyResponse['files']>): Promise<RestMock> {
+    const rest = restMock();
+    await senderFor(rest).reply({ components, files });
+    return rest;
+}
+
+describe('the portable file', () => {
+    it('reaches @discordjs/rest as its own bytes under its own name', async () => {
+        expect(sentFiles(await replyWith([{ data: BYTES, name: 'seed.txt' }]))).toEqual([
+            { name: 'seed.txt', data: BYTES }
+        ]);
+    });
+
+    it('sends alt text on the attachments entry, which RawFile has no field for', async () => {
+        const rest = await replyWith([{ data: BYTES, name: 'seed.txt', description: 'four bytes' }]);
+
+        expect(sentAttachments(rest)).toEqual([{ id: 0, filename: 'seed.txt', description: 'four bytes' }]);
+    });
+
+    it('sends no attachments entry when no file carries alt text', async () => {
+        expect(sentAttachments(await replyWith([{ data: BYTES, name: 'seed.txt' }]))).toBeUndefined();
+    });
+
+    it('accepts a Buffer, which extends Uint8Array', async () => {
+        const buffer = Buffer.from(BYTES);
+
+        expect(sentFiles(await replyWith([{ data: buffer, name: 'seed.txt' }]))).toEqual([
+            { name: 'seed.txt', data: buffer }
+        ]);
+    });
+
+    it('keeps each file under the name it was given', async () => {
+        const rest = await replyWith([
+            { data: BYTES, name: 'first.txt' },
+            { data: BYTES, name: 'second.txt' }
+        ]);
+
+        expect(sentFiles(rest)?.map((file) => file.name)).toEqual(['first.txt', 'second.txt']);
+    });
+});
+
+describe('what the types reject', () => {
+    it('rejects every form @discordjs/rest cannot upload', () => {
+        const rejected: ReplyResponse[] = [
+            // @ts-expect-error nothing on this transport reads a path off disk
+            { components, files: ['./logo.png'] },
+            // @ts-expect-error the discord.js attachment payload is gateway-only
+            { components, files: [{ attachment: Buffer.from('x'), name: 'a.txt' }] },
+            // @ts-expect-error a node stream is gateway-only
+            { components, files: [Readable.from([Buffer.from('x')])] },
+            // @ts-expect-error name is required because an unnamed file cannot be referenced by a v2 component
+            { components, files: [{ data: BYTES }] }
+        ];
+
+        expect(rejected).toHaveLength(4);
+    });
+});
+
+describe('the other verbs', () => {
+    it('sends the bytes on followUp', async () => {
+        const rest = restMock();
+        const sender = senderFor(rest);
+        await sender.reply({ components });
+
+        await sender.followUp({ components, files: [{ data: BYTES, name: 'seed.txt' }] });
+
+        expect((rest.post.mock.calls[1]?.[1] as { files?: RawFile[] }).files).toEqual([
+            { name: 'seed.txt', data: BYTES }
+        ]);
+    });
+
+    it('sends the bytes on edit', async () => {
+        const rest = restMock();
+        const sender = senderFor(rest);
+        await sender.defer();
+
+        await sender.edit({ components, files: [{ data: BYTES, name: 'seed.txt' }] });
+
+        expect((rest.patch.mock.calls[0]?.[1] as { files?: RawFile[] }).files).toEqual([
+            { name: 'seed.txt', data: BYTES }
+        ]);
+    });
+});

--- a/packages/http/tests/node/reply/ReplySender.test.ts
+++ b/packages/http/tests/node/reply/ReplySender.test.ts
@@ -71,7 +71,7 @@ interface WebhookOptions {
     files?: { name: string; data: Buffer }[];
 }
 
-// justified: vitest types mock.calls as unknown[], the tuple cast reads the wire route and body the sender passed
+// justified: vitest types mock.calls as unknown[], so the tuple cast reads the wire route and body the sender passed
 function postCall(rest: RestMock, index = 0): { route: string; options: PostOptions } {
     const [route, options] = rest.post.mock.calls[index] as [string, PostOptions];
     return { route, options };
@@ -700,13 +700,13 @@ describe('ReplySender.showModal', () => {
 describe('ReplySender files', () => {
     it('forwards files to the REST files option and allowed_mentions into the body', async () => {
         const rest = restMock();
-        const files = [{ attachment: Buffer.from('x'), name: 'a.txt' }];
+        const files = [{ data: Buffer.from('x'), name: 'a.txt' }];
         const allowedMentions = { parse: [] as ('roles' | 'users' | 'everyone')[] };
 
         await senderFor(rest).reply({ components: reply.components, allowedMentions, files });
 
         const { options } = postCall(rest);
-        expect(options.files).toEqual([{ name: 'a.txt', data: files[0]?.attachment }]);
+        expect(options.files).toEqual([{ name: 'a.txt', data: files[0]?.data }]);
         expect(options.body.data?.allowed_mentions).toEqual(allowedMentions);
     });
 
@@ -723,7 +723,7 @@ describe('ReplySender files', () => {
 
     it('omits the attachments key when files carry no description', async () => {
         const rest = restMock();
-        const files = [{ attachment: Buffer.from('x'), name: 'a.txt' }];
+        const files = [{ data: Buffer.from('x'), name: 'a.txt' }];
 
         await senderFor(rest).reply({ components: reply.components, files });
 
@@ -733,8 +733,8 @@ describe('ReplySender files', () => {
     it('keeps attachment ids aligned when only some files carry descriptions', async () => {
         const rest = restMock();
         const files = [
-            { attachment: Buffer.from('a'), name: 'plain.txt' },
-            { attachment: Buffer.from('b'), name: 'described.txt', description: 'alt text' }
+            { data: Buffer.from('a'), name: 'plain.txt' },
+            { data: Buffer.from('b'), name: 'described.txt', description: 'alt text' }
         ];
 
         await senderFor(rest).reply({ components: reply.components, files });
@@ -747,13 +747,13 @@ describe('ReplySender files', () => {
 
     it('carries file descriptions into the attachments body entries', async () => {
         const rest = restMock();
-        const files = [{ attachment: Buffer.from('x'), name: 'report.txt', description: 'quarterly totals' }];
+        const files = [{ data: Buffer.from('x'), name: 'report.txt', description: 'quarterly totals' }];
 
         await senderFor(rest).reply({ components: reply.components, files });
 
         expect(postCall(rest).options.body.data?.attachments).toEqual([
             { id: 0, filename: 'report.txt', description: 'quarterly totals' }
         ]);
-        expect(postCall(rest).options.files).toEqual([{ name: 'report.txt', data: files[0]?.attachment }]);
+        expect(postCall(rest).options.files).toEqual([{ name: 'report.txt', data: files[0]?.data }]);
     });
 });

--- a/packages/types/src/Interfaces/ReplyResponse.ts
+++ b/packages/types/src/Interfaces/ReplyResponse.ts
@@ -28,10 +28,15 @@ interface ReplyAllowedMentions {
 export interface ReplyFile {
     /** The file's bytes. A node `Buffer` assigns here because it extends `Uint8Array`. */
     readonly data: Uint8Array;
-    /** The filename Discord shows, and the name an `attachment://` component reference resolves against. */
+    /**
+     * The filename Discord shows, and the name an `attachment://` component reference resolves against.
+     * Prefix it with `SPOILER_` to blur the attachment until the viewer clicks through.
+     */
     readonly name: string;
     /** Alt text shown to screen readers and on hover. */
     readonly description?: string;
+    /** A display title Discord shows in place of the filename. */
+    readonly title?: string;
 }
 
 /**

--- a/packages/types/src/Interfaces/ReplyResponse.ts
+++ b/packages/types/src/Interfaces/ReplyResponse.ts
@@ -14,24 +14,41 @@ interface ReplyAllowedMentions {
     readonly repliedUser?: boolean;
 }
 
-/** A file as discord.js accepts it in a message's `files` field. */
-interface ReplyFile {
-    readonly attachment: Buffer | string;
-    readonly name?: string;
+/**
+ * Bytes to upload with a reply. A reply attaching only these files sends on either transport.
+ *
+ * @example
+ * ```ts
+ * await this.reply({
+ *     components: [chart],
+ *     files: [{ data: await renderChart(), name: 'chart.png', description: 'Sales by month' }]
+ * });
+ * ```
+ */
+export interface ReplyFile {
+    /** The file's bytes. A node `Buffer` assigns here because it extends `Uint8Array`. */
+    readonly data: Uint8Array;
+    /** The filename Discord shows, and the name an `attachment://` component reference resolves against. */
+    readonly name: string;
+    /** Alt text shown to screen readers and on hover. */
     readonly description?: string;
 }
 
 /**
  * A ComponentsV2 reply. Discord's components-v2 flag forbids `content`, `embeds`, `stickers`, and `poll`,
  * so a reply carries only `components` plus the v2-compatible `allowedMentions` and `files`.
+ *
+ * @typeParam TNative - Extra file forms one transport accepts beyond {@link ReplyFile}. `@seedcord/gateway`
+ * binds the discord.js file forms and exports that as `GatewayReplyResponse`. A reply built from
+ * {@link ReplyFile} alone assigns to either transport.
  */
-export interface ReplyResponse {
+export interface ReplyResponse<TNative = never> {
     /** The component tree the reply renders from. */
     readonly components: V2Component[];
     /** Which mentions written inside the components resolve into real pings. */
     readonly allowedMentions?: ReplyAllowedMentions;
     /** Attachments to upload. Under v2 each must be referenced by a thumbnail, media gallery, or file component, or it uploads hidden. */
-    readonly files?: readonly ReplyFile[];
+    readonly files?: readonly (ReplyFile | TNative)[];
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable file attachments with required filenames and optional titles and descriptions.
  * Gateway replies now support native Discord.js file formats alongside portable files.
  * File attachments are supported consistently for replies, updates, follow-ups, and edits.
  * JSON attachments are encoded as UTF-8 bytes for reliable delivery.

* **Bug Fixes**
  * Improved HTTP attachment serialization, including filenames, metadata, and spoiler names.
  * Preserved attachment metadata during transport conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->