### PR TITLE
feat: create command templates

### DIFF
--- a/.changeset/spotty-baboons-stick.md
+++ b/.changeset/spotty-baboons-stick.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/http': patch
+---
+
+Export other useful packages from http transport like how gateway does

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -30,6 +30,7 @@
     "files": [
         "bin",
         "dist",
+        "templates",
         "package.json",
         "README.md",
         "LICENSE"

--- a/cli/create-seedcord/templates/README.md.hbs
+++ b/cli/create-seedcord/templates/README.md.hbs
@@ -1,0 +1,62 @@
+# {{ projectName }}
+
+A Discord bot built with [seedcord](https://seedcord.org){{#if isGateway}} on the gateway transport{{else}} on the http transport{{/if}}.
+
+## Running it
+
+```sh
+{{ pm.run }} dev
+```
+
+That starts the dev server with hot reload{{#unless isGateway}} and opens a tunnel so Discord can reach your interactions endpoint{{/unless}}.
+
+## Scripts
+
+<!-- prettier-ignore-start -->
+
+| script | what it does |
+| --- | --- |
+| `{{ pm.run }} dev` | dev server with hot reload |
+| `{{ pm.run }} build` | compile to `dist/` |
+| `{{ pm.run }} start` | run the compiled build |
+| `{{ pm.run }} codegen` | regenerate `src/seedcord-gen.d.ts` |
+| `{{ pm.run }} lint` | eslint |
+| `{{ pm.run }} tc` | type-check |
+
+<!-- prettier-ignore-end -->
+
+Run `codegen` after you add a command or change its options. It writes the types behind `this.options`, and the generated file is committed.
+
+## Environment
+
+`.env` holds your secrets and is gitignored.
+
+<!-- prettier-ignore-start -->
+
+| key | required |
+| --- | --- |
+| `DISCORD_BOT_TOKEN` | yes |
+{{#unless isGateway}}
+| `DISCORD_PUBLIC_KEY` | yes |
+{{/unless}}
+| `UNKNOWN_EXCEPTION_WEBHOOK_URL` | no |
+| `HANDLED_EXCEPTION_WEBHOOK_URL` | no |
+| `ENV` | no, defaults to `development` |
+
+<!-- prettier-ignore-end -->
+
+The two webhook keys take Discord webhook URLs. Set them to get error reports posted to a channel.
+
+## Where things go
+
+- `src/commands/` holds command definitions, one class per command.
+- `src/handlers/` holds the code that runs when someone uses one.
+{{#if hasEvents}}
+- `src/events/` holds event handlers for the things you said your bot reacts to.
+{{/if}}
+- `src/bot.ts` is the config.
+
+## Docs
+
+- Guide: <https://guide.seedcord.org>
+- API reference: <https://docs.seedcord.org>

--- a/cli/create-seedcord/templates/env.hbs
+++ b/cli/create-seedcord/templates/env.hbs
@@ -1,0 +1,13 @@
+# Your bot token, from the Bot page of your app in the Discord Developer Portal
+DISCORD_BOT_TOKEN={{ token }}
+{{#unless isGateway}}
+
+# Public key, from the General Information page of the same app
+DISCORD_PUBLIC_KEY={{ publicKey }}
+{{/unless}}
+
+# Discord webhooks the framework posts error reports to. Leave empty to skip reporting.
+UNKNOWN_EXCEPTION_WEBHOOK_URL=
+HANDLED_EXCEPTION_WEBHOOK_URL=
+
+ENV=development

--- a/cli/create-seedcord/templates/eslint.config.mjs.hbs
+++ b/cli/create-seedcord/templates/eslint.config.mjs.hbs
@@ -1,0 +1,8 @@
+import createConfig from '@seedcord/eslint-config';
+
+export default createConfig({
+    tsconfigRootDir: import.meta.dirname,
+    registerDiscordjsPlugin: true,
+    registerSeedcordPlugin: true,
+    generalIgnores: ['**/seedcord-gen.d.ts']
+});

--- a/cli/create-seedcord/templates/gitignore.hbs
+++ b/cli/create-seedcord/templates/gitignore.hbs
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+logs/
+*.log
+*.tsbuildinfo
+.eslintcache
+.seedcord/
+
+.env*
+!.env.example
+
+.DS_Store

--- a/cli/create-seedcord/templates/package.json.hbs
+++ b/cli/create-seedcord/templates/package.json.hbs
@@ -1,0 +1,37 @@
+{
+    "name": "{{ projectName }}",
+    "type": "module",
+    "version": "0.1.0",
+    "private": true,
+    "engines": {
+        "node": ">=24.11"
+    },
+    "scripts": {
+        "dev": "seedcord dev",
+        "build": "seedcord build",
+        "start": "node --enable-source-maps dist/index.mjs",
+        "codegen": "seedcord codegen",
+        "lint": "eslint 'src/**/*.ts' --cache",
+        "lint:fix": "eslint 'src/**/*.ts' --fix --cache",
+        "fmt": "prettier --write 'src/**/*.{ts,json,md}' --cache",
+        "tc": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@discordjs/builders": "{{ versions.builders }}",
+{{#if isGateway}}
+        "@seedcord/gateway": "{{ versions.gateway }}",
+        "discord.js": "{{ versions.discordjs }}",
+{{else}}
+        "@seedcord/http": "{{ versions.http }}",
+{{/if}}
+        "envapt": "{{ versions.envapt }}",
+        "reflect-metadata": "{{ versions.reflectMetadata }}"
+    },
+    "devDependencies": {
+        "@seedcord/eslint-config": "{{ versions.eslintConfig }}",
+        "@seedcord/tsconfig": "{{ versions.tsconfig }}",
+        "prettier": "{{ versions.prettier }}",
+        "seedcord": "{{ versions.cli }}",
+        "typescript": "{{ versions.typescript }}"
+    }
+}

--- a/cli/create-seedcord/templates/prettier.config.mjs.hbs
+++ b/cli/create-seedcord/templates/prettier.config.mjs.hbs
@@ -1,0 +1,3 @@
+import { PRETTIER_CONFIG } from '@seedcord/eslint-config';
+
+export default PRETTIER_CONFIG;

--- a/cli/create-seedcord/templates/prettierignore.hbs
+++ b/cli/create-seedcord/templates/prettierignore.hbs
@@ -1,0 +1,1 @@
+seedcord-gen.d.ts

--- a/cli/create-seedcord/templates/seedcord.config.ts.hbs
+++ b/cli/create-seedcord/templates/seedcord.config.ts.hbs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'seedcord';
+
+export default defineConfig({
+    root: './src',
+    instance: './bot.ts',
+    entry: './index.ts',
+    build: {
+        tsconfig: './tsconfig.build.json'
+    }
+});

--- a/cli/create-seedcord/templates/src/bot.ts.hbs
+++ b/cli/create-seedcord/templates/src/bot.ts.hbs
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+
+import { resolve } from 'node:path';
+
+{{#if isGateway}}
+import { Seedcord } from '@seedcord/gateway';
+import { GatewayIntentBits{{#if partials}}, Partials{{/if}} } from 'discord.js';
+{{else}}
+import { Seedcord } from '@seedcord/http';
+{{/if}}
+import { Envapter } from 'envapt';
+
+Envapter.baseDir = resolve(import.meta.dirname, '..');
+
+export const seedcord = new Seedcord({
+    bot: {
+{{#if isGateway}}
+        clientOptions: {
+            intents: [
+{{#each intents}}
+                GatewayIntentBits.{{ this }}{{#unless @last}},{{/unless}}
+{{/each}}
+            ]{{#if partials}},
+            partials: [{{#each partials}}Partials.{{ this }}{{#unless @last}}, {{/unless}}{{/each}}]{{/if}}
+        },
+{{/if}}
+        interactions: {
+            path: resolve(import.meta.dirname, './handlers')
+        },
+        commands: {
+            path: resolve(import.meta.dirname, './commands')
+        }{{#if isGateway}},
+        events: {
+{{#if hasEvents}}
+            path: resolve(import.meta.dirname, './events')
+{{else}}
+            path: null
+{{/if}}
+        }{{/if}}
+    },
+    subscribers: {
+        path: null
+    },
+    botColor: '{{ botColor }}',
+    notifications: {
+        developerUsername: '{{ developerUsername }}'
+    }
+});
+
+export default seedcord;

--- a/cli/create-seedcord/templates/src/commands/Ping.ts.hbs
+++ b/cli/create-seedcord/templates/src/commands/Ping.ts.hbs
@@ -1,0 +1,13 @@
+import { BuilderComponent, RegisterCommand } from '{{ transportPackage }}';
+
+@RegisterCommand('global')
+export class Ping extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+
+        this.instance
+            .setName('ping')
+            .setDescription('Check that the bot is answering')
+            .addBooleanOption((option) => option.setName('detailed').setDescription('Include process uptime'));
+    }
+}

--- a/cli/create-seedcord/templates/src/handlers/Ping.ts.hbs
+++ b/cli/create-seedcord/templates/src/handlers/Ping.ts.hbs
@@ -1,0 +1,15 @@
+import { SlashHandler, SlashRoute, timestampFromSnowflake } from '{{ transportPackage }}';
+
+@SlashRoute('ping')
+export class Ping extends SlashHandler<'ping'> {
+    public async execute(): Promise<void> {
+        const roundtrip = Date.now() - timestampFromSnowflake(this.event.id);
+        const lines = ['### Pong', `Roundtrip **${roundtrip}ms**`];
+
+        if (this.options.getBoolean('detailed')) {
+            lines.push(`Uptime **${Math.round(process.uptime())}s**`);
+        }
+
+        await this.reply(lines.join('\n'));
+    }
+}

--- a/cli/create-seedcord/templates/src/index.ts.hbs
+++ b/cli/create-seedcord/templates/src/index.ts.hbs
@@ -1,0 +1,3 @@
+import seedcord from './bot';
+
+await seedcord.start();

--- a/cli/create-seedcord/templates/tsconfig.build.json.hbs
+++ b/cli/create-seedcord/templates/tsconfig.build.json.hbs
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "noEmit": false
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/cli/create-seedcord/templates/tsconfig.json.hbs
+++ b/cli/create-seedcord/templates/tsconfig.json.hbs
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "@seedcord/tsconfig/node",
+    "compilerOptions": {
+        "rootDir": "./",
+        "outDir": "./dist"
+    },
+    "include": ["src/**/*.ts", "seedcord.config.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/mocks/gateway/src/commands/Ping.ts
+++ b/mocks/gateway/src/commands/Ping.ts
@@ -1,4 +1,4 @@
-import { BuilderComponent, RegisterCommand } from '@seedcord/http';
+import { BuilderComponent, RegisterCommand } from '@seedcord/gateway';
 
 @RegisterCommand('global')
 export class Ping extends BuilderComponent<'command'> {

--- a/mocks/gateway/src/handlers/Ping.ts
+++ b/mocks/gateway/src/handlers/Ping.ts
@@ -1,4 +1,4 @@
-import { SlashHandler, SlashRoute, timestampFromSnowflake } from '@seedcord/http';
+import { SlashHandler, SlashRoute, timestampFromSnowflake } from '@seedcord/gateway';
 
 @SlashRoute('ping')
 export class Ping extends SlashHandler<'ping'> {

--- a/mocks/gateway/src/seedcord-gen.d.ts
+++ b/mocks/gateway/src/seedcord-gen.d.ts
@@ -13,6 +13,7 @@ declare module '@seedcord/gateway' {
         feed: {};
         leaderboard: {};
         maintenance: { notify: { kind: 'user'; required: true }; target: { kind: 'channel'; required: true; channelTypes: [0, 5] }; reason: { kind: 'string'; required: false } };
+        ping: { detailed: { kind: 'boolean'; required: false } };
         probe: { query: { kind: 'string'; required: true; autocomplete: true }; count: { kind: 'integer'; required: false; autocomplete: true }; ratio: { kind: 'number'; required: false; autocomplete: true }; category: { kind: 'string'; required: false; choices: ['books', 'films'] }; exact: { kind: 'boolean'; required: false } };
         roster: {};
         'test/confirmable/v2': {};

--- a/mocks/http/src/seedcord-gen.d.ts
+++ b/mocks/http/src/seedcord-gen.d.ts
@@ -4,7 +4,7 @@
 // prettier-ignore
 declare module '@seedcord/http' {
     interface SlashOptionRegistry {
-        ping: { note: { kind: 'string'; required: true } };
+        ping: { detailed: { kind: 'boolean'; required: false } };
     }
     interface UserContextMenuRegistry {
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -67,6 +67,7 @@
         "@discordjs/rest": "catalog:deps",
         "@seedcord/core": "workspace:*",
         "@seedcord/errors": "workspace:*",
+        "@seedcord/event-emitter": "workspace:*",
         "@seedcord/logger": "workspace:*",
         "@seedcord/rate-limiter": "workspace:*",
         "@seedcord/types": "workspace:*",

--- a/packages/http/src/edge.index.ts
+++ b/packages/http/src/edge.index.ts
@@ -15,7 +15,12 @@ export { Emojis } from '@src/emojis/EmojiInjector';
 export type { InjectedEmojiMap, ResolvedEmoji } from '@src/emojis/EmojiInjector';
 
 export * from '@seedcord/core';
+export * from '@seedcord/errors';
+export * from '@seedcord/event-emitter';
+export * from '@seedcord/logger';
+export * from '@seedcord/rate-limiter';
 export type * from '@seedcord/types';
+export * from '@seedcord/utils';
 
 export * from './handlers';
 // two `export *` both re-export RepliableHandler, so export it explicitly to resolve to the http subclass

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,7 +454,7 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: ^4.118.0
-        version: 4.118.0(@types/node@25.9.3)
+        version: 4.118.0(@types/node@26.1.2)
 
   cli/create-seedcord:
     devDependencies:
@@ -918,6 +918,9 @@ importers:
       '@seedcord/errors':
         specifier: workspace:*
         version: link:../errors
+      '@seedcord/event-emitter':
+        specifier: workspace:*
+        version: link:../event-emitter
       '@seedcord/logger':
         specifier: workspace:*
         version: link:../logger
@@ -11885,7 +11888,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -14854,19 +14857,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  miniflare@5.20260730.0-alpha(@types/node@25.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.3(@types/node@25.9.3)
-      undici: 7.29.0
-      workerd: 1.20260730.1
-      ws: 8.21.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
   miniflare@5.20260730.0-alpha(@types/node@26.1.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -15721,39 +15711,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
-
-  sharp@0.35.3(@types/node@25.9.3):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.9.3
 
   sharp@0.35.3(@types/node@26.1.2):
     dependencies:
@@ -16766,23 +16723,6 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20260730.1
       '@cloudflare/workerd-linux-arm64': 1.20260730.1
       '@cloudflare/workerd-windows-64': 1.20260730.1
-
-  wrangler@4.118.0(@types/node@25.9.3):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.1
-      miniflare: 5.20260730.0-alpha(@types/node@25.9.3)
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260730.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
 
   wrangler@4.118.0(@types/node@26.1.2):
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project creation now generates complete starter projects for gateway or HTTP transport.
  - Generated projects include bot setup, configuration, environment variables, build scripts, linting, formatting, and ignore files.
  - Added starter Ping command with latency reporting and optional process uptime details.
  - Expanded public HTTP transport exports.

- **Documentation**
  - Generated projects now include a README with setup instructions, development guidance, environment variables, and links to Seedcord documentation.

- **Improvements**
  - Updated example Ping commands to use an optional `detailed` setting instead of a required note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->