### PR TITLE
feat: the `pnpm create seedcord` command

### DIFF
--- a/.changeset/crisp-games-count.md
+++ b/.changeset/crisp-games-count.md
@@ -1,0 +1,5 @@
+---
+'seedcord': patch
+---
+
+Fix cli bin missing shebang so npm works correctly

--- a/.changeset/fifty-moons-grab.md
+++ b/.changeset/fifty-moons-grab.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/errors': patch
+'@seedcord/logger': patch
+---
+
+Moved `paint` to the errors package

--- a/.changeset/loud-news-decide.md
+++ b/.changeset/loud-news-decide.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/errors': patch
+---
+
+New error codes for the create command

--- a/.changeset/plain-ducks-listen.md
+++ b/.changeset/plain-ducks-listen.md
@@ -1,0 +1,5 @@
+---
+'create-seedcord': minor
+---
+
+Scaffold a new bot with `pnpm create seedcord`.

--- a/.github/skills/code-commenting-guidelines/SKILL.md
+++ b/.github/skills/code-commenting-guidelines/SKILL.md
@@ -78,7 +78,7 @@ Four things. Everything outside this list is a code fix.
 
 **Where an authored number came from.** Any timeout, retry count, threshold, or buffer size someone picked. The constant name says what it is. The comment says why that value and what happens at a different one.
 
-**A workaround.** A bug in a dependency, a language trap, a limit of the type system. Say what breaks without it, so the next person does not clean it up and re-break the build.
+**A workaround.** A bug in a dependency, a language trap, a limit of the type system. Say what breaks without it. The next person needs that to leave it alone.
 
 **An invariant set up somewhere else.** "Sorted by `createdAt` before this point" when the sort happens in a different file. Anything the reader would have to open another file to know.
 
@@ -170,7 +170,7 @@ Add a consequence only when a reader would misread the code without it. Usually 
 
 ```ts
 // drafted
-// zero packs to one char, so an empty block means the body was truncated
+// zero packs to one char, which means an empty block is a truncated body
 
 // cut at the connective, still works, ship this one
 // an empty block means the body was truncated

--- a/.github/skills/writing-voice/SKILL.md
+++ b/.github/skills/writing-voice/SKILL.md
@@ -15,7 +15,7 @@ This covers everything a human reads. A field description, a `//` comment, a com
 
 This is the rule that matters most and the one that gets broken most.
 
-An abstract phrase is shorter than the plain sentence it replaces, so any rule that rewards brevity will pull you toward abstraction. Resist it. **Cut whole ideas. Keep common words.**
+An abstract phrase is shorter than the plain sentence it replaces. Any rule that rewards brevity will pull you toward abstraction. Resist it. **Cut whole ideas. Keep common words.**
 
 A sentence improves when you drop a point the reader did not need. A sentence gets worse when you compress a point into a technical-sounding noun phrase. The second one looks like editing and is the opposite of it.
 
@@ -50,7 +50,7 @@ Those ten are examples of one move, and checking against them catches nothing. A
 
 **Did you borrow it as a picture?** A word carried in from maths, physics, war, or biology to stand for what you mean is a picture, and the reader has to unpack it to get back to the thing. Name the thing.
 
-No list will cover this, so apply the test to every phrase. The question is whether the word already meant this here before you wrote the sentence. Debounce, backoff, snowflake, gateway, and shard pass, because they are the real names of real things in this codebase. A word you reached past the domain for does not.
+No list will cover this. Apply the test to every phrase. The question is whether the word already meant this here before you wrote the sentence. Debounce, backoff, snowflake, gateway, and shard pass, because they are the real names of real things in this codebase. A word you reached past the domain for does not.
 
 ---
 
@@ -116,7 +116,7 @@ The standing swaps:
 
 ### A company is an actor
 
-Discord, Cloudflare, and a browser vendor are people and servers, so they do act. "Discord rejects a hostname it already rejected" is correct and precise. "The parser wants a trailing newline" is the banned thing. The line falls between an organization that made a choice and a function that executes one.
+Discord, Cloudflare, and a browser vendor are people and servers. They do act. "Discord rejects a hostname it already rejected" is correct and precise. "The parser wants a trailing newline" is the banned thing. The line falls between an organization that made a choice and a function that executes one.
 
 > "I have now seen programs 'trying to do things', 'wanting to do things', 'believing things to be true', 'knowing things' etc. Don't be so naive as to believe that this use of language is harmless." Dijkstra, EWD854.
 
@@ -154,7 +154,7 @@ Rule of thumb: if an adjective cannot be replaced by a measurable fact or a code
 
 Em-dash `—` and en-dash `–` are banned in prose. Use a comma, parentheses, a hyphen, or two sentences.
 
-Colon `:` and semicolon `;` are banned as a clause splice, where the mark joins two complete clauses into one sentence. A colon introducing a list, a code block, or a short label is standard, so keep it.
+Colon `:` and semicolon `;` are banned as a clause splice, where the mark joins two complete clauses into one sentence. A colon introducing a list, a code block, or a short label is standard. Keep it.
 
 Comma splices are banned. A comma cannot join two complete clauses. Every comma carries a connector after it, separates list items, or becomes a period.
 
@@ -163,7 +163,7 @@ Comma splices are banned. A comma cannot join two complete clauses. Every comma 
 **Fix a splice by rewriting it shorter, in this order.**
 
 1. **Collapse to one clause.** Most splices are one fact stretched over two. This is almost always the best result and the one to try first.
-2. **Add the connector that names the real relation** (`because`, `since`, `and`, `then`, `so`). Keeps one sentence when both halves genuinely earn their place.
+2. **Add the connector that names the real relation** (`because`, `since`, `and`, `then`). Keeps one sentence when both halves genuinely earn their place.
 3. **Two sentences.** The fallback when the halves are independent facts that both matter.
 
 Going to a period first produces two stubby sentences carrying what one short line said better.
@@ -179,17 +179,17 @@ Going to a period first produces two stubby sentences carrying what one short li
 // Bad: two facts jammed with a comma
 // the cache is keyed by file, a rename lands as a fresh entry
 // Good (2): the connector names the relation
-// the cache is keyed by file, so a rename lands as a fresh entry
+// a rename lands as a fresh entry because the cache is keyed by file
 ```
 
 **Replace a banned mark with punctuation that does the same job.** A `;` or `—` between two complete clauses is holding two thoughts apart, and a bare comma cannot do that. Use a period.
 
-**Do not default to ", so".** A semicolon often sets two related facts side by side, and ", so" claims a cause the original never made. Use it only when the second clause genuinely results from the first. Otherwise pick the connector that fits, `because` or `since` for a reason, `, and` for a neutral join, or a period when there is no relation at all.
+**A connector that claims a cause has to earn it.** Reaching for one to hold a second clause on is how a sentence grows a consequence the reader was about to read anyway. Name the reason for the first clause with `because` or `since`, join two facts with `and`, or end the sentence.
 
-- BAD, invented cause: "meaningless without a filesystem, so it throws".
-- GOOD: "it throws because it's meaningless without a filesystem".
-- BAD, stacked: "binds a source per file, so restore it after any swap so later tests see a clean default".
-- GOOD: "binds a source per file. Tests here swap it, so restore it afterward for a clean default."
+- BAD, invented cause: "it is meaningless without a filesystem and it throws".
+- GOOD: "it throws because it is meaningless without a filesystem".
+- BAD, stacked: "binds a source per file and restore it after any swap and later tests see a clean default".
+- GOOD: "binds a source per file. Tests here swap it, then restore it for a clean default."
 
 ### Contrast
 

--- a/.github/skills/writing-voice/SKILL.md
+++ b/.github/skills/writing-voice/SKILL.md
@@ -74,6 +74,21 @@ Scan a draft for words ending in `-tion`, `-ment`, `-ance`, and `-ility`. Most o
 
 Cut "there is" and "there are" openers. Start with the subject or the verb.
 
+### Lead with who does what
+
+The other way a verb goes missing is a split sentence, where one clause becomes two and the real verb sits behind an `is`. It feels like emphasis while you write it. It costs the reader a whole clause to unpack. Don't write cleft sentences, basically.
+
+<!--prettier-ignore-start-->
+
+| Split | Direct |
+|---|---|
+| an empty target is what lets the cleanup work | scaffold deletes the directory when a step fails |
+| what this does is reset the cache | this resets the cache |
+| it is the config that sets the port | the config sets the port |
+| the reason it fails is the missing shebang | it fails because the shebang is missing |
+
+<!--prettier-ignore-end-->
+
 ---
 
 ## 3. Anthropomorphism, with a test you can apply

--- a/cli/create-seedcord/README.md
+++ b/cli/create-seedcord/README.md
@@ -15,7 +15,6 @@ Scaffold a new seedcord bot project.
 pnpm create seedcord my-bot
 npm create seedcord my-bot
 yarn create seedcord my-bot
-bun create seedcord my-bot // currently doesn't work because bun doesn't support legacy decorators
 ```
 
 It asks where the project goes, how Discord reaches your bot, what the bot should react to, your bot token, and an accent color. Then it writes the project, installs, formats, generates your command types, and makes the first commit.

--- a/cli/create-seedcord/README.md
+++ b/cli/create-seedcord/README.md
@@ -5,8 +5,45 @@
   </picture>
 </p>
 
-# @seedcord/create-seedcord
+# create-seedcord
 
-Scaffold a new seedcord bot project
+Scaffold a new seedcord bot project.
+
+## Usage
+
+```sh
+pnpm create seedcord my-bot
+npm create seedcord my-bot
+yarn create seedcord my-bot
+bun create seedcord my-bot // currently doesn't work because bun doesn't support legacy decorators
+```
+
+It asks where the project goes, how Discord reaches your bot, what the bot should react to, your bot token, and an accent color. Then it writes the project, installs, formats, generates your command types, and makes the first commit.
+
+## Flags
+
+Every question has a flag. Pass them all to skip all questions. `--help` prints the list.
+
+npm forwards flags to the package only after a `--`:
+
+```sh
+npm create seedcord my-bot -- --transport gateway --capabilities reactions
+pnpm create seedcord my-bot --transport gateway --capabilities reactions
+```
+
+`--no-install` and `--no-git` turn off those two steps.
+
+With no terminal to ask on, it reads the flags alone. It names the flag that would supply any answer you left out.
+
+## What you get
+
+You get a TypeScript project with one slash command, its handler, a sample event handler (if you picked `gateway`), `seedcord.config.ts`, eslint, prettier, and a `.env` listing every key the framework reads.
+
+`pnpm dev` starts it with hot reload. On the http transport it also opens a cloudflared tunnel and sets it up, and Discord posts interactions to that URL.
+
+## Docs
+
+- Guide: <https://guide.seedcord.org>
+- API reference: <https://docs.seedcord.org>
 
 Part of the [seedcord](https://github.com/seedcord/seedcord) framework. Until a major v1.0.0 release, expect breaking changes in minor versions.

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -46,7 +46,6 @@
         "@seedcord/tsdown-config": "workspace:*",
         "@seedcord/types": "workspace:*",
         "@seedcord/vitest-config": "workspace:*",
-        "chalk": "catalog:deps",
         "discord.js": "catalog:peer",
         "handlebars": "^4.7.9",
         "package-manager-detector": "^1.8.0",

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -40,6 +40,7 @@
     },
     "devDependencies": {
         "@clack/prompts": "catalog:deps",
+        "@seedcord/errors": "workspace:*",
         "@seedcord/eslint-config": "workspace:*",
         "@seedcord/tsconfig": "workspace:*",
         "@seedcord/tsdown-config": "workspace:*",

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -46,7 +46,7 @@
         "@seedcord/tsdown-config": "workspace:*",
         "@seedcord/types": "workspace:*",
         "@seedcord/vitest-config": "workspace:*",
-        "chalk": "^6.0.0",
+        "chalk": "catalog:deps",
         "discord.js": "catalog:peer",
         "handlebars": "^4.7.9",
         "package-manager-detector": "^1.8.0",

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -39,6 +39,8 @@
         "coverage": "vitest run --coverage"
     },
     "devDependencies": {
+        "@clack/prompts": "catalog:deps",
+        "@seedcord/errors": "workspace:*",
         "@seedcord/eslint-config": "workspace:*",
         "@seedcord/tsconfig": "workspace:*",
         "@seedcord/tsdown-config": "workspace:*",
@@ -51,8 +53,5 @@
     "publishConfig": {
         "access": "public",
         "provenance": true
-    },
-    "dependencies": {
-        "@clack/prompts": "catalog:deps"
     }
 }

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -47,6 +47,7 @@
         "@seedcord/types": "workspace:*",
         "@seedcord/vitest-config": "workspace:*",
         "discord.js": "catalog:peer",
+        "handlebars": "^4.7.9",
         "tsx": "catalog:deps",
         "typescript": "catalog:peer"
     },

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -40,7 +40,6 @@
     },
     "devDependencies": {
         "@clack/prompts": "catalog:deps",
-        "@seedcord/errors": "workspace:*",
         "@seedcord/eslint-config": "workspace:*",
         "@seedcord/tsconfig": "workspace:*",
         "@seedcord/tsdown-config": "workspace:*",

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -48,6 +48,7 @@
         "@seedcord/vitest-config": "workspace:*",
         "discord.js": "catalog:peer",
         "handlebars": "^4.7.9",
+        "package-manager-detector": "^1.8.0",
         "tsx": "catalog:deps",
         "typescript": "catalog:peer"
     },

--- a/cli/create-seedcord/package.json
+++ b/cli/create-seedcord/package.json
@@ -46,6 +46,7 @@
         "@seedcord/tsdown-config": "workspace:*",
         "@seedcord/types": "workspace:*",
         "@seedcord/vitest-config": "workspace:*",
+        "chalk": "^6.0.0",
         "discord.js": "catalog:peer",
         "handlebars": "^4.7.9",
         "package-manager-detector": "^1.8.0",

--- a/cli/create-seedcord/src/cli/banner.ts
+++ b/cli/create-seedcord/src/cli/banner.ts
@@ -1,13 +1,8 @@
-import chalk from 'chalk';
-
-// the dev CLI paints the wordmark in these two
-const SEED = '#f04e36';
-const CORD = '#6fab49';
-const VERSION = '#f7f5e8';
+import { paint } from '@seedcord/errors/internal';
 
 export function banner(version = process.env.PACKAGE_VERSION): string {
-    const wordmark = `${chalk.hex(SEED).bold('seed')}${chalk.hex(CORD).bold('cord')}`;
+    const wordmark = `${paint.flesh.bold('seed')}${paint.rind.bold('cord')}`;
     if (version === undefined) return wordmark;
 
-    return `${wordmark}${chalk.hex(VERSION)(` • v${version}`)}`;
+    return `${wordmark}${paint.pith(` • v${version}`)}`;
 }

--- a/cli/create-seedcord/src/cli/banner.ts
+++ b/cli/create-seedcord/src/cli/banner.ts
@@ -1,0 +1,13 @@
+import chalk from 'chalk';
+
+// the dev CLI paints the wordmark in these two
+const SEED = '#f04e36';
+const CORD = '#6fab49';
+const VERSION = '#f7f5e8';
+
+export function banner(version = process.env.PACKAGE_VERSION): string {
+    const wordmark = `${chalk.hex(SEED).bold('seed')}${chalk.hex(CORD).bold('cord')}`;
+    if (version === undefined) return wordmark;
+
+    return `${wordmark}${chalk.hex(VERSION)(` • v${version}`)}`;
+}

--- a/cli/create-seedcord/src/cli/help.ts
+++ b/cli/create-seedcord/src/cli/help.ts
@@ -1,4 +1,4 @@
-import { STEPS } from '../interview/steps';
+import { STEPS } from '@interview/steps';
 
 const EXTRA = [
     { name: 'no-install', description: 'skip installing dependencies' },

--- a/cli/create-seedcord/src/cli/help.ts
+++ b/cli/create-seedcord/src/cli/help.ts
@@ -1,0 +1,23 @@
+import { STEPS } from '../interview/steps';
+
+const EXTRA = [
+    { name: 'no-install', description: 'skip installing dependencies' },
+    { name: 'no-git', description: 'skip git init and the first commit' },
+    { name: 'help', description: 'print this' }
+];
+
+export function helpText(): string {
+    const flags = [...STEPS.map((step) => step.flag), ...EXTRA];
+    const width = Math.max(...flags.map((flag) => flag.name.length));
+    const lines = flags.map((flag) => `  --${flag.name.padEnd(width)}  ${flag.description}`);
+
+    return [
+        'Usage: create-seedcord [directory] [flags]',
+        '',
+        'Every question the interview asks has a flag. Pass them all to skip the interview.',
+        '',
+        ...lines,
+        '',
+        'npm needs a -- before the flags: npm create seedcord my-bot -- --transport gateway'
+    ].join('\n');
+}

--- a/cli/create-seedcord/src/cli/invite.ts
+++ b/cli/create-seedcord/src/cli/invite.ts
@@ -1,0 +1,14 @@
+const AUTHORIZE = 'https://discord.com/oauth2/authorize';
+const SNOWFLAKE = /^\d{17,20}$/;
+
+// the first token part is the application id in base64
+export function inviteUrl(token: string): string | null {
+    const [encoded] = token.split('.');
+    if (encoded === undefined || encoded === '') return null;
+
+    const applicationId = Buffer.from(encoded, 'base64').toString('utf8');
+    if (!SNOWFLAKE.test(applicationId)) return null;
+
+    // Discord reads the scopes and permissions off the app's Installation tab
+    return `${AUTHORIZE}?client_id=${applicationId}`;
+}

--- a/cli/create-seedcord/src/cli/packageManager.ts
+++ b/cli/create-seedcord/src/cli/packageManager.ts
@@ -1,0 +1,26 @@
+import { resolveCommand } from 'package-manager-detector/commands';
+import { getUserAgent } from 'package-manager-detector/detect';
+
+import type { AgentName, ResolvedCommand } from 'package-manager-detector';
+
+// pnpm below 6.30 and bun before mid-2024 set no user agent
+const FALLBACK: AgentName = 'npm';
+
+// resolveCommand answers per script, and the README needs the part in front of one
+const PROBE_SCRIPT = 'dev';
+
+export function runningAgent(): AgentName {
+    return getUserAgent() ?? FALLBACK;
+}
+
+export function runPrefix(agent: AgentName): string {
+    const resolved = resolveCommand(agent, 'run', [PROBE_SCRIPT]);
+    if (!resolved) return `${agent} run`;
+
+    return [resolved.command, ...resolved.args.slice(0, -1)].join(' ');
+}
+
+export function addCommand(agent: AgentName, packages: string[], dev: boolean): ResolvedCommand {
+    const args = dev ? ['-D', ...packages] : packages;
+    return resolveCommand(agent, 'add', args) ?? { command: agent, args: ['add', ...args] };
+}

--- a/cli/create-seedcord/src/cli/packageManager.ts
+++ b/cli/create-seedcord/src/cli/packageManager.ts
@@ -24,3 +24,7 @@ export function addCommand(agent: AgentName, packages: string[], dev: boolean): 
     const args = dev ? ['-D', ...packages] : packages;
     return resolveCommand(agent, 'add', args) ?? { command: agent, args: ['add', ...args] };
 }
+
+export function execCommand(agent: AgentName, args: string[]): ResolvedCommand {
+    return resolveCommand(agent, 'execute-local', args) ?? { command: agent, args: ['exec', ...args] };
+}

--- a/cli/create-seedcord/src/cli/parseInput.ts
+++ b/cli/create-seedcord/src/cli/parseInput.ts
@@ -3,10 +3,10 @@ import { parseArgs } from 'node:util';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
-import { applyFlags } from '../interview/applyFlags';
-import { STEPS } from '../interview/steps';
+import { applyFlags } from '@interview/applyFlags';
+import { STEPS } from '@interview/steps';
 
-import type { Answers } from '../interview/types';
+import type { Answers } from '@interview/types';
 
 export interface CliInput {
     supplied: Partial<Answers>;

--- a/cli/create-seedcord/src/cli/parseInput.ts
+++ b/cli/create-seedcord/src/cli/parseInput.ts
@@ -1,0 +1,67 @@
+import { parseArgs } from 'node:util';
+
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
+import { applyFlags } from '../interview/applyFlags';
+import { STEPS } from '../interview/steps';
+
+import type { Answers } from '../interview/types';
+
+export interface CliInput {
+    supplied: Partial<Answers>;
+    install: boolean;
+    git: boolean;
+    help: boolean;
+}
+
+const OPTIONS = {
+    ...Object.fromEntries(STEPS.map((step) => [step.flag.name, { type: 'string' }] as const)),
+    'no-install': { type: 'boolean' },
+    'no-git': { type: 'boolean' },
+    help: { type: 'boolean', short: 'h' }
+} as const;
+
+function readArgv(argv: string[]): { values: Record<string, unknown>; positionals: string[] } {
+    try {
+        return parseArgs({ args: argv, options: OPTIONS, allowPositionals: true, strict: true });
+    } catch (error) {
+        throw new SeedcordError(SeedcordErrorCode.CreateBadUsage, [
+            Error.isError(error) ? error.message : 'Could not read the command line.'
+        ]);
+    }
+}
+
+function directoryFrom(positionals: string[], flagged: unknown): string | undefined {
+    if (positionals.length > 1) {
+        throw new SeedcordError(SeedcordErrorCode.CreateBadUsage, ['Pass one directory at most.']);
+    }
+
+    const [bare] = positionals;
+    if (bare !== undefined && typeof flagged === 'string' && flagged !== bare) {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'dir',
+            'The directory was given twice. Pass it as an argument or as a flag.'
+        ]);
+    }
+
+    return typeof flagged === 'string' ? flagged : bare;
+}
+
+export function parseInput(argv: string[]): CliInput {
+    const { values, positionals } = readArgv(argv);
+    const directory = directoryFrom(positionals, values.dir);
+
+    const raw = Object.fromEntries(
+        Object.entries({ ...values, dir: directory }).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string'
+        )
+    );
+
+    return {
+        supplied: applyFlags(STEPS, raw),
+        install: values['no-install'] !== true,
+        git: values['no-git'] !== true,
+        help: values.help === true
+    };
+}

--- a/cli/create-seedcord/src/cli/parseInput.ts
+++ b/cli/create-seedcord/src/cli/parseInput.ts
@@ -12,15 +12,20 @@ export interface CliInput {
     supplied: Partial<Answers>;
     install: boolean;
     git: boolean;
-    help: boolean;
 }
 
 const OPTIONS = {
     ...Object.fromEntries(STEPS.map((step) => [step.flag.name, { type: 'string' }] as const)),
     'no-install': { type: 'boolean' },
-    'no-git': { type: 'boolean' },
-    help: { type: 'boolean', short: 'h' }
+    'no-git': { type: 'boolean' }
 } as const;
+
+const HELP_FLAGS = new Set(['--help', '-h']);
+
+// parseArgs throws on a bad flag before it ever reads --help
+export function wantsHelp(argv: string[]): boolean {
+    return argv.some((argument) => HELP_FLAGS.has(argument));
+}
 
 function readArgv(argv: string[]): { values: Record<string, unknown>; positionals: string[] } {
     try {
@@ -61,7 +66,6 @@ export function parseInput(argv: string[]): CliInput {
     return {
         supplied: applyFlags(STEPS, raw),
         install: values['no-install'] !== true,
-        git: values['no-git'] !== true,
-        help: values.help === true
+        git: values['no-git'] !== true
     };
 }

--- a/cli/create-seedcord/src/cli/reportFailure.ts
+++ b/cli/create-seedcord/src/cli/reportFailure.ts
@@ -2,15 +2,16 @@ import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 
 export interface Failure {
     code: number;
-    message: string | null;
+    cancelled: boolean;
+    message: string;
 }
 
 // nothing reaches disk until the interview ends
-const CANCELLED: Failure = { code: 0, message: null };
+const CANCELLED: Failure = { code: 0, cancelled: true, message: 'Nothing was written.' };
 
 export function reportFailure(error: unknown): Failure {
     if (isSeedcordError(error, undefined, SeedcordErrorCode.CreateCancelled)) return CANCELLED;
-    if (isSeedcordError(error) || Error.isError(error)) return { code: 1, message: error.message };
 
-    return { code: 1, message: String(error) };
+    const message = isSeedcordError(error) || Error.isError(error) ? error.message : String(error);
+    return { code: 1, cancelled: false, message };
 }

--- a/cli/create-seedcord/src/cli/reportFailure.ts
+++ b/cli/create-seedcord/src/cli/reportFailure.ts
@@ -2,16 +2,19 @@ import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 
 export interface Failure {
     code: number;
-    cancelled: boolean;
-    message: string;
+    message: string | null;
+    closing: string;
 }
 
 // nothing reaches disk until the interview ends
-const CANCELLED: Failure = { code: 0, cancelled: true, message: 'Nothing was written.' };
+const CANCELLED: Failure = { code: 0, message: null, closing: 'Nothing was written.' };
 
 export function reportFailure(error: unknown): Failure {
     if (isSeedcordError(error, undefined, SeedcordErrorCode.CreateCancelled)) return CANCELLED;
 
+    // scaffold removes the tree it wrote before a step failure gets here
+    const removed = isSeedcordError(error, undefined, SeedcordErrorCode.CreateStepFailed);
     const message = isSeedcordError(error) || Error.isError(error) ? error.message : String(error);
-    return { code: 1, cancelled: false, message };
+
+    return { code: 1, message, closing: removed ? 'Nothing was kept.' : 'Nothing was created.' };
 }

--- a/cli/create-seedcord/src/cli/reportFailure.ts
+++ b/cli/create-seedcord/src/cli/reportFailure.ts
@@ -1,0 +1,16 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+
+export interface Failure {
+    code: number;
+    message: string | null;
+}
+
+// nothing reaches disk until the interview ends
+const CANCELLED: Failure = { code: 0, message: null };
+
+export function reportFailure(error: unknown): Failure {
+    if (isSeedcordError(error, undefined, SeedcordErrorCode.CreateCancelled)) return CANCELLED;
+    if (isSeedcordError(error) || Error.isError(error)) return { code: 1, message: error.message };
+
+    return { code: 1, message: String(error) };
+}

--- a/cli/create-seedcord/src/cli/steps.ts
+++ b/cli/create-seedcord/src/cli/steps.ts
@@ -5,13 +5,10 @@ import { S_STEP_SUBMIT, log, spinner } from '@clack/prompts';
 export interface StepLabels {
     running: string;
     done: string;
-    stream?: boolean;
 }
 
-export type StepLogger = (line: string) => void;
-
 export interface StepUi {
-    run: <Ret>(labels: StepLabels, work: (onLine: StepLogger) => Promise<Ret>) => Promise<Ret>;
+    run: <Ret>(labels: StepLabels, work: () => Promise<Ret>) => Promise<Ret>;
     skip: (label: string) => void;
 }
 
@@ -21,15 +18,8 @@ export function clackSteps(): StepUi {
             const spin = spinner();
             spin.start(labels.running);
 
-            const onLine: StepLogger =
-                labels.stream === true
-                    ? (line) => {
-                          spin.message(`${labels.running}  ${styleText('dim', line)}`);
-                      }
-                    : () => undefined;
-
             try {
-                const result = await work(onLine);
+                const result = await work();
                 spin.stop(labels.done);
                 return result;
             } catch (error) {
@@ -47,7 +37,7 @@ export function clackSteps(): StepUi {
 
 export function silentSteps(): StepUi {
     return {
-        run: async (_labels, work) => work(() => undefined),
+        run: async (_labels, work) => work(),
         skip: () => undefined
     };
 }

--- a/cli/create-seedcord/src/cli/steps.ts
+++ b/cli/create-seedcord/src/cli/steps.ts
@@ -1,5 +1,5 @@
 import { S_STEP_SUBMIT, log, spinner } from '@clack/prompts';
-import chalk from 'chalk';
+import { paint } from '@seedcord/errors/internal';
 
 interface StepLabels {
     running: string;
@@ -28,7 +28,7 @@ export function clackSteps(): StepUi {
             }
         },
         skip: (label) => {
-            log.message(chalk.gray(`${label} (skipped)`), { symbol: chalk.gray(S_STEP_SUBMIT) });
+            log.message(paint.mute(`${label} (skipped)`), { symbol: paint.mute(S_STEP_SUBMIT) });
         }
     };
 }

--- a/cli/create-seedcord/src/cli/steps.ts
+++ b/cli/create-seedcord/src/cli/steps.ts
@@ -1,7 +1,7 @@
 import { S_STEP_SUBMIT, log, spinner } from '@clack/prompts';
 import chalk from 'chalk';
 
-export interface StepLabels {
+interface StepLabels {
     running: string;
     done: string;
 }
@@ -14,7 +14,8 @@ export interface StepUi {
 export function clackSteps(): StepUi {
     return {
         run: async (labels, work) => {
-            const spin = spinner();
+            // clack fixes the indicator at construction
+            const spin = spinner({ indicator: 'timer' });
             spin.start(labels.running);
 
             try {
@@ -22,7 +23,7 @@ export function clackSteps(): StepUi {
                 spin.stop(labels.done);
                 return result;
             } catch (error) {
-                spin.error(labels.running);
+                spin.error(`${labels.running} failed`);
                 throw error;
             }
         },

--- a/cli/create-seedcord/src/cli/steps.ts
+++ b/cli/create-seedcord/src/cli/steps.ts
@@ -1,6 +1,5 @@
-import { styleText } from 'node:util';
-
 import { S_STEP_SUBMIT, log, spinner } from '@clack/prompts';
+import chalk from 'chalk';
 
 export interface StepLabels {
     running: string;
@@ -28,9 +27,7 @@ export function clackSteps(): StepUi {
             }
         },
         skip: (label) => {
-            log.message(styleText('gray', `${label} (skipped)`), {
-                symbol: styleText('gray', S_STEP_SUBMIT)
-            });
+            log.message(chalk.gray(`${label} (skipped)`), { symbol: chalk.gray(S_STEP_SUBMIT) });
         }
     };
 }

--- a/cli/create-seedcord/src/cli/steps.ts
+++ b/cli/create-seedcord/src/cli/steps.ts
@@ -1,0 +1,53 @@
+import { styleText } from 'node:util';
+
+import { S_STEP_SUBMIT, log, spinner } from '@clack/prompts';
+
+export interface StepLabels {
+    running: string;
+    done: string;
+    stream?: boolean;
+}
+
+export type StepLogger = (line: string) => void;
+
+export interface StepUi {
+    run: <Ret>(labels: StepLabels, work: (onLine: StepLogger) => Promise<Ret>) => Promise<Ret>;
+    skip: (label: string) => void;
+}
+
+export function clackSteps(): StepUi {
+    return {
+        run: async (labels, work) => {
+            const spin = spinner();
+            spin.start(labels.running);
+
+            const onLine: StepLogger =
+                labels.stream === true
+                    ? (line) => {
+                          spin.message(`${labels.running}  ${styleText('dim', line)}`);
+                      }
+                    : () => undefined;
+
+            try {
+                const result = await work(onLine);
+                spin.stop(labels.done);
+                return result;
+            } catch (error) {
+                spin.error(labels.running);
+                throw error;
+            }
+        },
+        skip: (label) => {
+            log.message(styleText('gray', `${label} (skipped)`), {
+                symbol: styleText('gray', S_STEP_SUBMIT)
+            });
+        }
+    };
+}
+
+export function silentSteps(): StepUi {
+    return {
+        run: async (_labels, work) => work(() => undefined),
+        skip: () => undefined
+    };
+}

--- a/cli/create-seedcord/src/cli/summary.ts
+++ b/cli/create-seedcord/src/cli/summary.ts
@@ -37,6 +37,7 @@ export function dashboardToggles(capabilities: string[]): string[] {
 // the token and public key stay out, since this line reaches scroll-back and screenshots
 export function reproducingCommand(answers: ScaffoldAnswers, agent: AgentName): string {
     const flags = [
+        `--language ${answers.language}`,
         `--transport ${answers.transport}`,
         ...(answers.capabilities === undefined ? [] : [`--capabilities ${answers.capabilities.join(',')}`]),
         '--token YOUR_TOKEN',

--- a/cli/create-seedcord/src/cli/summary.ts
+++ b/cli/create-seedcord/src/cli/summary.ts
@@ -1,3 +1,5 @@
+import { paint } from '@seedcord/errors/internal';
+
 import { runPrefix } from '@cli/packageManager';
 import { privilegedFor } from '@interview/capabilities';
 
@@ -26,9 +28,9 @@ export function dashboardToggles(capabilities: string[]): string[] {
 
     return [
         'Turn these on for your app under Bot, at',
-        PORTAL,
+        paint.sky(PORTAL),
         '',
-        ...privileged.map((intent) => `  ${TOGGLE_LABELS[intent] ?? intent}`)
+        ...privileged.map((intent) => `  ${paint.amber(TOGGLE_LABELS[intent] ?? intent)}`)
     ];
 }
 

--- a/cli/create-seedcord/src/cli/summary.ts
+++ b/cli/create-seedcord/src/cli/summary.ts
@@ -1,0 +1,47 @@
+import { runPrefix } from '@cli/packageManager';
+import { privilegedFor } from '@interview/capabilities';
+
+import type { ScaffoldAnswers } from '@template/context';
+import type { AgentName } from 'package-manager-detector';
+
+const PORTAL = 'https://discord.com/developers/applications';
+
+// discord labels the three toggles differently from the intents they turn on
+const TOGGLE_LABELS: Record<string, string> = {
+    GuildMembers: 'Server Members Intent',
+    GuildPresences: 'Presence Intent',
+    MessageContent: 'Message Content Intent'
+};
+
+export function nextSteps(answers: ScaffoldAnswers, run: { agent: AgentName; installed: boolean }): string[] {
+    const prefix = runPrefix(run.agent);
+    const install = run.installed ? [] : [`${run.agent} install`];
+
+    return [`cd ${answers.directory}`, ...install, `${prefix} dev`];
+}
+
+export function dashboardToggles(capabilities: string[]): string[] {
+    const privileged = privilegedFor(capabilities);
+    if (privileged.length === 0) return [];
+
+    return [
+        `Turn these on for your app at ${PORTAL}, under Bot:`,
+        ...privileged.map((intent) => `  ${TOGGLE_LABELS[intent] ?? intent}`)
+    ];
+}
+
+// the token and public key stay out, since this line reaches scroll-back and screenshots
+export function reproducingCommand(answers: ScaffoldAnswers, agent: AgentName): string {
+    const flags = [
+        `--transport ${answers.transport}`,
+        ...(answers.capabilities === undefined ? [] : [`--capabilities ${answers.capabilities.join(',')}`]),
+        '--token YOUR_TOKEN',
+        ...(answers.publicKey === undefined ? [] : ['--public-key YOUR_PUBLIC_KEY']),
+        `--color ${answers.botColor}`
+    ];
+
+    // npm alone forwards flags to the package through a double dash
+    const separator = agent === 'npm' ? '-- ' : '';
+
+    return `${agent} create seedcord ${answers.directory} ${separator}${flags.join(' ')}`;
+}

--- a/cli/create-seedcord/src/cli/summary.ts
+++ b/cli/create-seedcord/src/cli/summary.ts
@@ -25,7 +25,9 @@ export function dashboardToggles(capabilities: string[]): string[] {
     if (privileged.length === 0) return [];
 
     return [
-        `Turn these on for your app at ${PORTAL}, under Bot:`,
+        'Turn these on for your app under Bot, at',
+        PORTAL,
+        '',
         ...privileged.map((intent) => `  ${TOGGLE_LABELS[intent] ?? intent}`)
     ];
 }

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
 
-import { intro, isCI, isTTY, log, outro } from '@clack/prompts';
+import { cancel, intro, isCI, isTTY, log, outro } from '@clack/prompts';
 
 import { helpText } from '@cli/help';
 import { runningAgent } from '@cli/packageManager';
@@ -61,7 +61,10 @@ async function main(): Promise<void> {
 try {
     await main();
 } catch (error) {
-    const { code, message } = reportFailure(error);
-    if (message !== null) log.error(message);
-    process.exit(code);
+    const failure = reportFailure(error);
+
+    if (failure.cancelled) cancel(failure.message);
+    else log.error(failure.message);
+
+    process.exit(failure.code);
 }

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,12 +1,20 @@
+import { resolve } from 'node:path';
 import process from 'node:process';
 
-import { intro, isCI, isTTY, log, outro } from '@clack/prompts';
+import { intro, isCI, isTTY, log, outro, spinner } from '@clack/prompts';
 
 import { helpText } from '@cli/help';
+import { runningAgent } from '@cli/packageManager';
 import { parseInput } from '@cli/parseInput';
 import { reportFailure } from '@cli/reportFailure';
 import { runFlow } from '@interview/runFlow';
 import { STEPS } from '@interview/steps';
+import { execRunner } from '@scaffold/exec';
+import { scaffold } from '@scaffold/scaffold';
+import { requireScaffoldAnswers } from '@template/context';
+
+// dist/index.mjs and src/index.ts both sit one level under the package root
+const TEMPLATES = resolve(import.meta.dirname, '../templates');
 
 function isInteractive(): boolean {
     return Boolean(process.stdin.isTTY) && isTTY(process.stdout) && !isCI();
@@ -23,9 +31,31 @@ async function main(): Promise<void> {
     const interactive = isInteractive();
     if (interactive) intro('create-seedcord');
 
-    const answers = await runFlow(STEPS, input.supplied, { interactive });
+    const answers = requireScaffoldAnswers(await runFlow(STEPS, input.supplied, { interactive }));
+    const target = resolve(process.cwd(), answers.directory);
 
-    if (interactive) outro(`Answers collected for ${String(answers.directory)}.`);
+    const progress = interactive ? spinner() : null;
+    progress?.start('Setting up your project');
+
+    const result = await scaffold(
+        {
+            target,
+            templatesRoot: TEMPLATES,
+            answers,
+            agent: runningAgent(),
+            install: input.install,
+            git: input.git
+        },
+        execRunner
+    ).catch((error: unknown) => {
+        progress?.stop('Setup failed');
+        throw error;
+    });
+
+    progress?.stop('Project ready');
+    if (result.gitNotice !== null) log.warn(result.gitNotice);
+
+    if (interactive) outro(`cd ${answers.directory}`);
 }
 
 try {

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
+import { styleText } from 'node:util';
 
 import { cancel, intro, isCI, isTTY, log, outro } from '@clack/prompts';
 
@@ -8,11 +9,16 @@ import { runningAgent } from '@cli/packageManager';
 import { parseInput } from '@cli/parseInput';
 import { reportFailure } from '@cli/reportFailure';
 import { clackSteps, silentSteps } from '@cli/steps';
+import { dashboardToggles, nextSteps, reproducingCommand } from '@cli/summary';
 import { runFlow } from '@interview/runFlow';
 import { STEPS } from '@interview/steps';
+import { missingNotice, probeCloudflared } from '@scaffold/cloudflared';
 import { execRunner } from '@scaffold/exec';
 import { scaffold } from '@scaffold/scaffold';
 import { requireScaffoldAnswers } from '@template/context';
+
+import type { ScaffoldAnswers } from '@template/context';
+import type { AgentName } from 'package-manager-detector';
 
 // dist/index.mjs and src/index.ts are both one level under the package root
 const TEMPLATES = resolve(import.meta.dirname, '../templates');
@@ -39,13 +45,14 @@ async function main(): Promise<void> {
 
     const answers = requireScaffoldAnswers(await runFlow(STEPS, input.supplied, { interactive }));
     const target = resolve(process.cwd(), answers.directory);
+    const agent = runningAgent();
 
     const result = await scaffold(
         {
             target,
             templatesRoot: TEMPLATES,
             answers,
-            agent: runningAgent(),
+            agent,
             install: input.install,
             git: input.git,
             steps: interactive ? clackSteps() : silentSteps()
@@ -55,7 +62,28 @@ async function main(): Promise<void> {
 
     if (result.gitNotice !== null) log.warn(result.gitNotice);
 
-    if (interactive) outro(`cd ${answers.directory}`);
+    await reportOutcome(answers, agent, result.installed, interactive);
+}
+
+async function reportOutcome(
+    answers: ScaffoldAnswers,
+    agent: AgentName,
+    installed: boolean,
+    interactive: boolean
+): Promise<void> {
+    if (!interactive) return;
+
+    const toggles = dashboardToggles(answers.capabilities ?? []);
+    if (toggles.length > 0) log.warn(toggles.join('\n'));
+
+    if (answers.transport === 'http' && !(await probeCloudflared())) {
+        log.warn(missingNotice(process.platform));
+    }
+
+    log.step(nextSteps(answers, { agent, installed }).join('\n'));
+    log.message(styleText('dim', reproducingCommand(answers, agent)));
+
+    outro('https://guide.seedcord.org');
 }
 
 try {

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,9 +1,10 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
-import { styleText } from 'node:util';
 
 import { cancel, intro, isCI, isTTY, log, outro } from '@clack/prompts';
+import chalk from 'chalk';
 
+import { banner } from '@cli/banner';
 import { helpText } from '@cli/help';
 import { runningAgent } from '@cli/packageManager';
 import { parseInput } from '@cli/parseInput';
@@ -41,7 +42,7 @@ async function main(): Promise<void> {
     }
 
     const interactive = isInteractive();
-    if (interactive) intro('create-seedcord');
+    if (interactive) intro(banner());
 
     const answers = requireScaffoldAnswers(await runFlow(STEPS, input.supplied, { interactive }));
     const target = resolve(process.cwd(), answers.directory);
@@ -81,7 +82,7 @@ async function reportOutcome(
     }
 
     log.step(nextSteps(answers, { agent, installed }).join('\n'));
-    log.message(styleText('dim', reproducingCommand(answers, agent)));
+    log.message(chalk.dim(reproducingCommand(answers, agent)));
 
     outro('https://guide.seedcord.org');
 }

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,23 +1,29 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
 
-import { intro, isCI, isTTY, log, outro, spinner } from '@clack/prompts';
+import { intro, isCI, isTTY, log, outro } from '@clack/prompts';
 
 import { helpText } from '@cli/help';
 import { runningAgent } from '@cli/packageManager';
 import { parseInput } from '@cli/parseInput';
 import { reportFailure } from '@cli/reportFailure';
+import { clackSteps, silentSteps } from '@cli/steps';
 import { runFlow } from '@interview/runFlow';
 import { STEPS } from '@interview/steps';
 import { execRunner } from '@scaffold/exec';
 import { scaffold } from '@scaffold/scaffold';
 import { requireScaffoldAnswers } from '@template/context';
 
-// dist/index.mjs and src/index.ts both sit one level under the package root
+// dist/index.mjs and src/index.ts are both one level under the package root
 const TEMPLATES = resolve(import.meta.dirname, '../templates');
 
+// a pty reporting zero columns makes clack wrap every line into an unbounded string
+function hasUsableWidth(): boolean {
+    return process.stdout.columns > 0;
+}
+
 function isInteractive(): boolean {
-    return Boolean(process.stdin.isTTY) && isTTY(process.stdout) && !isCI();
+    return Boolean(process.stdin.isTTY) && isTTY(process.stdout) && hasUsableWidth() && !isCI();
 }
 
 async function main(): Promise<void> {
@@ -34,9 +40,6 @@ async function main(): Promise<void> {
     const answers = requireScaffoldAnswers(await runFlow(STEPS, input.supplied, { interactive }));
     const target = resolve(process.cwd(), answers.directory);
 
-    const progress = interactive ? spinner() : null;
-    progress?.start('Setting up your project');
-
     const result = await scaffold(
         {
             target,
@@ -44,15 +47,12 @@ async function main(): Promise<void> {
             answers,
             agent: runningAgent(),
             install: input.install,
-            git: input.git
+            git: input.git,
+            steps: interactive ? clackSteps() : silentSteps()
         },
         execRunner
-    ).catch((error: unknown) => {
-        progress?.stop('Setup failed');
-        throw error;
-    });
+    );
 
-    progress?.stop('Project ready');
     if (result.gitNotice !== null) log.warn(result.gitNotice);
 
     if (interactive) outro(`cd ${answers.directory}`);

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -112,5 +112,6 @@ try {
     if (failure.message !== null) log.error(failure.message);
     cancel(failure.closing);
 
-    process.exit(failure.code);
+    // process.exit would cut the two lines above short when stdout is a pipe
+    process.exitCode = failure.code;
 }

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,13 +1,13 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
 
-import { cancel, intro, isCI, isTTY, log, outro } from '@clack/prompts';
-import chalk from 'chalk';
+import { cancel, intro, isCI, isTTY, log, note, outro } from '@clack/prompts';
 
 import { banner } from '@cli/banner';
 import { helpText } from '@cli/help';
+import { inviteUrl } from '@cli/invite';
 import { runningAgent } from '@cli/packageManager';
-import { parseInput } from '@cli/parseInput';
+import { parseInput, wantsHelp } from '@cli/parseInput';
 import { reportFailure } from '@cli/reportFailure';
 import { clackSteps, silentSteps } from '@cli/steps';
 import { dashboardToggles, nextSteps, reproducingCommand } from '@cli/summary';
@@ -34,9 +34,9 @@ function isInteractive(): boolean {
 }
 
 async function main(): Promise<void> {
-    const input = parseInput(process.argv.slice(2));
+    const argv = process.argv.slice(2);
 
-    if (input.help) {
+    if (wantsHelp(argv)) {
         process.stdout.write(`${helpText()}\n`);
         return;
     }
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
     const interactive = isInteractive();
     if (interactive) intro(banner());
 
+    const input = parseInput(argv);
     const answers = requireScaffoldAnswers(await runFlow(STEPS, input.supplied, { interactive }));
     const target = resolve(process.cwd(), answers.directory);
     const agent = runningAgent();
@@ -66,6 +67,12 @@ async function main(): Promise<void> {
     await reportOutcome(answers, agent, result.installed, interactive);
 }
 
+// a gutter on the wrapped rows would end up in whatever gets pasted
+function copyable(label: string, value: string): void {
+    log.message(label);
+    log.message(value, { withGuide: false, spacing: 0 });
+}
+
 async function reportOutcome(
     answers: ScaffoldAnswers,
     agent: AgentName,
@@ -75,14 +82,18 @@ async function reportOutcome(
     if (!interactive) return;
 
     const toggles = dashboardToggles(answers.capabilities ?? []);
-    if (toggles.length > 0) log.warn(toggles.join('\n'));
+    if (toggles.length > 0) note(toggles.join('\n'), 'Dashboard toggles');
 
     if (answers.transport === 'http' && !(await probeCloudflared())) {
         log.warn(missingNotice(process.platform));
     }
 
-    log.step(nextSteps(answers, { agent, installed }).join('\n'));
-    log.message(chalk.dim(reproducingCommand(answers, agent)));
+    note(nextSteps(answers, { agent, installed }).join('\n'), 'Next steps');
+
+    const invite = inviteUrl(answers.token);
+    if (invite !== null) copyable('Add the bot to a server', invite);
+
+    copyable('Run this setup again', reproducingCommand(answers, agent));
 
     outro('https://guide.seedcord.org');
 }
@@ -92,8 +103,8 @@ try {
 } catch (error) {
     const failure = reportFailure(error);
 
-    if (failure.cancelled) cancel(failure.message);
-    else log.error(failure.message);
+    if (failure.message !== null) log.error(failure.message);
+    cancel(failure.closing);
 
     process.exit(failure.code);
 }

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import process from 'node:process';
 
 import { cancel, intro, isCI, isTTY, log, note, outro } from '@clack/prompts';
+import { paint } from '@seedcord/errors/internal';
 
 import { banner } from '@cli/banner';
 import { helpText } from '@cli/help';
@@ -69,7 +70,7 @@ async function main(): Promise<void> {
 
 // a gutter on the wrapped rows would end up in whatever gets pasted
 function copyable(label: string, value: string): void {
-    log.message(label);
+    log.message(paint.mute(label));
     log.message(value, { withGuide: false, spacing: 0 });
 }
 
@@ -88,14 +89,19 @@ async function reportOutcome(
         log.warn(missingNotice(process.platform));
     }
 
-    note(nextSteps(answers, { agent, installed }).join('\n'), 'Next steps');
+    note(
+        nextSteps(answers, { agent, installed })
+            .map((step) => paint.mint(step))
+            .join('\n'),
+        'Next steps'
+    );
 
     const invite = inviteUrl(answers.token);
-    if (invite !== null) copyable('Add the bot to a server', invite);
+    if (invite !== null) copyable('Add the bot to a server', paint.sky(invite));
 
-    copyable('Run this setup again', reproducingCommand(answers, agent));
+    copyable('Run this setup again', paint.mute(reproducingCommand(answers, agent)));
 
-    outro('https://guide.seedcord.org');
+    outro(paint.sky('https://guide.seedcord.org'));
 }
 
 try {

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -2,11 +2,11 @@ import process from 'node:process';
 
 import { intro, isCI, isTTY, log, outro } from '@clack/prompts';
 
-import { helpText } from './cli/help';
-import { parseInput } from './cli/parseInput';
-import { reportFailure } from './cli/reportFailure';
-import { runFlow } from './interview/runFlow';
-import { STEPS } from './interview/steps';
+import { helpText } from '@cli/help';
+import { parseInput } from '@cli/parseInput';
+import { reportFailure } from '@cli/reportFailure';
+import { runFlow } from '@interview/runFlow';
+import { STEPS } from '@interview/steps';
 
 function isInteractive(): boolean {
     return Boolean(process.stdin.isTTY) && isTTY(process.stdout) && !isCI();

--- a/cli/create-seedcord/src/index.ts
+++ b/cli/create-seedcord/src/index.ts
@@ -1,4 +1,37 @@
-export { CAPABILITIES, intentsFor, partialsFor, privilegedFor } from './interview/capabilities';
-export { applyFlags } from './interview/applyFlags';
-export { runFlow } from './interview/runFlow';
-export { STEPS } from './interview/steps';
+import process from 'node:process';
+
+import { intro, isCI, isTTY, log, outro } from '@clack/prompts';
+
+import { helpText } from './cli/help';
+import { parseInput } from './cli/parseInput';
+import { reportFailure } from './cli/reportFailure';
+import { runFlow } from './interview/runFlow';
+import { STEPS } from './interview/steps';
+
+function isInteractive(): boolean {
+    return Boolean(process.stdin.isTTY) && isTTY(process.stdout) && !isCI();
+}
+
+async function main(): Promise<void> {
+    const input = parseInput(process.argv.slice(2));
+
+    if (input.help) {
+        process.stdout.write(`${helpText()}\n`);
+        return;
+    }
+
+    const interactive = isInteractive();
+    if (interactive) intro('create-seedcord');
+
+    const answers = await runFlow(STEPS, input.supplied, { interactive });
+
+    if (interactive) outro(`Answers collected for ${String(answers.directory)}.`);
+}
+
+try {
+    await main();
+} catch (error) {
+    const { code, message } = reportFailure(error);
+    if (message !== null) log.error(message);
+    process.exit(code);
+}

--- a/cli/create-seedcord/src/interview/capabilities.ts
+++ b/cli/create-seedcord/src/interview/capabilities.ts
@@ -10,8 +10,8 @@ export const CAPABILITIES = [
     },
     {
         id: 'message-text',
-        label: 'What messages actually say',
-        hint: 'privileged. without this, message text is empty unless the message mentions your bot',
+        label: 'What messages actually say (privileged intent. needs a dashboard toggle)',
+        hint: 'without this, message text is empty unless the message mentions your bot',
         // MessageContent subscribes to nothing on its own
         intents: ['GuildMessages', 'MessageContent'],
         partials: []
@@ -33,15 +33,15 @@ export const CAPABILITIES = [
     },
     {
         id: 'members',
-        label: 'Member joins and leaves',
-        hint: 'privileged. also covers nickname and role changes',
+        label: 'Member joins and leaves (privileged intent. needs a dashboard toggle)',
+        hint: 'also covers nickname and role changes',
         intents: ['GuildMembers'],
         partials: ['GuildMember']
     },
     {
         id: 'presence',
-        label: 'Member online status',
-        hint: 'privileged. who is online, and what they are playing',
+        label: 'Member online status (privileged intent. needs a dashboard toggle)',
+        hint: 'who is online, and what they are playing',
         intents: ['GuildPresences'],
         partials: []
     },

--- a/cli/create-seedcord/src/interview/capabilities.ts
+++ b/cli/create-seedcord/src/interview/capabilities.ts
@@ -10,7 +10,7 @@ export const CAPABILITIES = [
     },
     {
         id: 'message-text',
-        label: 'What messages actually say (privileged intent. needs a dashboard toggle)',
+        label: "The messages' contents",
         hint: 'without this, message text is empty unless the message mentions your bot',
         // MessageContent subscribes to nothing on its own
         intents: ['GuildMessages', 'MessageContent'],
@@ -33,14 +33,14 @@ export const CAPABILITIES = [
     },
     {
         id: 'members',
-        label: 'Member joins and leaves (privileged intent. needs a dashboard toggle)',
+        label: 'Member joins and leaves',
         hint: 'also covers nickname and role changes',
         intents: ['GuildMembers'],
         partials: ['GuildMember']
     },
     {
         id: 'presence',
-        label: 'Member online status (privileged intent. needs a dashboard toggle)',
+        label: 'Member online status',
         hint: 'who is online, and what they are playing',
         intents: ['GuildPresences'],
         partials: []
@@ -108,4 +108,8 @@ const PRIVILEGED_INTENTS = new Set<IntentName>(['GuildMembers', 'GuildPresences'
 
 export function privilegedFor(ids: readonly string[]): IntentName[] {
     return intentsFor(ids).filter((intent) => PRIVILEGED_INTENTS.has(intent));
+}
+
+export function isPrivileged(id: string): boolean {
+    return privilegedFor([id]).length > 0;
 }

--- a/cli/create-seedcord/src/interview/capabilities.ts
+++ b/cli/create-seedcord/src/interview/capabilities.ts
@@ -36,7 +36,7 @@ export const CAPABILITIES = [
         label: 'Member joins and leaves',
         hint: 'privileged. also covers nickname and role changes',
         intents: ['GuildMembers'],
-        partials: []
+        partials: ['GuildMember']
     },
     {
         id: 'presence',
@@ -62,9 +62,10 @@ export const CAPABILITIES = [
     {
         id: 'scheduled-events',
         label: 'Scheduled events',
-        hint: 'know when a server event is created, updated, or starts',
+        hint: 'know when a server event is made, changed, or starts, and when people sign up',
         intents: ['GuildScheduledEvents'],
-        partials: []
+        // only the sign-up events read the user cache
+        partials: ['User']
     },
     {
         id: 'automod',
@@ -78,7 +79,8 @@ export const CAPABILITIES = [
         label: 'Polls',
         hint: 'know when someone votes in a poll',
         intents: ['GuildMessagePolls', 'DirectMessagePolls'],
-        partials: []
+        // getPoll returns null on a partial message unless both Poll and PollAnswer are set
+        partials: ['Message', 'Channel', 'Poll', 'PollAnswer']
     }
 ] as const;
 

--- a/cli/create-seedcord/src/interview/runFlow.ts
+++ b/cli/create-seedcord/src/interview/runFlow.ts
@@ -1,3 +1,6 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
 import type { AnyStep, Answers } from './types';
 
 export async function runFlow(steps: AnyStep[], supplied: Partial<Answers>): Promise<Partial<Answers>> {
@@ -6,7 +9,7 @@ export async function runFlow(steps: AnyStep[], supplied: Partial<Answers>): Pro
     for (const step of steps) {
         if (step.skip?.(answers)) {
             if (step.key in supplied) {
-                throw new Error(`The --${step.flag.name} flag does not apply to the answers you gave.`);
+                throw new SeedcordError(SeedcordErrorCode.CreateFlagNotApplicable, [step.flag.name]);
             }
             continue;
         }

--- a/cli/create-seedcord/src/interview/runFlow.ts
+++ b/cli/create-seedcord/src/interview/runFlow.ts
@@ -3,7 +3,11 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import type { AnyStep, Answers } from './types';
 
-export async function runFlow(steps: AnyStep[], supplied: Partial<Answers>): Promise<Partial<Answers>> {
+export async function runFlow(
+    steps: AnyStep[],
+    supplied: Partial<Answers>,
+    options: { interactive: boolean }
+): Promise<Partial<Answers>> {
     const answers: Partial<Answers> = { ...supplied };
 
     for (const step of steps) {
@@ -14,6 +18,13 @@ export async function runFlow(steps: AnyStep[], supplied: Partial<Answers>): Pro
             continue;
         }
         if (answers[step.key] !== undefined) continue;
+
+        if (!options.interactive) {
+            throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+                step.flag.name,
+                'Required when there is no terminal to ask on.'
+            ]);
+        }
 
         // justified: Step<Key> ties each key to its own answer type
         (answers as Record<keyof Answers, unknown>)[step.key] = await step.ask(answers);

--- a/cli/create-seedcord/src/interview/steps/botColor.ts
+++ b/cli/create-seedcord/src/interview/steps/botColor.ts
@@ -44,6 +44,8 @@ export const COLOR_NAMES = [
 
 export type ColorChoice = (typeof COLOR_NAMES)[number];
 
+const VISIBLE_COLORS = 8;
+
 // the framework's resolveColor takes six hex digits with the hash optional
 function normalizeHex(raw: string): `#${string}` | null {
     const digits = raw.trim().replace(/^#/, '');
@@ -87,7 +89,8 @@ export const botColorStep: Step<'botColor'> = {
                     message: 'Pick an accent color, or type a hex',
                     options: colorOptions,
                     initialValue: 'Blurple',
-                    placeholder: 'Blurple'
+                    placeholder: 'Blurple',
+                    maxItems: VISIBLE_COLORS
                 })
             )
         )

--- a/cli/create-seedcord/src/interview/steps/botColor.ts
+++ b/cli/create-seedcord/src/interview/steps/botColor.ts
@@ -4,8 +4,8 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Answers, Step } from '../types';
 import type { Option } from '@clack/prompts';
+import type { Answers, Step } from '@interview/types';
 import type { ColorName } from '@seedcord/types';
 
 export const COLOR_NAMES = [

--- a/cli/create-seedcord/src/interview/steps/botColor.ts
+++ b/cli/create-seedcord/src/interview/steps/botColor.ts
@@ -1,4 +1,6 @@
 import { autocomplete } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -54,7 +56,13 @@ function parseColor(raw: string): Answers['botColor'] {
 
     const value = raw.trim().toLowerCase();
     const match = COLOR_NAMES.find((name) => name.toLowerCase() === value);
-    if (!match) throw new Error(`Unknown color "${raw}". Use a color name or a six-digit hex.`);
+    if (!match) {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'color',
+            `Unknown color "${raw}". Use a color name or a six-digit hex.`
+        ]);
+    }
+
     return match;
 }
 

--- a/cli/create-seedcord/src/interview/steps/botColor.ts
+++ b/cli/create-seedcord/src/interview/steps/botColor.ts
@@ -79,7 +79,7 @@ function colorOptions(this: { userInput: string }): Option<string>[] {
 
 export const botColorStep: Step<'botColor'> = {
     key: 'botColor',
-    flag: { name: 'color', parse: parseColor },
+    flag: { name: 'color', description: 'a color name or a six-digit hex', parse: parseColor },
     ask: async () =>
         parseColor(
             requireAnswer(

--- a/cli/create-seedcord/src/interview/steps/capabilities.ts
+++ b/cli/create-seedcord/src/interview/steps/capabilities.ts
@@ -27,7 +27,11 @@ function parseCapabilities(raw: string): string[] {
 
 export const capabilitiesStep: Step<'capabilities'> = {
     key: 'capabilities',
-    flag: { name: 'capabilities', parse: parseCapabilities },
+    flag: {
+        name: 'capabilities',
+        description: `a comma separated list of ${CAPABILITIES.map((capability) => capability.id).join(', ')}`,
+        parse: parseCapabilities
+    },
     skip: (answers) => answers.transport === 'http',
     ask: async () =>
         requireAnswer(

--- a/cli/create-seedcord/src/interview/steps/capabilities.ts
+++ b/cli/create-seedcord/src/interview/steps/capabilities.ts
@@ -1,8 +1,8 @@
 import { multiselect } from '@clack/prompts';
 import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordError } from '@seedcord/errors/internal';
+import { SeedcordError, paint } from '@seedcord/errors/internal';
 
-import { CAPABILITIES } from '@interview/capabilities';
+import { CAPABILITIES, isPrivileged } from '@interview/capabilities';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -26,6 +26,11 @@ function parseCapabilities(raw: string): string[] {
     return ids;
 }
 
+// clack draws a hint only under the cursor
+function optionLabel(id: string, label: string): string {
+    return isPrivileged(id) ? `${label} ${paint.amber('privileged')}` : label;
+}
+
 export const capabilitiesStep: Step<'capabilities'> = {
     key: 'capabilities',
     flag: {
@@ -40,7 +45,7 @@ export const capabilitiesStep: Step<'capabilities'> = {
                 message: 'What should your bot react to?',
                 options: CAPABILITIES.map((capability) => ({
                     value: capability.id,
-                    label: capability.label,
+                    label: optionLabel(capability.id, capability.label),
                     hint: capability.hint
                 })),
                 required: false

--- a/cli/create-seedcord/src/interview/steps/capabilities.ts
+++ b/cli/create-seedcord/src/interview/steps/capabilities.ts
@@ -2,10 +2,11 @@ import { multiselect } from '@clack/prompts';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
-import { CAPABILITIES } from '../capabilities';
+import { CAPABILITIES } from '@interview/capabilities';
+
 import { requireAnswer } from './requireAnswer';
 
-import type { Step } from '../types';
+import type { Step } from '@interview/types';
 
 function parseCapabilities(raw: string): string[] {
     const ids = raw

--- a/cli/create-seedcord/src/interview/steps/capabilities.ts
+++ b/cli/create-seedcord/src/interview/steps/capabilities.ts
@@ -1,4 +1,6 @@
 import { multiselect } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { CAPABILITIES } from '../capabilities';
 import { requireAnswer } from './requireAnswer';
@@ -13,7 +15,10 @@ function parseCapabilities(raw: string): string[] {
 
     for (const id of ids) {
         if (!CAPABILITIES.some((capability) => capability.id === id)) {
-            throw new Error(`Unknown capability "${id}". Run with --help for the list.`);
+            throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+                'capabilities',
+                `Unknown capability "${id}". Run with --help for the list.`
+            ]);
         }
     }
 

--- a/cli/create-seedcord/src/interview/steps/directory.ts
+++ b/cli/create-seedcord/src/interview/steps/directory.ts
@@ -1,15 +1,28 @@
+import { basename } from 'node:path';
+
 import { text } from '@clack/prompts';
 import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordError } from '@seedcord/errors/internal';
+import { SeedcordError, paint } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
 import type { Step } from '@interview/types';
 
+const PACKAGE_NAME = /^[a-z\d][a-z\d._-]*$/;
+const FORMAT = 'lowercase, digits, and . _ -';
+
 function parseDirectory(raw: string): string {
     const value = raw.trim();
     if (value === '') {
         throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, ['dir', 'A project directory cannot be empty.']);
+    }
+
+    // context.ts copies the basename into package.json as the package name
+    if (!PACKAGE_NAME.test(basename(value))) {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'dir',
+            `The folder name becomes the package name. Use ${FORMAT}, starting with a letter or digit.`
+        ]);
     }
 
     return value;
@@ -22,9 +35,16 @@ export const directoryStep: Step<'directory'> = {
         parseDirectory(
             requireAnswer(
                 await text({
-                    message: 'Where should the project go?',
+                    message: `Where should the project go? ${paint.mute(FORMAT)}`,
                     placeholder: 'my-bot',
-                    validate: (value) => ((value ?? '').trim() === '' ? 'Enter a directory name.' : undefined)
+                    validate: (value) => {
+                        try {
+                            parseDirectory(value ?? '');
+                            return undefined;
+                        } catch (error) {
+                            return Error.isError(error) ? error.message : 'Enter a directory name.';
+                        }
+                    }
                 })
             )
         )

--- a/cli/create-seedcord/src/interview/steps/directory.ts
+++ b/cli/create-seedcord/src/interview/steps/directory.ts
@@ -1,4 +1,6 @@
 import { text } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -6,7 +8,10 @@ import type { Step } from '../types';
 
 function parseDirectory(raw: string): string {
     const value = raw.trim();
-    if (value === '') throw new Error('The project directory cannot be empty.');
+    if (value === '') {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, ['dir', 'A project directory cannot be empty.']);
+    }
+
     return value;
 }
 

--- a/cli/create-seedcord/src/interview/steps/directory.ts
+++ b/cli/create-seedcord/src/interview/steps/directory.ts
@@ -11,6 +11,8 @@ import type { Step } from '@interview/types';
 const PACKAGE_NAME = /^[a-z\d][a-z\d._-]*$/;
 const FORMAT = 'lowercase, digits, and . _ -';
 
+const MAX_NAME = 64;
+
 function parseDirectory(raw: string): string {
     const value = raw.trim();
     if (value === '') {
@@ -18,7 +20,16 @@ function parseDirectory(raw: string): string {
     }
 
     // context.ts copies the basename into package.json as the package name
-    if (!PACKAGE_NAME.test(basename(value))) {
+    const name = basename(value);
+
+    if (name.length > MAX_NAME) {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'dir',
+            `Keep the folder name to ${MAX_NAME} characters or fewer.`
+        ]);
+    }
+
+    if (!PACKAGE_NAME.test(name)) {
         throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
             'dir',
             `The folder name becomes the package name. Use ${FORMAT}, starting with a letter or digit.`

--- a/cli/create-seedcord/src/interview/steps/directory.ts
+++ b/cli/create-seedcord/src/interview/steps/directory.ts
@@ -4,7 +4,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Step } from '../types';
+import type { Step } from '@interview/types';
 
 function parseDirectory(raw: string): string {
     const value = raw.trim();

--- a/cli/create-seedcord/src/interview/steps/directory.ts
+++ b/cli/create-seedcord/src/interview/steps/directory.ts
@@ -17,7 +17,7 @@ function parseDirectory(raw: string): string {
 
 export const directoryStep: Step<'directory'> = {
     key: 'directory',
-    flag: { name: 'dir', parse: parseDirectory },
+    flag: { name: 'dir', description: 'where the project goes', parse: parseDirectory },
     ask: async () =>
         parseDirectory(
             requireAnswer(

--- a/cli/create-seedcord/src/interview/steps/index.ts
+++ b/cli/create-seedcord/src/interview/steps/index.ts
@@ -6,7 +6,7 @@ import { publicKeyStep } from './publicKey';
 import { tokenStep } from './token';
 import { transportStep } from './transport';
 
-import type { AnyStep } from '../types';
+import type { AnyStep } from '@interview/types';
 
 // the token and public key are both read off the Discord dashboard
 export const STEPS: AnyStep[] = [

--- a/cli/create-seedcord/src/interview/steps/language.ts
+++ b/cli/create-seedcord/src/interview/steps/language.ts
@@ -28,7 +28,7 @@ export function pickReply(random: () => number = Math.random): string {
 
 export const languageStep: Step<'language'> = {
     key: 'language',
-    flag: { name: 'language', parse: () => 'typescript' },
+    flag: { name: 'language', description: 'accepted, then overrides with typescript', parse: () => 'typescript' },
     ask: async () => {
         const picked = requireAnswer(
             await select<'typescript' | 'javascript'>({

--- a/cli/create-seedcord/src/interview/steps/language.ts
+++ b/cli/create-seedcord/src/interview/steps/language.ts
@@ -2,7 +2,7 @@ import { log, select } from '@clack/prompts';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Step } from '../types';
+import type { Step } from '@interview/types';
 
 export const JAVASCRIPT_REPLIES = [
     'weird flex. anyway, welcome to TypeScript.',

--- a/cli/create-seedcord/src/interview/steps/language.ts
+++ b/cli/create-seedcord/src/interview/steps/language.ts
@@ -6,19 +6,20 @@ import type { Step } from '../types';
 
 export const JAVASCRIPT_REPLIES = [
     'weird flex. anyway, welcome to TypeScript.',
-    'noted. ignored.',
-    'respectfully, no.',
-    'haha. anyway.',
+    'noted. ignored. TypeScript.',
+    'TypeScript. respectfully.',
+    'haha. TypeScript then.',
     'checking with legal... they said TypeScript.',
-    'ran that by the compiler. it hung up.',
-    'hard to hear you over all these type errors.',
-    "yeah... we don't do that here.",
-    'bold of you.',
-    'love the confidence.',
+    'ran that by the compiler. it hung up and started a TypeScript project.',
+    'hard to hear you over all these type errors. TypeScript should clear those up.',
+    "yeah... we don't do that here. TypeScript we can do.",
+    'bold of you. enjoy your TypeScript.',
+    'love the confidence. TypeScript will test it.',
     'absolutely. one TypeScript project coming up.',
     'sure thing. TypeScript, as requested.',
-    "you're gonna thank me in about a week.",
-    'are you okay?'
+    "you're gonna thank me for overriding this with TypeScript in about a week.",
+    'are you okay? here, have some TypeScript.',
+    'heard you. picked TypeScript anyway.'
 ] as const;
 
 export function pickReply(random: () => number = Math.random): string {

--- a/cli/create-seedcord/src/interview/steps/publicKey.ts
+++ b/cli/create-seedcord/src/interview/steps/publicKey.ts
@@ -25,7 +25,7 @@ function parsePublicKey(raw: string): string {
 
 export const publicKeyStep: Step<'publicKey'> = {
     key: 'publicKey',
-    flag: { name: 'public-key', parse: parsePublicKey },
+    flag: { name: 'public-key', description: 'your app public key, http only', parse: parsePublicKey },
     skip: (answers) => answers.transport === 'gateway',
     ask: async () =>
         parsePublicKey(

--- a/cli/create-seedcord/src/interview/steps/publicKey.ts
+++ b/cli/create-seedcord/src/interview/steps/publicKey.ts
@@ -1,4 +1,6 @@
 import { text } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -12,7 +14,10 @@ function parsePublicKey(raw: string): string {
     const value = raw.trim();
 
     if (value.length !== PUBLIC_KEY_CHARS || !HEX.test(value)) {
-        throw new Error(`A public key is ${PUBLIC_KEY_CHARS} hex characters. Copy it from your app's main page.`);
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'public-key',
+            `A public key is ${PUBLIC_KEY_CHARS} hex characters. Copy it from your app's main page.`
+        ]);
     }
 
     return value.toLowerCase();

--- a/cli/create-seedcord/src/interview/steps/publicKey.ts
+++ b/cli/create-seedcord/src/interview/steps/publicKey.ts
@@ -4,7 +4,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Step } from '../types';
+import type { Step } from '@interview/types';
 
 // an Ed25519 public key is 32 bytes
 const PUBLIC_KEY_CHARS = 64;

--- a/cli/create-seedcord/src/interview/steps/requireAnswer.ts
+++ b/cli/create-seedcord/src/interview/steps/requireAnswer.ts
@@ -1,14 +1,9 @@
 import { isCancel } from '@clack/prompts';
-
-class Cancelled extends Error {
-    constructor() {
-        super('Cancelled.');
-        this.name = 'Cancelled';
-    }
-}
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 // clack signals a cancel with a symbol
 export function requireAnswer<Value>(value: Value | symbol): Value {
-    if (isCancel(value)) throw new Cancelled();
+    if (isCancel(value)) throw new SeedcordError(SeedcordErrorCode.CreateCancelled);
     return value;
 }

--- a/cli/create-seedcord/src/interview/steps/token.ts
+++ b/cli/create-seedcord/src/interview/steps/token.ts
@@ -4,7 +4,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Step } from '../types';
+import type { Step } from '@interview/types';
 
 const TOKEN_PARTS = 3;
 

--- a/cli/create-seedcord/src/interview/steps/token.ts
+++ b/cli/create-seedcord/src/interview/steps/token.ts
@@ -1,26 +1,20 @@
 import { password } from '@clack/prompts';
 import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordError } from '@seedcord/errors/internal';
+import { SeedcordError, validateDiscordToken } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
 import type { Step } from '@interview/types';
 
-const TOKEN_PARTS = 3;
-
-// startup runs the real check through validateDiscordToken
 function parseToken(raw: string): string {
-    const value = raw.trim();
-    const parts = value.split('.');
-
-    if (parts.length !== TOKEN_PARTS || parts.includes('')) {
+    try {
+        return validateDiscordToken(raw);
+    } catch {
         throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
             'token',
             'That does not look like a bot token. Copy it from the Bot page of your app.'
         ]);
     }
-
-    return value;
 }
 
 export const tokenStep: Step<'token'> = {

--- a/cli/create-seedcord/src/interview/steps/token.ts
+++ b/cli/create-seedcord/src/interview/steps/token.ts
@@ -25,7 +25,7 @@ function parseToken(raw: string): string {
 
 export const tokenStep: Step<'token'> = {
     key: 'token',
-    flag: { name: 'token', parse: parseToken },
+    flag: { name: 'token', description: 'your bot token', parse: parseToken },
     ask: async () =>
         parseToken(
             requireAnswer(

--- a/cli/create-seedcord/src/interview/steps/token.ts
+++ b/cli/create-seedcord/src/interview/steps/token.ts
@@ -1,4 +1,6 @@
 import { password } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -12,7 +14,10 @@ function parseToken(raw: string): string {
     const parts = value.split('.');
 
     if (parts.length !== TOKEN_PARTS || parts.includes('')) {
-        throw new Error('That does not look like a bot token. Copy it from the Bot page of your app.');
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'token',
+            'That does not look like a bot token. Copy it from the Bot page of your app.'
+        ]);
     }
 
     return value;

--- a/cli/create-seedcord/src/interview/steps/transport.ts
+++ b/cli/create-seedcord/src/interview/steps/transport.ts
@@ -4,7 +4,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
-import type { Answers, Step } from '../types';
+import type { Answers, Step } from '@interview/types';
 
 const TRANSPORTS: Answers['transport'][] = ['gateway', 'http'];
 

--- a/cli/create-seedcord/src/interview/steps/transport.ts
+++ b/cli/create-seedcord/src/interview/steps/transport.ts
@@ -1,4 +1,6 @@
 import { select } from '@clack/prompts';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { requireAnswer } from './requireAnswer';
 
@@ -9,7 +11,13 @@ const TRANSPORTS: Answers['transport'][] = ['gateway', 'http'];
 function parseTransport(raw: string): Answers['transport'] {
     const value = raw.trim().toLowerCase();
     const match = TRANSPORTS.find((transport) => transport === value);
-    if (!match) throw new Error(`Unknown transport "${raw}". Pick gateway or http.`);
+    if (!match) {
+        throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
+            'transport',
+            `Unknown transport "${raw}". Pick gateway or http.`
+        ]);
+    }
+
     return match;
 }
 

--- a/cli/create-seedcord/src/interview/steps/transport.ts
+++ b/cli/create-seedcord/src/interview/steps/transport.ts
@@ -23,7 +23,7 @@ function parseTransport(raw: string): Answers['transport'] {
 
 export const transportStep: Step<'transport'> = {
     key: 'transport',
-    flag: { name: 'transport', parse: parseTransport },
+    flag: { name: 'transport', description: 'gateway or http', parse: parseTransport },
     ask: async () =>
         requireAnswer(
             await select<Answers['transport']>({

--- a/cli/create-seedcord/src/interview/steps/transport.ts
+++ b/cli/create-seedcord/src/interview/steps/transport.ts
@@ -6,7 +6,7 @@ import { requireAnswer } from './requireAnswer';
 
 import type { Answers, Step } from '@interview/types';
 
-const TRANSPORTS: Answers['transport'][] = ['gateway', 'http'];
+const TRANSPORTS: Answers['transport'][] = ['http', 'gateway'];
 
 function parseTransport(raw: string): Answers['transport'] {
     const value = raw.trim().toLowerCase();
@@ -14,7 +14,7 @@ function parseTransport(raw: string): Answers['transport'] {
     if (!match) {
         throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [
             'transport',
-            `Unknown transport "${raw}". Pick gateway or http.`
+            `Unknown transport "${raw}". Pick http or gateway.`
         ]);
     }
 
@@ -23,21 +23,21 @@ function parseTransport(raw: string): Answers['transport'] {
 
 export const transportStep: Step<'transport'> = {
     key: 'transport',
-    flag: { name: 'transport', description: 'gateway or http', parse: parseTransport },
+    flag: { name: 'transport', description: 'http or gateway', parse: parseTransport },
     ask: async () =>
         requireAnswer(
             await select<Answers['transport']>({
                 message: 'How should Discord reach your bot?',
                 options: [
                     {
-                        value: 'gateway',
-                        label: 'Gateway',
-                        hint: 'keeps a connection to Discord open. messages, reactions, joins, voice activity, and so on arrive on top of interactions'
-                    },
-                    {
                         value: 'http',
                         label: 'Http',
                         hint: 'Discord posts interactions to your URL'
+                    },
+                    {
+                        value: 'gateway',
+                        label: 'Gateway',
+                        hint: 'keeps a connection to Discord open. messages, reactions, joins, voice activity, and so on arrive on top of interactions'
                     }
                 ]
             })

--- a/cli/create-seedcord/src/interview/types.ts
+++ b/cli/create-seedcord/src/interview/types.ts
@@ -15,6 +15,8 @@ export interface Answers {
 interface FlagSpec<Key extends keyof Answers> {
     // no leading dashes
     name: string;
+    // one line, printed by --help
+    description: string;
     parse: (raw: string) => Answers[Key];
 }
 

--- a/cli/create-seedcord/src/scaffold/cloudflared.ts
+++ b/cli/create-seedcord/src/scaffold/cloudflared.ts
@@ -1,5 +1,4 @@
 import { execFile } from 'node:child_process';
-import process from 'node:process';
 import { promisify } from 'node:util';
 
 const run = promisify(execFile);
@@ -20,9 +19,4 @@ export function missingNotice(platform: NodeJS.Platform): string {
 export async function probeCloudflared(binary = 'cloudflared'): Promise<boolean> {
     const found = await run(binary, ['--version']).catch(() => null);
     return found !== null;
-}
-
-// brew and winget install it. every other platform gets a download page.
-export function canInstall(platform: NodeJS.Platform = process.platform): boolean {
-    return platform === 'darwin' || platform === 'win32';
 }

--- a/cli/create-seedcord/src/scaffold/cloudflared.ts
+++ b/cli/create-seedcord/src/scaffold/cloudflared.ts
@@ -18,7 +18,10 @@ export function missingNotice(platform: NodeJS.Platform): string {
     return `\`seedcord dev\` opens a cloudflared tunnel so Discord can reach your bot. Install it with:\n${paint.mint(installHint(platform))}`;
 }
 
-export async function probeCloudflared(binary = 'cloudflared'): Promise<boolean> {
-    const found = await run(binary, ['--version']).catch(() => null);
+// cloudflared --version answers in about 40ms and touches no network
+const PROBE_TIMEOUT_MS = 3000;
+
+export async function probeCloudflared(binary = 'cloudflared', timeout = PROBE_TIMEOUT_MS): Promise<boolean> {
+    const found = await run(binary, ['--version'], { timeout }).catch(() => null);
     return found !== null;
 }

--- a/cli/create-seedcord/src/scaffold/cloudflared.ts
+++ b/cli/create-seedcord/src/scaffold/cloudflared.ts
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
+import { paint } from '@seedcord/errors/internal';
+
 const run = promisify(execFile);
 
 const DOWNLOADS = 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/';
@@ -13,7 +15,7 @@ export function installHint(platform: NodeJS.Platform): string {
 }
 
 export function missingNotice(platform: NodeJS.Platform): string {
-    return `\`seedcord dev\` opens a cloudflared tunnel so Discord can reach your bot. Install it with:\n${installHint(platform)}`;
+    return `\`seedcord dev\` opens a cloudflared tunnel so Discord can reach your bot. Install it with:\n${paint.mint(installHint(platform))}`;
 }
 
 export async function probeCloudflared(binary = 'cloudflared'): Promise<boolean> {

--- a/cli/create-seedcord/src/scaffold/cloudflared.ts
+++ b/cli/create-seedcord/src/scaffold/cloudflared.ts
@@ -1,0 +1,28 @@
+import { execFile } from 'node:child_process';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+const DOWNLOADS = 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/';
+
+export function installHint(platform: NodeJS.Platform): string {
+    if (platform === 'darwin') return 'brew install cloudflared';
+    if (platform === 'win32') return 'winget install -e --id Cloudflare.cloudflared';
+
+    return DOWNLOADS;
+}
+
+export function missingNotice(platform: NodeJS.Platform): string {
+    return `\`seedcord dev\` opens a cloudflared tunnel so Discord can reach your bot. Install it with:\n${installHint(platform)}`;
+}
+
+export async function probeCloudflared(binary = 'cloudflared'): Promise<boolean> {
+    const found = await run(binary, ['--version']).catch(() => null);
+    return found !== null;
+}
+
+// brew and winget install it. every other platform gets a download page.
+export function canInstall(platform: NodeJS.Platform = process.platform): boolean {
+    return platform === 'darwin' || platform === 'win32';
+}

--- a/cli/create-seedcord/src/scaffold/exec.ts
+++ b/cli/create-seedcord/src/scaffold/exec.ts
@@ -1,0 +1,26 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
+import type { CommandRunner } from '@scaffold/scaffold';
+
+const run = promisify(execFile);
+
+function reasonFrom(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'stderr' in error) {
+        const { stderr } = error;
+        if (typeof stderr === 'string' && stderr.trim() !== '') return stderr.trim();
+    }
+
+    return Error.isError(error) ? error.message : String(error);
+}
+
+export async function execRunner(...[command, args, cwd]: Parameters<CommandRunner>): Promise<void> {
+    try {
+        await run(command, args, { cwd });
+    } catch (error) {
+        throw new SeedcordError(SeedcordErrorCode.CreateStepFailed, [[command, ...args].join(' '), reasonFrom(error)]);
+    }
+}

--- a/cli/create-seedcord/src/scaffold/exec.ts
+++ b/cli/create-seedcord/src/scaffold/exec.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import process from 'node:process';
 
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
@@ -8,13 +9,29 @@ import type { CommandRunner } from '@scaffold/scaffold';
 // an install logs hundreds of lines before the one that names the failure
 const KEPT_LINES = 12;
 
+// npm prefixes those lines with "npm error", pnpm and yarn with "ERR!"
+const NAMES_THE_CAUSE = /error|ERR!/i;
+
 // pnpm redraws its progress with carriage returns
 const LINE_BREAK = /[\r\n]+/;
-// one uncut chunk grew past node's max string length
-const MAX_LINE = 120;
+
+const PIPED_COLUMNS = 100;
+// clack indents captured output by three
+const GUTTER = 3;
+
+function lineWidth(): number {
+    return (process.stdout.columns > 0 ? process.stdout.columns : PIPED_COLUMNS) - GUTTER;
+}
+
+function failureLines(captured: string[]): string[] {
+    const named = captured.filter((line) => NAMES_THE_CAUSE.test(line));
+
+    return named.length > 0 ? named.slice(0, KEPT_LINES) : captured.slice(-KEPT_LINES);
+}
 
 export async function execRunner(...[command, args, cwd]: Parameters<CommandRunner>): Promise<void> {
     const spoken = [command, ...args].join(' ');
+    const width = lineWidth();
 
     return new Promise((resolve, reject) => {
         const child = spawn(command, args, { cwd });
@@ -22,7 +39,8 @@ export async function execRunner(...[command, args, cwd]: Parameters<CommandRunn
 
         const take = (chunk: Buffer): void => {
             for (const line of chunk.toString('utf8').split(LINE_BREAK)) {
-                const text = line.trim().slice(0, MAX_LINE);
+                // one uncut chunk grew past node's max string length
+                const text = line.trim().slice(0, width);
                 if (text === '') continue;
 
                 captured.push(text);
@@ -42,8 +60,8 @@ export async function execRunner(...[command, args, cwd]: Parameters<CommandRunn
                 return;
             }
 
-            const tail = captured.slice(-KEPT_LINES).join('\n');
-            reject(new SeedcordError(SeedcordErrorCode.CreateStepFailed, [spoken, tail || `exited with ${code}`]));
+            const shown = failureLines(captured).join('\n');
+            reject(new SeedcordError(SeedcordErrorCode.CreateStepFailed, [spoken, shown || `exited with ${code}`]));
         });
     });
 }

--- a/cli/create-seedcord/src/scaffold/exec.ts
+++ b/cli/create-seedcord/src/scaffold/exec.ts
@@ -1,26 +1,55 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
 import type { CommandRunner } from '@scaffold/scaffold';
 
-const run = promisify(execFile);
+// an install logs hundreds of lines before the one that names the failure
+const KEPT_LINES = 12;
 
-function reasonFrom(error: unknown): string {
-    if (typeof error === 'object' && error !== null && 'stderr' in error) {
-        const { stderr } = error;
-        if (typeof stderr === 'string' && stderr.trim() !== '') return stderr.trim();
-    }
+// pnpm redraws its progress with carriage returns
+const LINE_BREAK = /[\r\n]+/;
+// one uncut chunk grew past node's max string length
+const MAX_LINE = 120;
 
-    return Error.isError(error) ? error.message : String(error);
-}
+export async function execRunner(...[command, args, cwd, onLine]: Parameters<CommandRunner>): Promise<void> {
+    const spoken = [command, ...args].join(' ');
 
-export async function execRunner(...[command, args, cwd]: Parameters<CommandRunner>): Promise<void> {
-    try {
-        await run(command, args, { cwd });
-    } catch (error) {
-        throw new SeedcordError(SeedcordErrorCode.CreateStepFailed, [[command, ...args].join(' '), reasonFrom(error)]);
-    }
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, { cwd });
+        const captured: string[] = [];
+
+        const take = (chunk: Buffer): void => {
+            for (const line of chunk.toString('utf8').split(LINE_BREAK)) {
+                const text = line.trim().slice(0, MAX_LINE);
+                if (text === '') continue;
+
+                captured.push(text);
+
+                try {
+                    onLine?.(text);
+                } catch {
+                    // a throw inside a stream handler escapes this promise as an uncaught exception
+                }
+            }
+        };
+
+        child.stdout.on('data', take);
+        child.stderr.on('data', take);
+
+        child.on('error', (error) => {
+            reject(new SeedcordError(SeedcordErrorCode.CreateStepFailed, [spoken, error.message]));
+        });
+
+        child.on('close', (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+
+            const tail = captured.slice(-KEPT_LINES).join('\n');
+            reject(new SeedcordError(SeedcordErrorCode.CreateStepFailed, [spoken, tail || `exited with ${code}`]));
+        });
+    });
 }

--- a/cli/create-seedcord/src/scaffold/exec.ts
+++ b/cli/create-seedcord/src/scaffold/exec.ts
@@ -13,7 +13,7 @@ const LINE_BREAK = /[\r\n]+/;
 // one uncut chunk grew past node's max string length
 const MAX_LINE = 120;
 
-export async function execRunner(...[command, args, cwd, onLine]: Parameters<CommandRunner>): Promise<void> {
+export async function execRunner(...[command, args, cwd]: Parameters<CommandRunner>): Promise<void> {
     const spoken = [command, ...args].join(' ');
 
     return new Promise((resolve, reject) => {
@@ -26,12 +26,6 @@ export async function execRunner(...[command, args, cwd, onLine]: Parameters<Com
                 if (text === '') continue;
 
                 captured.push(text);
-
-                try {
-                    onLine?.(text);
-                } catch {
-                    // a throw inside a stream handler escapes this promise as an uncaught exception
-                }
             }
         };
 

--- a/cli/create-seedcord/src/scaffold/exec.ts
+++ b/cli/create-seedcord/src/scaffold/exec.ts
@@ -33,8 +33,11 @@ export async function execRunner(...[command, args, cwd]: Parameters<CommandRunn
     const spoken = [command, ...args].join(' ');
     const width = lineWidth();
 
+    // windows ships the package managers as .cmd shims
+    const shell = process.platform === 'win32';
+
     return new Promise((resolve, reject) => {
-        const child = spawn(command, args, { cwd });
+        const child = spawn(command, args, { cwd, shell });
         const captured: string[] = [];
 
         const take = (chunk: Buffer): void => {

--- a/cli/create-seedcord/src/scaffold/git.ts
+++ b/cli/create-seedcord/src/scaffold/git.ts
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+export interface GitProbe {
+    installed: boolean;
+    insideRepo: boolean;
+    userName: string | null;
+}
+
+export interface GitPlan {
+    init: boolean;
+    developerUsername: string;
+    notice: string | null;
+}
+
+// the framework's own default
+const PLACEHOLDER = 'the developer';
+
+const FALLBACK_TAIL = `Error cards will say "${PLACEHOLDER}" until you set notifications.developerUsername in src/bot.ts.`;
+const GIT_ABSENT = `git is not installed. ${FALLBACK_TAIL}`;
+const NAME_MISSING = `git reported no user.name. ${FALLBACK_TAIL}`;
+const ALREADY_REPO = 'this directory is already inside a git repo. Nothing was initialized.';
+
+function noticeFor(probe: GitProbe, wanted: boolean): string | null {
+    if (!probe.installed) return GIT_ABSENT;
+    if (probe.userName === null) return NAME_MISSING;
+    if (wanted && probe.insideRepo) return ALREADY_REPO;
+
+    return null;
+}
+
+export function gitPlanFrom(probe: GitProbe, wanted: boolean): GitPlan {
+    return {
+        init: wanted && probe.installed && !probe.insideRepo,
+        developerUsername: probe.userName ?? PLACEHOLDER,
+        notice: noticeFor(probe, wanted)
+    };
+}
+
+async function ask(args: string[], cwd: string): Promise<string | null> {
+    const result = await run('git', args, { cwd }).catch(() => null);
+    return result === null ? null : result.stdout.trim();
+}
+
+export async function probeGit(cwd: string): Promise<GitProbe> {
+    const version = await ask(['--version'], cwd);
+    if (version === null) return { installed: false, insideRepo: false, userName: null };
+
+    const [inside, userName] = await Promise.all([
+        ask(['rev-parse', '--is-inside-work-tree'], cwd),
+        ask(['config', 'user.name'], cwd)
+    ]);
+
+    return {
+        installed: true,
+        insideRepo: inside === 'true',
+        userName: userName === null || userName === '' ? null : userName
+    };
+}

--- a/cli/create-seedcord/src/scaffold/scaffold.ts
+++ b/cli/create-seedcord/src/scaffold/scaffold.ts
@@ -56,7 +56,11 @@ async function writeTree(target: string, files: { path: string; contents: string
 
 export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promise<ScaffoldResult> {
     const { existed } = await claimTarget(input.target);
-    const plan = gitPlanFrom(await probeGit(dirname(input.target)), input.git);
+
+    // execFile rejects when cwd does not exist
+    const parent = dirname(input.target);
+    await mkdir(parent, { recursive: true });
+    const plan = gitPlanFrom(await probeGit(parent), input.git);
 
     try {
         const context = buildContext(input.answers, {

--- a/cli/create-seedcord/src/scaffold/scaffold.ts
+++ b/cli/create-seedcord/src/scaffold/scaffold.ts
@@ -1,0 +1,93 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { addCommand, runPrefix } from '@cli/packageManager';
+import { gitPlanFrom, probeGit } from '@scaffold/git';
+import { claimTarget } from '@scaffold/target';
+import { buildContext } from '@template/context';
+import { renderTemplates } from '@template/render';
+
+import type { ScaffoldAnswers } from '@template/context';
+import type { AgentName } from 'package-manager-detector';
+
+export type CommandRunner = (command: string, args: string[], cwd: string) => Promise<void>;
+
+export interface ScaffoldInput {
+    target: string;
+    templatesRoot: string;
+    answers: ScaffoldAnswers;
+    agent: AgentName;
+    install: boolean;
+    git: boolean;
+}
+
+export interface ScaffoldResult {
+    installed: boolean;
+    committed: boolean;
+    gitNotice: string | null;
+}
+
+// @seedcord/tsconfig sets types: ['node'], and tsc fails outright without the package behind it
+const DEV_PACKAGES = [
+    '@seedcord/eslint-config',
+    '@seedcord/tsconfig',
+    '@types/node',
+    'prettier',
+    'seedcord',
+    // typescript-eslint 8 declares typescript >=4.8.4 <6.1.0, and typescript 7.0 ships no compiler api at all
+    'typescript@~6.0'
+];
+const SHARED_PACKAGES = ['@discordjs/builders', 'envapt'];
+
+function runtimePackages(isGateway: boolean): string[] {
+    const transport = isGateway ? ['@seedcord/gateway', 'discord.js'] : ['@seedcord/http'];
+    return [...transport, ...SHARED_PACKAGES];
+}
+
+async function writeTree(target: string, files: { path: string; contents: string }[]): Promise<void> {
+    for (const file of files) {
+        const destination = join(target, file.path);
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, file.contents, 'utf8');
+    }
+}
+
+export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promise<ScaffoldResult> {
+    const { existed } = await claimTarget(input.target);
+    const plan = gitPlanFrom(await probeGit(dirname(input.target)), input.git);
+
+    try {
+        const context = buildContext(input.answers, {
+            developerUsername: plan.developerUsername,
+            runCommand: runPrefix(input.agent)
+        });
+
+        await mkdir(input.target, { recursive: true });
+        await writeTree(input.target, await renderTemplates(input.templatesRoot, context));
+
+        if (input.install) {
+            const deps = addCommand(input.agent, runtimePackages(context.isGateway), false);
+            const dev = addCommand(input.agent, DEV_PACKAGES, true);
+
+            await run(deps.command, deps.args, input.target);
+            await run(dev.command, dev.args, input.target);
+
+            // format runs after install because prettier arrives with it
+            await run(input.agent, ['exec', 'prettier', '--write', '.'], input.target);
+            await run(input.agent, ['exec', 'seedcord', 'codegen'], input.target);
+        }
+
+        if (plan.init) {
+            await run('git', ['init'], input.target);
+            await run('git', ['add', '.'], input.target);
+            await run('git', ['commit', '-m', 'chore: create seedcord bot'], input.target);
+        }
+
+        return { installed: input.install, committed: plan.init, gitNotice: plan.notice };
+    } catch (error) {
+        await rm(input.target, { recursive: true, force: true });
+        if (existed) await mkdir(input.target, { recursive: true });
+
+        throw error;
+    }
+}

--- a/cli/create-seedcord/src/scaffold/scaffold.ts
+++ b/cli/create-seedcord/src/scaffold/scaffold.ts
@@ -7,10 +7,11 @@ import { claimTarget } from '@scaffold/target';
 import { buildContext } from '@template/context';
 import { renderTemplates } from '@template/render';
 
+import type { StepLogger, StepUi } from '@cli/steps';
 import type { ScaffoldAnswers } from '@template/context';
 import type { AgentName } from 'package-manager-detector';
 
-export type CommandRunner = (command: string, args: string[], cwd: string) => Promise<void>;
+export type CommandRunner = (command: string, args: string[], cwd: string, onLine?: StepLogger) => Promise<void>;
 
 export interface ScaffoldInput {
     target: string;
@@ -19,6 +20,7 @@ export interface ScaffoldInput {
     agent: AgentName;
     install: boolean;
     git: boolean;
+    steps: StepUi;
 }
 
 export interface ScaffoldResult {
@@ -27,14 +29,14 @@ export interface ScaffoldResult {
     gitNotice: string | null;
 }
 
-// @seedcord/tsconfig sets types: ['node'], and tsc fails outright without the package behind it
 const DEV_PACKAGES = [
     '@seedcord/eslint-config',
     '@seedcord/tsconfig',
+    // @seedcord/tsconfig sets types: ['node']
     '@types/node',
     'prettier',
     'seedcord',
-    // typescript-eslint 8 declares typescript >=4.8.4 <6.1.0, and typescript 7.0 ships no compiler api at all
+    // typescript-eslint 8 caps typescript below 6.1
     'typescript@~6.0'
 ];
 const SHARED_PACKAGES = ['@discordjs/builders', 'envapt'];
@@ -62,25 +64,47 @@ export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promis
             runCommand: runPrefix(input.agent)
         });
 
-        await mkdir(input.target, { recursive: true });
-        await writeTree(input.target, await renderTemplates(input.templatesRoot, context));
+        const { steps } = input;
+
+        await steps.run({ running: 'Writing files', done: 'Files written' }, async () => {
+            await mkdir(input.target, { recursive: true });
+            await writeTree(input.target, await renderTemplates(input.templatesRoot, context));
+        });
 
         if (input.install) {
             const deps = addCommand(input.agent, runtimePackages(context.isGateway), false);
             const dev = addCommand(input.agent, DEV_PACKAGES, true);
 
-            await run(deps.command, deps.args, input.target);
-            await run(dev.command, dev.args, input.target);
+            await steps.run(
+                { running: 'Installing dependencies', done: 'Dependencies installed', stream: true },
+                async (onLine) => {
+                    await run(deps.command, deps.args, input.target, onLine);
+                    await run(dev.command, dev.args, input.target, onLine);
+                }
+            );
 
-            // format runs after install because prettier arrives with it
-            await run(input.agent, ['exec', 'prettier', '--write', '.'], input.target);
-            await run(input.agent, ['exec', 'seedcord', 'codegen'], input.target);
+            // prettier is only on disk after the install above
+            await steps.run({ running: 'Formatting', done: 'Code formatted' }, () =>
+                run(input.agent, ['exec', 'prettier', '--write', '.'], input.target)
+            );
+
+            await steps.run({ running: 'Generating types', done: 'Types generated' }, () =>
+                run(input.agent, ['exec', 'seedcord', 'codegen'], input.target)
+            );
+        } else {
+            steps.skip('Dependencies installed');
+            steps.skip('Code formatted');
+            steps.skip('Types generated');
         }
 
         if (plan.init) {
-            await run('git', ['init'], input.target);
-            await run('git', ['add', '.'], input.target);
-            await run('git', ['commit', '-m', 'chore: create seedcord bot'], input.target);
+            await steps.run({ running: 'Setting up git', done: 'Committed' }, async () => {
+                await run('git', ['init'], input.target);
+                await run('git', ['add', '.'], input.target);
+                await run('git', ['commit', '-m', 'chore: create seedcord bot'], input.target);
+            });
+        } else {
+            steps.skip('Committed');
         }
 
         return { installed: input.install, committed: plan.init, gitNotice: plan.notice };

--- a/cli/create-seedcord/src/scaffold/scaffold.ts
+++ b/cli/create-seedcord/src/scaffold/scaffold.ts
@@ -7,11 +7,11 @@ import { claimTarget } from '@scaffold/target';
 import { buildContext } from '@template/context';
 import { renderTemplates } from '@template/render';
 
-import type { StepLogger, StepUi } from '@cli/steps';
+import type { StepUi } from '@cli/steps';
 import type { ScaffoldAnswers } from '@template/context';
 import type { AgentName } from 'package-manager-detector';
 
-export type CommandRunner = (command: string, args: string[], cwd: string, onLine?: StepLogger) => Promise<void>;
+export type CommandRunner = (command: string, args: string[], cwd: string) => Promise<void>;
 
 export interface ScaffoldInput {
     target: string;
@@ -75,13 +75,10 @@ export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promis
             const deps = addCommand(input.agent, runtimePackages(context.isGateway), false);
             const dev = addCommand(input.agent, DEV_PACKAGES, true);
 
-            await steps.run(
-                { running: 'Installing dependencies', done: 'Dependencies installed', stream: true },
-                async (onLine) => {
-                    await run(deps.command, deps.args, input.target, onLine);
-                    await run(dev.command, dev.args, input.target, onLine);
-                }
-            );
+            await steps.run({ running: 'Installing dependencies', done: 'Dependencies installed' }, async () => {
+                await run(deps.command, deps.args, input.target);
+                await run(dev.command, dev.args, input.target);
+            });
 
             // prettier is only on disk after the install above
             await steps.run({ running: 'Formatting', done: 'Code formatted' }, () =>

--- a/cli/create-seedcord/src/scaffold/scaffold.ts
+++ b/cli/create-seedcord/src/scaffold/scaffold.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
-import { addCommand, runPrefix } from '@cli/packageManager';
+import { addCommand, execCommand, runPrefix } from '@cli/packageManager';
 import { gitPlanFrom, probeGit } from '@scaffold/git';
 import { claimTarget } from '@scaffold/target';
 import { buildContext } from '@template/context';
@@ -54,6 +54,27 @@ async function writeTree(target: string, files: { path: string; contents: string
     }
 }
 
+async function runInstallSteps(input: ScaffoldInput, run: CommandRunner, isGateway: boolean): Promise<void> {
+    const { agent, steps, target } = input;
+
+    const deps = addCommand(agent, runtimePackages(isGateway), false);
+    const dev = addCommand(agent, DEV_PACKAGES, true);
+    const format = execCommand(agent, ['prettier', '--write', '.']);
+    const codegen = execCommand(agent, ['seedcord', 'codegen']);
+
+    await steps.run({ running: 'Installing dependencies', done: 'Dependencies installed' }, async () => {
+        await run(deps.command, deps.args, target);
+        await run(dev.command, dev.args, target);
+    });
+
+    // prettier is only on disk after the install above
+    await steps.run({ running: 'Formatting', done: 'Code formatted' }, () => run(format.command, format.args, target));
+
+    await steps.run({ running: 'Generating types', done: 'Types generated' }, () =>
+        run(codegen.command, codegen.args, target)
+    );
+}
+
 export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promise<ScaffoldResult> {
     const { existed } = await claimTarget(input.target);
 
@@ -76,22 +97,7 @@ export async function scaffold(input: ScaffoldInput, run: CommandRunner): Promis
         });
 
         if (input.install) {
-            const deps = addCommand(input.agent, runtimePackages(context.isGateway), false);
-            const dev = addCommand(input.agent, DEV_PACKAGES, true);
-
-            await steps.run({ running: 'Installing dependencies', done: 'Dependencies installed' }, async () => {
-                await run(deps.command, deps.args, input.target);
-                await run(dev.command, dev.args, input.target);
-            });
-
-            // prettier is only on disk after the install above
-            await steps.run({ running: 'Formatting', done: 'Code formatted' }, () =>
-                run(input.agent, ['exec', 'prettier', '--write', '.'], input.target)
-            );
-
-            await steps.run({ running: 'Generating types', done: 'Types generated' }, () =>
-                run(input.agent, ['exec', 'seedcord', 'codegen'], input.target)
-            );
+            await runInstallSteps(input, run, context.isGateway);
         } else {
             steps.skip('Dependencies installed');
             steps.skip('Code formatted');

--- a/cli/create-seedcord/src/scaffold/target.ts
+++ b/cli/create-seedcord/src/scaffold/target.ts
@@ -3,14 +3,14 @@ import { readdir, stat } from 'node:fs/promises';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
-// an empty target is what lets the cleanup remove everything it finds
-export async function claimTarget(target: string): Promise<void> {
+// scaffold deletes this directory when a step fails
+export async function claimTarget(target: string): Promise<{ existed: boolean }> {
     const found = await stat(target).catch(() => null);
-    if (found === null) return;
+    if (found === null) return { existed: false };
 
     if (found.isDirectory()) {
         const entries = await readdir(target);
-        if (entries.length === 0) return;
+        if (entries.length === 0) return { existed: true };
     }
 
     throw new SeedcordError(SeedcordErrorCode.CreateTargetNotEmpty, [target]);

--- a/cli/create-seedcord/src/scaffold/target.ts
+++ b/cli/create-seedcord/src/scaffold/target.ts
@@ -1,0 +1,17 @@
+import { readdir, stat } from 'node:fs/promises';
+
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
+// an empty target is what lets the cleanup remove everything it finds
+export async function claimTarget(target: string): Promise<void> {
+    const found = await stat(target).catch(() => null);
+    if (found === null) return;
+
+    if (found.isDirectory()) {
+        const entries = await readdir(target);
+        if (entries.length === 0) return;
+    }
+
+    throw new SeedcordError(SeedcordErrorCode.CreateTargetNotEmpty, [target]);
+}

--- a/cli/create-seedcord/src/template/context.ts
+++ b/cli/create-seedcord/src/template/context.ts
@@ -8,13 +8,16 @@ import type { Answers } from '../interview/types';
 export type ScaffoldAnswers = Partial<Answers> &
     Pick<Answers, 'botColor' | 'directory' | 'language' | 'token' | 'transport'>;
 
+// the three that make messageCreate fire
+const MESSAGE_CAPABILITIES = new Set(['guild-messages', 'message-text', 'direct-messages']);
+
 export interface TemplateContext {
     projectName: string;
     isGateway: boolean;
     transportPackage: string;
     intents: string[];
     partials: string[];
-    hasEvents: boolean;
+    hasMessages: boolean;
     token: string;
     publicKey: string;
     botColor: string;
@@ -35,7 +38,7 @@ export function buildContext(
         transportPackage: isGateway ? '@seedcord/gateway' : '@seedcord/http',
         intents: isGateway ? intentsFor(capabilities) : [],
         partials: isGateway ? partialsFor(capabilities) : [],
-        hasEvents: capabilities.length > 0,
+        hasMessages: capabilities.some((id) => MESSAGE_CAPABILITIES.has(id)),
         token: answers.token,
         publicKey: answers.publicKey ?? '',
         botColor: answers.botColor,

--- a/cli/create-seedcord/src/template/context.ts
+++ b/cli/create-seedcord/src/template/context.ts
@@ -1,8 +1,8 @@
 import { basename } from 'node:path';
 
-import { intentsFor, partialsFor } from '../interview/capabilities';
+import { intentsFor, partialsFor } from '@interview/capabilities';
 
-import type { Answers } from '../interview/types';
+import type { Answers } from '@interview/types';
 
 // capabilities and publicKey each belong to one transport, and runFlow leaves the other unset
 export type ScaffoldAnswers = Partial<Answers> &

--- a/cli/create-seedcord/src/template/context.ts
+++ b/cli/create-seedcord/src/template/context.ts
@@ -1,5 +1,8 @@
 import { basename } from 'node:path';
 
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+
 import { intentsFor, partialsFor } from '@interview/capabilities';
 
 import type { Answers } from '@interview/types';
@@ -23,6 +26,19 @@ export interface TemplateContext {
     botColor: string;
     developerUsername: string;
     pm: { run: string };
+}
+
+const REQUIRED = ['directory', 'language', 'transport', 'token', 'botColor'] as const;
+
+// runFlow either fills these or throws
+export function requireScaffoldAnswers(answers: Partial<Answers>): ScaffoldAnswers {
+    for (const key of REQUIRED) {
+        if (answers[key] === undefined) {
+            throw new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, [key, 'No answer was collected.']);
+        }
+    }
+
+    return answers as ScaffoldAnswers;
 }
 
 export function buildContext(

--- a/cli/create-seedcord/src/template/context.ts
+++ b/cli/create-seedcord/src/template/context.ts
@@ -1,0 +1,45 @@
+import { basename } from 'node:path';
+
+import { intentsFor, partialsFor } from '../interview/capabilities';
+
+import type { Answers } from '../interview/types';
+
+// capabilities and publicKey each belong to one transport, and runFlow leaves the other unset
+export type ScaffoldAnswers = Partial<Answers> &
+    Pick<Answers, 'botColor' | 'directory' | 'language' | 'token' | 'transport'>;
+
+export interface TemplateContext {
+    projectName: string;
+    isGateway: boolean;
+    transportPackage: string;
+    intents: string[];
+    partials: string[];
+    hasEvents: boolean;
+    token: string;
+    publicKey: string;
+    botColor: string;
+    developerUsername: string;
+    pm: { run: string };
+}
+
+export function buildContext(
+    answers: ScaffoldAnswers,
+    extras: { developerUsername: string; runCommand: string }
+): TemplateContext {
+    const isGateway = answers.transport === 'gateway';
+    const capabilities = isGateway ? (answers.capabilities ?? []) : [];
+
+    return {
+        projectName: basename(answers.directory),
+        isGateway,
+        transportPackage: isGateway ? '@seedcord/gateway' : '@seedcord/http',
+        intents: isGateway ? intentsFor(capabilities) : [],
+        partials: isGateway ? partialsFor(capabilities) : [],
+        hasEvents: capabilities.length > 0,
+        token: answers.token,
+        publicKey: answers.publicKey ?? '',
+        botColor: answers.botColor,
+        developerUsername: extras.developerUsername,
+        pm: { run: extras.runCommand }
+    };
+}

--- a/cli/create-seedcord/src/template/render.ts
+++ b/cli/create-seedcord/src/template/render.ts
@@ -1,0 +1,50 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join, posix, relative, sep } from 'node:path';
+
+import Handlebars from 'handlebars';
+
+import type { TemplateContext } from './context';
+
+export interface RenderedFile {
+    path: string;
+    contents: string;
+}
+
+// npm drops a literal .gitignore from a tarball, whatever the files list says
+const DOTTED = new Set(['env', 'gitignore', 'prettierignore']);
+
+function targetPath(templateRelative: string): string {
+    const parts = templateRelative.split(sep);
+    const name = parts.pop()?.replace(/\.hbs$/, '') ?? '';
+
+    return posix.join(...parts, DOTTED.has(name) ? `.${name}` : name);
+}
+
+async function templateFiles(root: string, directory: string): Promise<string[]> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const found = await Promise.all(
+        entries.map(async (entry) => {
+            const full = join(directory, entry.name);
+            if (entry.isDirectory()) return templateFiles(root, full);
+            return entry.name.endsWith('.hbs') ? [relative(root, full)] : [];
+        })
+    );
+
+    return found.flat();
+}
+
+export async function renderTemplates(templatesRoot: string, context: TemplateContext): Promise<RenderedFile[]> {
+    const sources = await templateFiles(templatesRoot, templatesRoot);
+
+    return Promise.all(
+        sources.map(async (source) => {
+            const raw = await readFile(join(templatesRoot, source), 'utf8');
+
+            return {
+                path: targetPath(source),
+                // every template is code, and escaping would mangle an apostrophe in a name
+                contents: Handlebars.compile(raw, { noEscape: true })(context)
+            };
+        })
+    );
+}

--- a/cli/create-seedcord/src/template/render.ts
+++ b/cli/create-seedcord/src/template/render.ts
@@ -36,7 +36,7 @@ async function templateFiles(root: string, directory: string): Promise<string[]>
 export async function renderTemplates(templatesRoot: string, context: TemplateContext): Promise<RenderedFile[]> {
     const sources = await templateFiles(templatesRoot, templatesRoot);
 
-    return Promise.all(
+    const rendered = await Promise.all(
         sources.map(async (source) => {
             const raw = await readFile(join(templatesRoot, source), 'utf8');
 
@@ -47,4 +47,7 @@ export async function renderTemplates(templatesRoot: string, context: TemplateCo
             };
         })
     );
+
+    // a template that wraps its whole body in a conditional writes no file when that is false
+    return rendered.filter((file) => file.contents.trim() !== '');
 }

--- a/cli/create-seedcord/templates/README.md.hbs
+++ b/cli/create-seedcord/templates/README.md.hbs
@@ -51,8 +51,8 @@ The two webhook keys take Discord webhook URLs. Set them to get error reports po
 
 - `src/commands/` holds command definitions, one class per command.
 - `src/handlers/` holds the code that runs when someone uses one.
-{{#if hasEvents}}
-- `src/events/` holds event handlers for the things you said your bot reacts to.
+{{#if isGateway}}
+- `src/events/` holds event handlers for the things happening in a server.
 {{/if}}
 - `src/bot.ts` is the config.
 

--- a/cli/create-seedcord/templates/package.json.hbs
+++ b/cli/create-seedcord/templates/package.json.hbs
@@ -15,22 +15,5 @@
         "lint:fix": "eslint 'src/**/*.ts' --fix --cache",
         "fmt": "prettier --write 'src/**/*.{ts,json,md}' --cache",
         "tc": "tsc --noEmit"
-    },
-    "dependencies": {
-        "@discordjs/builders": "{{ versions.builders }}",
-{{#if isGateway}}
-        "@seedcord/gateway": "{{ versions.gateway }}",
-        "discord.js": "{{ versions.discordjs }}",
-{{else}}
-        "@seedcord/http": "{{ versions.http }}",
-{{/if}}
-        "envapt": "{{ versions.envapt }}"
-    },
-    "devDependencies": {
-        "@seedcord/eslint-config": "{{ versions.eslintConfig }}",
-        "@seedcord/tsconfig": "{{ versions.tsconfig }}",
-        "prettier": "{{ versions.prettier }}",
-        "seedcord": "{{ versions.cli }}",
-        "typescript": "{{ versions.typescript }}"
     }
 }

--- a/cli/create-seedcord/templates/prettier.config.mjs.hbs
+++ b/cli/create-seedcord/templates/prettier.config.mjs.hbs
@@ -1,3 +1,3 @@
-import { PRETTIER_CONFIG } from '@seedcord/eslint-config';
+import { PRETTIER_CONFIG } from '@seedcord/eslint-config/prettier';
 
 export default PRETTIER_CONFIG;

--- a/cli/create-seedcord/templates/src/bot.ts.hbs
+++ b/cli/create-seedcord/templates/src/bot.ts.hbs
@@ -29,11 +29,7 @@ export const seedcord = new Seedcord({
             path: resolve(import.meta.dirname, './commands')
         }{{#if isGateway}},
         events: {
-{{#if hasEvents}}
             path: resolve(import.meta.dirname, './events')
-{{else}}
-            path: null
-{{/if}}
         }{{/if}}
     },
     subscribers: {

--- a/cli/create-seedcord/templates/src/events/Mentioned.ts.hbs
+++ b/cli/create-seedcord/templates/src/events/Mentioned.ts.hbs
@@ -1,0 +1,18 @@
+{{#if hasMessages}}
+import { EventHandler, Gated, IgnoreBots, RegisterEvent } from '{{ transportPackage }}';
+import { Events } from 'discord.js';
+
+@Gated(IgnoreBots)
+@RegisterEvent([Events.MessageCreate])
+export class Mentioned extends EventHandler<Events.MessageCreate> {
+    public async execute(): Promise<void> {
+        const [message] = this.event;
+        if (!message.inGuild()) return;
+
+        // discord sends the content of a message that mentions your app without the privileged intent
+        if (!message.mentions.users.has(message.client.user.id)) return;
+
+        await message.reply(`hey ${message.author.displayName}`);
+    }
+}
+{{/if}}

--- a/cli/create-seedcord/templates/src/events/Ready.ts.hbs
+++ b/cli/create-seedcord/templates/src/events/Ready.ts.hbs
@@ -1,0 +1,16 @@
+{{#if isGateway}}
+{{#unless hasMessages}}
+import { EventHandler, RegisterEvent } from '{{ transportPackage }}';
+import { Events } from 'discord.js';
+
+@RegisterEvent([Events.ClientReady, { frequency: 'once' }])
+export class Ready extends EventHandler<Events.ClientReady> {
+    public async execute(): Promise<void> {
+        const [client] = this.event;
+        const application = await client.application.fetch();
+
+        this.logger.info(`${application.name} is in ${client.guilds.cache.size} servers`);
+    }
+}
+{{/unless}}
+{{/if}}

--- a/cli/create-seedcord/tests/cli/invite.test.ts
+++ b/cli/create-seedcord/tests/cli/invite.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { inviteUrl } from '@cli/invite';
+
+function tokenFor(applicationId: string): string {
+    return `${Buffer.from(applicationId, 'utf8').toString('base64url')}.bbbbbb.${'c'.repeat(38)}`;
+}
+
+describe('inviteUrl', () => {
+    it('reads the application id out of the first token part', () => {
+        expect(inviteUrl(tokenFor('123456789012345678'))).toContain('client_id=123456789012345678');
+    });
+
+    it('takes an id that needed base64 padding Discord strips', () => {
+        expect(inviteUrl(tokenFor('1234567890123456789'))).toContain('client_id=1234567890123456789');
+    });
+
+    it('carries the id alone, leaving the scopes to the app dashboard', () => {
+        expect(inviteUrl(tokenFor('123456789012345678'))).toBe(
+            'https://discord.com/oauth2/authorize?client_id=123456789012345678'
+        );
+    });
+
+    it('says nothing when the first part decodes to something other than an id', () => {
+        expect(inviteUrl(`${'a'.repeat(26)}.bbbbbb.${'c'.repeat(38)}`)).toBeNull();
+    });
+
+    it('says nothing when the id is too short to be a snowflake', () => {
+        expect(inviteUrl(tokenFor('1234'))).toBeNull();
+    });
+
+    it('says nothing for a value with no parts to read', () => {
+        expect(inviteUrl('')).toBeNull();
+    });
+});

--- a/cli/create-seedcord/tests/cli/packageManager.test.ts
+++ b/cli/create-seedcord/tests/cli/packageManager.test.ts
@@ -2,7 +2,7 @@ import process from 'node:process';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { addCommand, runPrefix, runningAgent } from '@cli/packageManager';
+import { addCommand, execCommand, runPrefix, runningAgent } from '@cli/packageManager';
 
 const original = process.env.npm_config_user_agent;
 
@@ -54,5 +54,17 @@ describe('addCommand', () => {
 
     it('keeps every package in the order it was given', () => {
         expect(addCommand('pnpm', ['a', 'b', 'c'], false).args).toEqual(['add', 'a', 'b', 'c']);
+    });
+});
+
+describe('execCommand', () => {
+    it('spells running a local binary the way each manager does', () => {
+        expect(execCommand('pnpm', ['prettier'])).toEqual({ command: 'pnpm', args: ['exec', 'prettier'] });
+        expect(execCommand('npm', ['prettier'])).toEqual({ command: 'npx', args: ['prettier'] });
+        expect(execCommand('bun', ['prettier'])).toEqual({ command: 'bun', args: ['x', 'prettier'] });
+    });
+
+    it('keeps the arguments after the binary name', () => {
+        expect(execCommand('pnpm', ['prettier', '--write', '.']).args).toEqual(['exec', 'prettier', '--write', '.']);
     });
 });

--- a/cli/create-seedcord/tests/cli/packageManager.test.ts
+++ b/cli/create-seedcord/tests/cli/packageManager.test.ts
@@ -1,32 +1,38 @@
 import process from 'node:process';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { addCommand, execCommand, runPrefix, runningAgent } from '@cli/packageManager';
 
-const original = process.env.npm_config_user_agent;
-
 afterEach(() => {
-    process.env.npm_config_user_agent = original;
+    vi.unstubAllEnvs();
 });
 
 describe('runningAgent', () => {
     it('reads the manager npm and friends announce', () => {
-        process.env.npm_config_user_agent = 'pnpm/11.6.0 npm/? node/v25.9.0 darwin arm64';
+        vi.stubEnv('npm_config_user_agent', 'pnpm/11.6.0 npm/? node/v25.9.0 darwin arm64');
         expect(runningAgent()).toBe('pnpm');
 
-        process.env.npm_config_user_agent = 'bun/1.3.0 npm/? node/v25.9.0 darwin arm64';
+        vi.stubEnv('npm_config_user_agent', 'bun/1.3.0 npm/? node/v25.9.0 darwin arm64');
         expect(runningAgent()).toBe('bun');
     });
 
     it('falls back to npm when the variable is missing', () => {
-        delete process.env.npm_config_user_agent;
+        vi.stubEnv('npm_config_user_agent', undefined);
         expect(runningAgent()).toBe('npm');
     });
 
     it('falls back to npm for a manager it does not know', () => {
-        process.env.npm_config_user_agent = 'quackpm/1.0.0 node/v25.9.0';
+        vi.stubEnv('npm_config_user_agent', 'quackpm/1.0.0 node/v25.9.0');
         expect(runningAgent()).toBe('npm');
+    });
+
+    it('leaves the environment as it found it', () => {
+        const before = process.env.npm_config_user_agent;
+        vi.stubEnv('npm_config_user_agent', 'quackpm/1.0.0');
+        vi.unstubAllEnvs();
+
+        expect(process.env.npm_config_user_agent).toBe(before);
     });
 });
 

--- a/cli/create-seedcord/tests/cli/packageManager.test.ts
+++ b/cli/create-seedcord/tests/cli/packageManager.test.ts
@@ -1,0 +1,58 @@
+import process from 'node:process';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { addCommand, runPrefix, runningAgent } from '@src/cli/packageManager';
+
+const original = process.env.npm_config_user_agent;
+
+afterEach(() => {
+    process.env.npm_config_user_agent = original;
+});
+
+describe('runningAgent', () => {
+    it('reads the manager npm and friends announce', () => {
+        process.env.npm_config_user_agent = 'pnpm/11.6.0 npm/? node/v25.9.0 darwin arm64';
+        expect(runningAgent()).toBe('pnpm');
+
+        process.env.npm_config_user_agent = 'bun/1.3.0 npm/? node/v25.9.0 darwin arm64';
+        expect(runningAgent()).toBe('bun');
+    });
+
+    it('falls back to npm when the variable is missing', () => {
+        delete process.env.npm_config_user_agent;
+        expect(runningAgent()).toBe('npm');
+    });
+
+    it('falls back to npm for a manager it does not know', () => {
+        process.env.npm_config_user_agent = 'quackpm/1.0.0 node/v25.9.0';
+        expect(runningAgent()).toBe('npm');
+    });
+});
+
+describe('runPrefix', () => {
+    it('keeps run in front of the script name', () => {
+        expect(runPrefix('npm')).toBe('npm run');
+        expect(runPrefix('pnpm')).toBe('pnpm run');
+        expect(runPrefix('yarn')).toBe('yarn run');
+        expect(runPrefix('bun')).toBe('bun run');
+    });
+});
+
+describe('addCommand', () => {
+    it('uses the verb each manager expects', () => {
+        expect(addCommand('npm', ['discord.js'], false)).toEqual({ command: 'npm', args: ['i', 'discord.js'] });
+        expect(addCommand('pnpm', ['discord.js'], false)).toEqual({ command: 'pnpm', args: ['add', 'discord.js'] });
+    });
+
+    it('passes -D for a dev dependency', () => {
+        expect(addCommand('pnpm', ['typescript'], true)).toEqual({
+            command: 'pnpm',
+            args: ['add', '-D', 'typescript']
+        });
+    });
+
+    it('keeps every package in the order it was given', () => {
+        expect(addCommand('pnpm', ['a', 'b', 'c'], false).args).toEqual(['add', 'a', 'b', 'c']);
+    });
+});

--- a/cli/create-seedcord/tests/cli/packageManager.test.ts
+++ b/cli/create-seedcord/tests/cli/packageManager.test.ts
@@ -2,7 +2,7 @@ import process from 'node:process';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { addCommand, runPrefix, runningAgent } from '@src/cli/packageManager';
+import { addCommand, runPrefix, runningAgent } from '@cli/packageManager';
 
 const original = process.env.npm_config_user_agent;
 

--- a/cli/create-seedcord/tests/cli/parseInput.test.ts
+++ b/cli/create-seedcord/tests/cli/parseInput.test.ts
@@ -1,0 +1,89 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, expect, it } from 'vitest';
+
+import { parseInput } from '@src/cli/parseInput';
+
+function thrownBy(run: () => unknown): unknown {
+    try {
+        run();
+    } catch (error) {
+        return error;
+    }
+
+    return undefined;
+}
+
+describe('parseInput', () => {
+    it('reads every step flag into its answer', () => {
+        const { supplied } = parseInput([
+            '--dir',
+            'my-bot',
+            '--transport',
+            'http',
+            '--token',
+            'aaa.bbb.ccc',
+            '--public-key',
+            'a'.repeat(64),
+            '--color',
+            'Blurple'
+        ]);
+
+        expect(supplied).toEqual({
+            directory: 'my-bot',
+            transport: 'http',
+            token: 'aaa.bbb.ccc',
+            publicKey: 'a'.repeat(64),
+            botColor: 'Blurple'
+        });
+    });
+
+    it('takes the directory from a bare argument', () => {
+        expect(parseInput(['my-bot']).supplied.directory).toBe('my-bot');
+    });
+
+    it('rejects a directory given as both an argument and a flag', () => {
+        const thrown = thrownBy(() => parseInput(['my-bot', '--dir', 'other']));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateInvalidAnswer)).toBe(true);
+    });
+
+    it('accepts the same directory twice', () => {
+        expect(parseInput(['my-bot', '--dir', 'my-bot']).supplied.directory).toBe('my-bot');
+    });
+
+    it('installs and runs git unless told otherwise', () => {
+        const { install, git } = parseInput([]);
+
+        expect(install).toBe(true);
+        expect(git).toBe(true);
+    });
+
+    it('turns each step off through its own flag', () => {
+        expect(parseInput(['--no-install']).install).toBe(false);
+        expect(parseInput(['--no-git']).git).toBe(false);
+    });
+
+    it('reads the help flag under both spellings', () => {
+        expect(parseInput(['--help']).help).toBe(true);
+        expect(parseInput(['-h']).help).toBe(true);
+    });
+
+    it('names an unknown flag and points at the help', () => {
+        const thrown = thrownBy(() => parseInput(['--transpor', 'http']));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateBadUsage)).toBe(true);
+        expect((thrown as Error).message).toContain('--help');
+    });
+
+    it('rejects more than one bare argument', () => {
+        const thrown = thrownBy(() => parseInput(['my-bot', 'other-bot']));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateBadUsage)).toBe(true);
+    });
+
+    it('still rejects a flag value the step refuses', () => {
+        const thrown = thrownBy(() => parseInput(['--transport', 'websocket']));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateInvalidAnswer)).toBe(true);
+    });
+});

--- a/cli/create-seedcord/tests/cli/parseInput.test.ts
+++ b/cli/create-seedcord/tests/cli/parseInput.test.ts
@@ -1,7 +1,9 @@
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it } from 'vitest';
 
-import { parseInput } from '@cli/parseInput';
+import { parseInput, wantsHelp } from '@cli/parseInput';
+
+const TOKEN = `${'a'.repeat(26)}.${'b'.repeat(6)}.${'c'.repeat(38)}`;
 
 function thrownBy(run: () => unknown): unknown {
     try {
@@ -21,7 +23,7 @@ describe('parseInput', () => {
             '--transport',
             'http',
             '--token',
-            'aaa.bbb.ccc',
+            TOKEN,
             '--public-key',
             'a'.repeat(64),
             '--color',
@@ -31,7 +33,7 @@ describe('parseInput', () => {
         expect(supplied).toEqual({
             directory: 'my-bot',
             transport: 'http',
-            token: 'aaa.bbb.ccc',
+            token: TOKEN,
             publicKey: 'a'.repeat(64),
             botColor: 'Blurple'
         });
@@ -63,11 +65,6 @@ describe('parseInput', () => {
         expect(parseInput(['--no-git']).git).toBe(false);
     });
 
-    it('reads the help flag under both spellings', () => {
-        expect(parseInput(['--help']).help).toBe(true);
-        expect(parseInput(['-h']).help).toBe(true);
-    });
-
     it('names an unknown flag and points at the help', () => {
         const thrown = thrownBy(() => parseInput(['--transpor', 'http']));
 
@@ -85,5 +82,24 @@ describe('parseInput', () => {
         const thrown = thrownBy(() => parseInput(['--transport', 'websocket']));
 
         expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateInvalidAnswer)).toBe(true);
+    });
+});
+
+describe('wantsHelp', () => {
+    it('reads the flag under both spellings', () => {
+        expect(wantsHelp(['--help'])).toBe(true);
+        expect(wantsHelp(['-h'])).toBe(true);
+    });
+
+    it('reads it alongside other flags', () => {
+        expect(wantsHelp(['my-bot', '--transport', 'http', '--help'])).toBe(true);
+    });
+
+    it('answers without parsing, so a bad flag still reaches the help', () => {
+        expect(wantsHelp(['--transpor', 'http', '--help'])).toBe(true);
+    });
+
+    it('is false for a run that asked for none', () => {
+        expect(wantsHelp(['my-bot', '--no-git'])).toBe(false);
     });
 });

--- a/cli/create-seedcord/tests/cli/parseInput.test.ts
+++ b/cli/create-seedcord/tests/cli/parseInput.test.ts
@@ -1,7 +1,7 @@
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it } from 'vitest';
 
-import { parseInput } from '@src/cli/parseInput';
+import { parseInput } from '@cli/parseInput';
 
 function thrownBy(run: () => unknown): unknown {
     try {

--- a/cli/create-seedcord/tests/cli/reportFailure.test.ts
+++ b/cli/create-seedcord/tests/cli/reportFailure.test.ts
@@ -4,44 +4,47 @@ import { describe, expect, it } from 'vitest';
 
 import { reportFailure } from '@cli/reportFailure';
 
+const THROWN = [
+    new SeedcordError(SeedcordErrorCode.CreateCancelled),
+    new SeedcordError(SeedcordErrorCode.CreateTargetNotEmpty, ['my-bot']),
+    new SeedcordError(SeedcordErrorCode.CreateStepFailed, ['pnpm add', 'ECONNREFUSED']),
+    new Error('boom'),
+    'a string',
+    undefined
+];
+
 describe('reportFailure', () => {
-    it('exits a cancel successfully and still says something', () => {
+    it('exits a cancel successfully and prints no error above the closing line', () => {
         const failure = reportFailure(new SeedcordError(SeedcordErrorCode.CreateCancelled));
 
-        expect(failure).toEqual({ code: 0, cancelled: true, message: 'Nothing was written.' });
+        expect(failure).toEqual({ code: 0, message: null, closing: 'Nothing was written.' });
     });
 
     it('prints the message of any other coded error', () => {
         const error = new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, ['dir', 'Nope.']);
 
-        expect(reportFailure(error)).toEqual({ code: 1, cancelled: false, message: '--dir: Nope.' });
+        expect(reportFailure(error)).toEqual({ code: 1, message: '--dir: Nope.', closing: 'Nothing was created.' });
+    });
+
+    it('says the tree was removed when a scaffold step failed', () => {
+        const error = new SeedcordError(SeedcordErrorCode.CreateStepFailed, ['pnpm add', 'ECONNREFUSED']);
+
+        expect(reportFailure(error).closing).toBe('Nothing was kept.');
     });
 
     it('prints whatever an uncoded throw carries', () => {
-        expect(reportFailure(new Error('the disk went away'))).toEqual({
-            code: 1,
-            cancelled: false,
-            message: 'the disk went away'
-        });
+        expect(reportFailure(new Error('the disk went away')).message).toBe('the disk went away');
     });
 
     it('survives a throw that is not an error at all', () => {
-        expect(reportFailure('just a string')).toEqual({
-            code: 1,
-            cancelled: false,
-            message: 'just a string'
-        });
+        expect(reportFailure('just a string').message).toBe('just a string');
     });
 
-    it('never returns an empty message, since every path prints one', () => {
-        const thrown = [
-            new SeedcordError(SeedcordErrorCode.CreateCancelled),
-            new SeedcordError(SeedcordErrorCode.CreateTargetNotEmpty, ['my-bot']),
-            new Error('boom'),
-            'a string',
-            undefined
-        ];
+    it('closes the clack frame on every path', () => {
+        expect(THROWN.map((error) => reportFailure(error).closing).filter((line) => line === '')).toEqual([]);
+    });
 
-        expect(thrown.map((error) => reportFailure(error).message).filter((message) => message === '')).toEqual([]);
+    it('never returns an empty message, since every path that has one prints it', () => {
+        expect(THROWN.map((error) => reportFailure(error).message).filter((message) => message === '')).toEqual([]);
     });
 });

--- a/cli/create-seedcord/tests/cli/reportFailure.test.ts
+++ b/cli/create-seedcord/tests/cli/reportFailure.test.ts
@@ -5,27 +5,43 @@ import { describe, expect, it } from 'vitest';
 import { reportFailure } from '@cli/reportFailure';
 
 describe('reportFailure', () => {
-    it('leaves a cancel silent and successful', () => {
-        expect(reportFailure(new SeedcordError(SeedcordErrorCode.CreateCancelled))).toEqual({
-            code: 0,
-            message: null
-        });
+    it('exits a cancel successfully and still says something', () => {
+        const failure = reportFailure(new SeedcordError(SeedcordErrorCode.CreateCancelled));
+
+        expect(failure).toEqual({ code: 0, cancelled: true, message: 'Nothing was written.' });
     });
 
     it('prints the message of any other coded error', () => {
         const error = new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, ['dir', 'Nope.']);
 
-        expect(reportFailure(error)).toEqual({ code: 1, message: '--dir: Nope.' });
+        expect(reportFailure(error)).toEqual({ code: 1, cancelled: false, message: '--dir: Nope.' });
     });
 
     it('prints whatever an uncoded throw carries', () => {
         expect(reportFailure(new Error('the disk went away'))).toEqual({
             code: 1,
+            cancelled: false,
             message: 'the disk went away'
         });
     });
 
     it('survives a throw that is not an error at all', () => {
-        expect(reportFailure('just a string')).toEqual({ code: 1, message: 'just a string' });
+        expect(reportFailure('just a string')).toEqual({
+            code: 1,
+            cancelled: false,
+            message: 'just a string'
+        });
+    });
+
+    it('never returns an empty message, since every path prints one', () => {
+        const thrown = [
+            new SeedcordError(SeedcordErrorCode.CreateCancelled),
+            new SeedcordError(SeedcordErrorCode.CreateTargetNotEmpty, ['my-bot']),
+            new Error('boom'),
+            'a string',
+            undefined
+        ];
+
+        expect(thrown.map((error) => reportFailure(error).message).filter((message) => message === '')).toEqual([]);
     });
 });

--- a/cli/create-seedcord/tests/cli/reportFailure.test.ts
+++ b/cli/create-seedcord/tests/cli/reportFailure.test.ts
@@ -1,0 +1,31 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+import { describe, expect, it } from 'vitest';
+
+import { reportFailure } from '@src/cli/reportFailure';
+
+describe('reportFailure', () => {
+    it('leaves a cancel silent and successful', () => {
+        expect(reportFailure(new SeedcordError(SeedcordErrorCode.CreateCancelled))).toEqual({
+            code: 0,
+            message: null
+        });
+    });
+
+    it('prints the message of any other coded error', () => {
+        const error = new SeedcordError(SeedcordErrorCode.CreateInvalidAnswer, ['dir', 'Nope.']);
+
+        expect(reportFailure(error)).toEqual({ code: 1, message: '--dir: Nope.' });
+    });
+
+    it('prints whatever an uncoded throw carries', () => {
+        expect(reportFailure(new Error('the disk went away'))).toEqual({
+            code: 1,
+            message: 'the disk went away'
+        });
+    });
+
+    it('survives a throw that is not an error at all', () => {
+        expect(reportFailure('just a string')).toEqual({ code: 1, message: 'just a string' });
+    });
+});

--- a/cli/create-seedcord/tests/cli/reportFailure.test.ts
+++ b/cli/create-seedcord/tests/cli/reportFailure.test.ts
@@ -2,7 +2,7 @@ import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { describe, expect, it } from 'vitest';
 
-import { reportFailure } from '@src/cli/reportFailure';
+import { reportFailure } from '@cli/reportFailure';
 
 describe('reportFailure', () => {
     it('leaves a cancel silent and successful', () => {

--- a/cli/create-seedcord/tests/cli/summary.test.ts
+++ b/cli/create-seedcord/tests/cli/summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { dashboardToggles, nextSteps, reproducingCommand } from '@cli/summary';
+import { STEPS } from '@interview/steps';
 
 import type { ScaffoldAnswers } from '@template/context';
 
@@ -88,9 +89,20 @@ describe('reproducingCommand', () => {
         const command = reproducingCommand(GATEWAY, 'pnpm');
 
         expect(command).toContain('my-bot');
+        expect(command).toContain('--language typescript');
         expect(command).toContain('--transport gateway');
         expect(command).toContain('--capabilities guild-messages');
         expect(command).toContain('--color Blurple');
+    });
+
+    it('answers every step a re-run would ask', () => {
+        const command = reproducingCommand(HTTP, 'pnpm');
+        // the directory goes in as the positional argument
+        const flagged = STEPS.filter((step) => step.flag.name !== 'dir' && step.skip?.(HTTP) !== true);
+
+        for (const step of flagged) {
+            expect(command).toContain(`--${step.flag.name} `);
+        }
     });
 
     it('leaves capabilities out on http', () => {
@@ -106,6 +118,6 @@ describe('reproducingCommand', () => {
     });
 
     it('leaves the double dash out for every other manager', () => {
-        expect(reproducingCommand(GATEWAY, 'pnpm')).toContain('pnpm create seedcord my-bot --transport');
+        expect(reproducingCommand(GATEWAY, 'pnpm')).not.toContain(' -- ');
     });
 });

--- a/cli/create-seedcord/tests/cli/summary.test.ts
+++ b/cli/create-seedcord/tests/cli/summary.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { dashboardToggles, nextSteps, reproducingCommand } from '@cli/summary';
+
+import type { ScaffoldAnswers } from '@template/context';
+
+const GATEWAY: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'gateway',
+    capabilities: ['guild-messages'],
+    token: 'aaa.bbb.ccc',
+    botColor: 'Blurple'
+};
+
+const HTTP: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'http',
+    token: 'aaa.bbb.ccc',
+    publicKey: 'a'.repeat(64),
+    botColor: 'Blurple'
+};
+
+describe('nextSteps', () => {
+    it('opens with the directory to change into', () => {
+        expect(nextSteps(GATEWAY, { agent: 'pnpm', installed: true })[0]).toBe('cd my-bot');
+    });
+
+    it('uses the running package manager for the dev script', () => {
+        expect(nextSteps(GATEWAY, { agent: 'npm', installed: true })).toContain('npm run dev');
+        expect(nextSteps(GATEWAY, { agent: 'pnpm', installed: true })).toContain('pnpm run dev');
+    });
+
+    it('adds the install when the run skipped it', () => {
+        const steps = nextSteps(GATEWAY, { agent: 'pnpm', installed: false });
+
+        expect(steps).toContain('pnpm install');
+        expect(steps.indexOf('pnpm install')).toBeLessThan(steps.indexOf('pnpm run dev'));
+    });
+
+    it('leaves the install out when it already ran', () => {
+        expect(nextSteps(GATEWAY, { agent: 'pnpm', installed: true })).not.toContain('pnpm install');
+    });
+});
+
+describe('dashboardToggles', () => {
+    it('says nothing for a bot that asked for no privileged intent', () => {
+        expect(dashboardToggles(['guild-messages', 'reactions'])).toEqual([]);
+    });
+
+    it('names the toggle behind each privileged pick', () => {
+        const lines = dashboardToggles(['message-text', 'members', 'presence']).join('\n');
+
+        expect(lines).toContain('Message Content');
+        expect(lines).toContain('Server Members');
+        expect(lines).toContain('Presence');
+    });
+
+    it('points at the developer portal', () => {
+        expect(dashboardToggles(['members']).join('\n')).toContain('https://discord.com/developers/applications');
+    });
+
+    it('says nothing on http, which has no intents', () => {
+        expect(dashboardToggles([])).toEqual([]);
+    });
+});
+
+describe('reproducingCommand', () => {
+    it('keeps the secret out of the line', () => {
+        const command = reproducingCommand(GATEWAY, 'pnpm');
+
+        expect(command).not.toContain('aaa.bbb.ccc');
+        expect(command).toContain('--token');
+    });
+
+    it('uses placeholders a shell will not choke on', () => {
+        const command = reproducingCommand(HTTP, 'pnpm');
+
+        expect(command).not.toMatch(/[<>|&;$`]/);
+    });
+
+    it('keeps the public key out too', () => {
+        expect(reproducingCommand(HTTP, 'pnpm')).not.toContain('a'.repeat(64));
+    });
+
+    it('carries every answer the run used', () => {
+        const command = reproducingCommand(GATEWAY, 'pnpm');
+
+        expect(command).toContain('my-bot');
+        expect(command).toContain('--transport gateway');
+        expect(command).toContain('--capabilities guild-messages');
+        expect(command).toContain('--color Blurple');
+    });
+
+    it('leaves capabilities out on http', () => {
+        expect(reproducingCommand(HTTP, 'pnpm')).not.toContain('--capabilities');
+    });
+
+    it('leaves the public key flag out on gateway', () => {
+        expect(reproducingCommand(GATEWAY, 'pnpm')).not.toContain('--public-key');
+    });
+
+    it('puts the double dash in for npm, which needs it before flags', () => {
+        expect(reproducingCommand(GATEWAY, 'npm')).toContain('npm create seedcord my-bot --');
+    });
+
+    it('leaves the double dash out for every other manager', () => {
+        expect(reproducingCommand(GATEWAY, 'pnpm')).toContain('pnpm create seedcord my-bot --transport');
+    });
+});

--- a/cli/create-seedcord/tests/interview/applyFlags.test.ts
+++ b/cli/create-seedcord/tests/interview/applyFlags.test.ts
@@ -6,13 +6,13 @@ import type { AnyStep } from '@src/interview/types';
 
 const directory: AnyStep = {
     key: 'directory',
-    flag: { name: 'dir', parse: (raw) => raw },
+    flag: { name: 'dir', description: 'a stub', parse: (raw) => raw },
     ask: () => Promise.resolve('asked')
 };
 
 const capabilities: AnyStep = {
     key: 'capabilities',
-    flag: { name: 'capabilities', parse: (raw) => raw.split(',') },
+    flag: { name: 'capabilities', description: 'a stub', parse: (raw) => raw.split(',') },
     ask: () => Promise.resolve([])
 };
 

--- a/cli/create-seedcord/tests/interview/applyFlags.test.ts
+++ b/cli/create-seedcord/tests/interview/applyFlags.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyFlags } from '@src/interview/applyFlags';
+import { applyFlags } from '@interview/applyFlags';
 
-import type { AnyStep } from '@src/interview/types';
+import type { AnyStep } from '@interview/types';
 
 const directory: AnyStep = {
     key: 'directory',

--- a/cli/create-seedcord/tests/interview/capabilities.test.ts
+++ b/cli/create-seedcord/tests/interview/capabilities.test.ts
@@ -46,8 +46,26 @@ describe('partialsFor', () => {
         expect(partialsFor(['reactions'])).toEqual(['Message', 'Channel', 'Reaction']);
     });
 
+    it('takes the member partial a leave needs', () => {
+        expect(partialsFor(['members'])).toEqual(['GuildMember']);
+    });
+
+    it('takes the four a poll vote needs', () => {
+        expect(partialsFor(['polls'])).toEqual(['Message', 'Channel', 'Poll', 'PollAnswer']);
+    });
+
+    it('takes the user partial an event sign-up needs', () => {
+        expect(partialsFor(['scheduled-events'])).toEqual(['User']);
+    });
+
     it('lists a shared partial once', () => {
         const partials = partialsFor(['reactions', 'direct-messages']);
+
+        expect(new Set(partials).size).toBe(partials.length);
+    });
+
+    it('lists a shared partial once across reactions and polls', () => {
+        const partials = partialsFor(['reactions', 'polls']);
 
         expect(new Set(partials).size).toBe(partials.length);
     });

--- a/cli/create-seedcord/tests/interview/capabilities.test.ts
+++ b/cli/create-seedcord/tests/interview/capabilities.test.ts
@@ -11,6 +11,17 @@ describe('CAPABILITIES', () => {
     it('never offers Guilds as a choice', () => {
         expect(CAPABILITIES.flatMap((c) => c.intents)).not.toContain('Guilds');
     });
+
+    it('marks the dashboard toggle in the label, which clack draws on every row', () => {
+        for (const capability of CAPABILITIES) {
+            const gated = privilegedFor([capability.id]).length > 0;
+            expect(capability.label.includes('needs a dashboard toggle')).toBe(gated);
+        }
+    });
+
+    it('keeps the marker out of the hints, which clack draws only under the cursor', () => {
+        expect(CAPABILITIES.filter((c) => c.hint.includes('privileged'))).toEqual([]);
+    });
 });
 
 describe('intentsFor', () => {

--- a/cli/create-seedcord/tests/interview/capabilities.test.ts
+++ b/cli/create-seedcord/tests/interview/capabilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { CAPABILITIES, intentsFor, partialsFor, privilegedFor } from '@src/interview/capabilities';
+import { CAPABILITIES, intentsFor, partialsFor, privilegedFor } from '@interview/capabilities';
 
 describe('CAPABILITIES', () => {
     it('offers eleven options with unique ids', () => {

--- a/cli/create-seedcord/tests/interview/capabilities.test.ts
+++ b/cli/create-seedcord/tests/interview/capabilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { CAPABILITIES, intentsFor, partialsFor, privilegedFor } from '@interview/capabilities';
+import { CAPABILITIES, intentsFor, isPrivileged, partialsFor, privilegedFor } from '@interview/capabilities';
 
 describe('CAPABILITIES', () => {
     it('offers eleven options with unique ids', () => {
@@ -12,15 +12,18 @@ describe('CAPABILITIES', () => {
         expect(CAPABILITIES.flatMap((c) => c.intents)).not.toContain('Guilds');
     });
 
-    it('marks the dashboard toggle in the label, which clack draws on every row', () => {
-        for (const capability of CAPABILITIES) {
-            const gated = privilegedFor([capability.id]).length > 0;
-            expect(capability.label.includes('needs a dashboard toggle')).toBe(gated);
-        }
-    });
-
     it('keeps the marker out of the hints, which clack draws only under the cursor', () => {
         expect(CAPABILITIES.filter((c) => c.hint.includes('privileged'))).toEqual([]);
+    });
+});
+
+describe('isPrivileged', () => {
+    it('names the three the dashboard gates and nothing else', () => {
+        expect(CAPABILITIES.filter((c) => isPrivileged(c.id)).map((c) => c.id)).toEqual([
+            'message-text',
+            'members',
+            'presence'
+        ]);
     });
 });
 

--- a/cli/create-seedcord/tests/interview/capabilityNames.types.test.ts
+++ b/cli/create-seedcord/tests/interview/capabilityNames.types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
-import type { IntentName, PartialName } from '@src/interview/capabilities';
+import type { IntentName, PartialName } from '@interview/capabilities';
 import type { GatewayIntentBits, Partials } from 'discord.js';
 
 describe('the names the capability map declares', () => {

--- a/cli/create-seedcord/tests/interview/colorNames.types.test.ts
+++ b/cli/create-seedcord/tests/interview/colorNames.types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
+import type { ColorChoice } from '@interview/steps/botColor';
 import type { ColorName } from '@seedcord/types';
-import type { ColorChoice } from '@src/interview/steps/botColor';
 
 // the `satisfies ColorName[]` on the list already proves the other direction
 describe('the color names the picker offers', () => {

--- a/cli/create-seedcord/tests/interview/errorCodes.test.ts
+++ b/cli/create-seedcord/tests/interview/errorCodes.test.ts
@@ -44,14 +44,16 @@ describe('a flag answering a skipped question', () => {
     it('throws its own code, separate from a rejected value', async () => {
         const publicKey: Step<'publicKey'> = {
             key: 'publicKey',
-            flag: { name: 'public-key', parse: (raw) => raw },
+            flag: { name: 'public-key', description: 'a stub', parse: (raw) => raw },
             skip: (answers) => answers.transport === 'gateway',
             ask: () => Promise.resolve('prompted')
         };
 
-        const thrown = await runFlow([publicKey], { transport: 'gateway', publicKey: 'supplied' }).catch(
-            (error: unknown) => error
-        );
+        const thrown = await runFlow(
+            [publicKey],
+            { transport: 'gateway', publicKey: 'supplied' },
+            { interactive: true }
+        ).catch((error: unknown) => error);
 
         expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateFlagNotApplicable)).toBe(true);
         expect((thrown as Error).message).toContain('public-key');

--- a/cli/create-seedcord/tests/interview/errorCodes.test.ts
+++ b/cli/create-seedcord/tests/interview/errorCodes.test.ts
@@ -1,0 +1,59 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, expect, it } from 'vitest';
+
+import { runFlow } from '@src/interview/runFlow';
+import { botColorStep } from '@src/interview/steps/botColor';
+import { capabilitiesStep } from '@src/interview/steps/capabilities';
+import { directoryStep } from '@src/interview/steps/directory';
+import { publicKeyStep } from '@src/interview/steps/publicKey';
+import { tokenStep } from '@src/interview/steps/token';
+import { transportStep } from '@src/interview/steps/transport';
+
+import type { Step } from '@src/interview/types';
+
+function thrownBy(run: () => unknown): unknown {
+    try {
+        run();
+    } catch (error) {
+        return error;
+    }
+
+    return undefined;
+}
+
+describe('a rejected flag value', () => {
+    const rejects: [flag: string, run: () => unknown, reason: string][] = [
+        ['dir', () => directoryStep.flag.parse('   '), 'cannot be empty'],
+        ['transport', () => transportStep.flag.parse('websocket'), 'websocket'],
+        ['capabilities', () => capabilitiesStep.flag.parse('telepathy'), 'telepathy'],
+        ['token', () => tokenStep.flag.parse('aaa.bbb'), 'Bot page'],
+        ['public-key', () => publicKeyStep.flag.parse('abc'), '64 hex'],
+        ['color', () => botColorStep.flag.parse('chartreuse'), 'chartreuse']
+    ];
+
+    it.each(rejects)('names --%s and keeps its reason', (flag, run, reason) => {
+        const thrown = thrownBy(run);
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateInvalidAnswer)).toBe(true);
+        expect((thrown as Error).message).toContain(`--${flag}`);
+        expect((thrown as Error).message).toContain(reason);
+    });
+});
+
+describe('a flag answering a skipped question', () => {
+    it('throws its own code, separate from a rejected value', async () => {
+        const publicKey: Step<'publicKey'> = {
+            key: 'publicKey',
+            flag: { name: 'public-key', parse: (raw) => raw },
+            skip: (answers) => answers.transport === 'gateway',
+            ask: () => Promise.resolve('prompted')
+        };
+
+        const thrown = await runFlow([publicKey], { transport: 'gateway', publicKey: 'supplied' }).catch(
+            (error: unknown) => error
+        );
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateFlagNotApplicable)).toBe(true);
+        expect((thrown as Error).message).toContain('public-key');
+    });
+});

--- a/cli/create-seedcord/tests/interview/errorCodes.test.ts
+++ b/cli/create-seedcord/tests/interview/errorCodes.test.ts
@@ -1,15 +1,15 @@
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it } from 'vitest';
 
-import { runFlow } from '@src/interview/runFlow';
-import { botColorStep } from '@src/interview/steps/botColor';
-import { capabilitiesStep } from '@src/interview/steps/capabilities';
-import { directoryStep } from '@src/interview/steps/directory';
-import { publicKeyStep } from '@src/interview/steps/publicKey';
-import { tokenStep } from '@src/interview/steps/token';
-import { transportStep } from '@src/interview/steps/transport';
+import { runFlow } from '@interview/runFlow';
+import { botColorStep } from '@interview/steps/botColor';
+import { capabilitiesStep } from '@interview/steps/capabilities';
+import { directoryStep } from '@interview/steps/directory';
+import { publicKeyStep } from '@interview/steps/publicKey';
+import { tokenStep } from '@interview/steps/token';
+import { transportStep } from '@interview/steps/transport';
 
-import type { Step } from '@src/interview/types';
+import type { Step } from '@interview/types';
 
 function thrownBy(run: () => unknown): unknown {
     try {

--- a/cli/create-seedcord/tests/interview/nonInteractive.test.ts
+++ b/cli/create-seedcord/tests/interview/nonInteractive.test.ts
@@ -1,9 +1,9 @@
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it } from 'vitest';
 
-import { runFlow } from '@src/interview/runFlow';
+import { runFlow } from '@interview/runFlow';
 
-import type { Answers, Step } from '@src/interview/types';
+import type { Answers, Step } from '@interview/types';
 
 function neverAsks<Key extends keyof Answers>(key: Key, flag: string): Step<Key> {
     return {

--- a/cli/create-seedcord/tests/interview/nonInteractive.test.ts
+++ b/cli/create-seedcord/tests/interview/nonInteractive.test.ts
@@ -1,0 +1,42 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, expect, it } from 'vitest';
+
+import { runFlow } from '@src/interview/runFlow';
+
+import type { Answers, Step } from '@src/interview/types';
+
+function neverAsks<Key extends keyof Answers>(key: Key, flag: string): Step<Key> {
+    return {
+        key,
+        flag: { name: flag, description: 'a stub', parse: (raw) => raw as Answers[Key] },
+        ask: () => Promise.reject(new Error(`${key} was asked with no terminal`))
+    };
+}
+
+describe('runFlow with no terminal', () => {
+    it('takes every answer from the flags', async () => {
+        const answers = await runFlow([neverAsks('directory', 'dir')], { directory: 'my-bot' }, { interactive: false });
+
+        expect(answers.directory).toBe('my-bot');
+    });
+
+    it('names the flag that would have to supply a missing answer', async () => {
+        const thrown = await runFlow([neverAsks('transport', 'transport')], {}, { interactive: false }).catch(
+            (error: unknown) => error
+        );
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateInvalidAnswer)).toBe(true);
+        expect((thrown as Error).message).toContain('--transport');
+    });
+
+    it('leaves a skipped step alone', async () => {
+        const publicKey: Step<'publicKey'> = {
+            ...neverAsks('publicKey', 'public-key'),
+            skip: (answers) => answers.transport === 'gateway'
+        };
+
+        const answers = await runFlow([publicKey], { transport: 'gateway' }, { interactive: false });
+
+        expect(answers.publicKey).toBeUndefined();
+    });
+});

--- a/cli/create-seedcord/tests/interview/pickerSteps.test.ts
+++ b/cli/create-seedcord/tests/interview/pickerSteps.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { botColorStep, COLOR_NAMES } from '@src/interview/steps/botColor';
-import { capabilitiesStep } from '@src/interview/steps/capabilities';
+import { botColorStep, COLOR_NAMES } from '@interview/steps/botColor';
+import { capabilitiesStep } from '@interview/steps/capabilities';
 
 describe('capabilitiesStep', () => {
     it('splits a comma list into ids', () => {

--- a/cli/create-seedcord/tests/interview/requireAnswer.test.ts
+++ b/cli/create-seedcord/tests/interview/requireAnswer.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { requireAnswer } from '@src/interview/steps/requireAnswer';
 
-// clack never exports its cancel symbol, and isCancel compares it by identity
+// clack never exports its cancel symbol
 const { CANCEL } = vi.hoisted(() => ({ CANCEL: Symbol('cancel') }));
 
 vi.mock('@clack/prompts', async (importOriginal) => ({

--- a/cli/create-seedcord/tests/interview/requireAnswer.test.ts
+++ b/cli/create-seedcord/tests/interview/requireAnswer.test.ts
@@ -1,0 +1,32 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, expect, it, vi } from 'vitest';
+
+import { requireAnswer } from '@src/interview/steps/requireAnswer';
+
+// clack never exports its cancel symbol, and isCancel compares it by identity
+const { CANCEL } = vi.hoisted(() => ({ CANCEL: Symbol('cancel') }));
+
+vi.mock('@clack/prompts', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@clack/prompts')>()),
+    isCancel: (value: unknown) => value === CANCEL
+}));
+
+describe('requireAnswer', () => {
+    it('returns an answer untouched', () => {
+        expect(requireAnswer('my-bot')).toBe('my-bot');
+    });
+
+    it('throws the cancel code when the user pressed Ctrl-C', () => {
+        const thrown = (() => {
+            try {
+                requireAnswer<string>(CANCEL);
+            } catch (error) {
+                return error;
+            }
+
+            return undefined;
+        })();
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateCancelled)).toBe(true);
+    });
+});

--- a/cli/create-seedcord/tests/interview/requireAnswer.test.ts
+++ b/cli/create-seedcord/tests/interview/requireAnswer.test.ts
@@ -1,7 +1,7 @@
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it, vi } from 'vitest';
 
-import { requireAnswer } from '@src/interview/steps/requireAnswer';
+import { requireAnswer } from '@interview/steps/requireAnswer';
 
 // clack never exports its cancel symbol
 const { CANCEL } = vi.hoisted(() => ({ CANCEL: Symbol('cancel') }));

--- a/cli/create-seedcord/tests/interview/runFlow.test.ts
+++ b/cli/create-seedcord/tests/interview/runFlow.test.ts
@@ -7,7 +7,7 @@ import type { Answers, Step } from '@src/interview/types';
 function stubStep<Key extends keyof Answers>(key: Key, value: Answers[Key], asked: (keyof Answers)[]): Step<Key> {
     return {
         key,
-        flag: { name: String(key), parse: (raw) => raw as Answers[Key] },
+        flag: { name: String(key), description: 'a stub', parse: (raw) => raw as Answers[Key] },
         ask: () => {
             asked.push(key);
             return Promise.resolve(value);
@@ -20,7 +20,8 @@ describe('runFlow', () => {
         const asked: (keyof Answers)[] = [];
         const answers = await runFlow(
             [stubStep('directory', 'my-bot', asked), stubStep('transport', 'gateway', asked)],
-            {}
+            {},
+            { interactive: true }
         );
 
         expect(asked).toEqual(['directory', 'transport']);
@@ -29,7 +30,13 @@ describe('runFlow', () => {
 
     it('leaves a step unasked when its flag already supplied the answer', async () => {
         const asked: (keyof Answers)[] = [];
-        const answers = await runFlow([stubStep('directory', 'prompted', asked)], { directory: 'from-flag' });
+        const answers = await runFlow(
+            [stubStep('directory', 'prompted', asked)],
+            { directory: 'from-flag' },
+            {
+                interactive: true
+            }
+        );
 
         expect(asked).toEqual([]);
         expect(answers.directory).toBe('from-flag');
@@ -42,7 +49,7 @@ describe('runFlow', () => {
             skip: (answers) => answers.transport === 'http'
         };
 
-        const answers = await runFlow([stubStep('transport', 'http', asked), capabilities], {});
+        const answers = await runFlow([stubStep('transport', 'http', asked), capabilities], {}, { interactive: true });
 
         expect(asked).toEqual(['transport']);
         expect(answers.capabilities).toBeUndefined();
@@ -52,12 +59,12 @@ describe('runFlow', () => {
         const asked: (keyof Answers)[] = [];
         const publicKey: Step<'publicKey'> = {
             ...stubStep('publicKey', 'prompted', asked),
-            flag: { name: 'public-key', parse: (raw) => raw },
+            flag: { name: 'public-key', description: 'a stub', parse: (raw) => raw },
             skip: (answers) => answers.transport === 'gateway'
         };
 
-        await expect(runFlow([publicKey], { transport: 'gateway', publicKey: 'supplied' })).rejects.toThrow(
-            /public-key/
-        );
+        await expect(
+            runFlow([publicKey], { transport: 'gateway', publicKey: 'supplied' }, { interactive: true })
+        ).rejects.toThrow(/public-key/);
     });
 });

--- a/cli/create-seedcord/tests/interview/runFlow.test.ts
+++ b/cli/create-seedcord/tests/interview/runFlow.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { runFlow } from '@src/interview/runFlow';
+import { runFlow } from '@interview/runFlow';
 
-import type { Answers, Step } from '@src/interview/types';
+import type { Answers, Step } from '@interview/types';
 
 function stubStep<Key extends keyof Answers>(key: Key, value: Answers[Key], asked: (keyof Answers)[]): Step<Key> {
     return {

--- a/cli/create-seedcord/tests/interview/secretSteps.test.ts
+++ b/cli/create-seedcord/tests/interview/secretSteps.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { publicKeyStep } from '@src/interview/steps/publicKey';
-import { tokenStep } from '@src/interview/steps/token';
+import { publicKeyStep } from '@interview/steps/publicKey';
+import { tokenStep } from '@interview/steps/token';
 
 const KEY = 'a'.repeat(64);
 

--- a/cli/create-seedcord/tests/interview/secretSteps.test.ts
+++ b/cli/create-seedcord/tests/interview/secretSteps.test.ts
@@ -4,20 +4,24 @@ import { publicKeyStep } from '@interview/steps/publicKey';
 import { tokenStep } from '@interview/steps/token';
 
 const KEY = 'a'.repeat(64);
+const TOKEN = `${'a'.repeat(26)}.${'b'.repeat(6)}.${'c'.repeat(38)}`;
 
 describe('tokenStep', () => {
     it('takes a token shaped like the three parts Discord issues', () => {
-        const token = `${'a'.repeat(26)}.${'b'.repeat(6)}.${'c'.repeat(38)}`;
-        expect(tokenStep.flag.parse(token)).toBe(token);
+        expect(tokenStep.flag.parse(TOKEN)).toBe(TOKEN);
     });
 
     it('trims a token a shell or a copy paste padded', () => {
-        expect(tokenStep.flag.parse('  aaa.bbb.ccc  ')).toBe('aaa.bbb.ccc');
+        expect(tokenStep.flag.parse(`  ${TOKEN}  `)).toBe(TOKEN);
+    });
+
+    it('rejects three parts too short to be a token, which the bot would reject at startup', () => {
+        expect(() => tokenStep.flag.parse('aaa.bbb.ccc')).toThrow();
     });
 
     it('rejects a value with the wrong number of parts', () => {
         expect(() => tokenStep.flag.parse('aaa.bbb')).toThrow();
-        expect(() => tokenStep.flag.parse('aaa.bbb.ccc.ddd')).toThrow();
+        expect(() => tokenStep.flag.parse(`${TOKEN}.ddd`)).toThrow();
     });
 
     it('rejects an empty part, which is what a truncated paste looks like', () => {
@@ -26,6 +30,10 @@ describe('tokenStep', () => {
 
     it('rejects nothing at all', () => {
         expect(() => tokenStep.flag.parse('   ')).toThrow();
+    });
+
+    it('names the flag and the Bot page, since the framework error names neither', () => {
+        expect(() => tokenStep.flag.parse('aaa.bbb.ccc')).toThrow(/--token: .*Bot page/);
     });
 });
 

--- a/cli/create-seedcord/tests/interview/steps.test.ts
+++ b/cli/create-seedcord/tests/interview/steps.test.ts
@@ -31,6 +31,19 @@ describe('directoryStep', () => {
     it('takes the punctuation npm allows', () => {
         expect(directoryStep.flag.parse('my-bot_2.0')).toBe('my-bot_2.0');
     });
+
+    it('takes a name right on the length limit', () => {
+        const longest = 'a'.repeat(64);
+        expect(directoryStep.flag.parse(longest)).toBe(longest);
+    });
+
+    it('rejects one character past it, and says the number', () => {
+        expect(() => directoryStep.flag.parse('a'.repeat(65))).toThrow(/64/);
+    });
+
+    it('measures the folder, leaving the path in front of it out', () => {
+        expect(directoryStep.flag.parse(`${'nested/'.repeat(20)}my-bot`)).toContain('my-bot');
+    });
 });
 
 describe('transportStep', () => {

--- a/cli/create-seedcord/tests/interview/steps.test.ts
+++ b/cli/create-seedcord/tests/interview/steps.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { directoryStep } from '@src/interview/steps/directory';
-import { JAVASCRIPT_REPLIES, languageStep, pickReply } from '@src/interview/steps/language';
-import { transportStep } from '@src/interview/steps/transport';
+import { directoryStep } from '@interview/steps/directory';
+import { JAVASCRIPT_REPLIES, languageStep, pickReply } from '@interview/steps/language';
+import { transportStep } from '@interview/steps/transport';
 
 describe('directoryStep', () => {
     it('takes the directory from its flag verbatim', () => {

--- a/cli/create-seedcord/tests/interview/steps.test.ts
+++ b/cli/create-seedcord/tests/interview/steps.test.ts
@@ -29,7 +29,7 @@ describe('transportStep', () => {
     });
 
     it('names both options when the value is neither', () => {
-        expect(() => transportStep.flag.parse('websocket')).toThrow(/gateway.*http/);
+        expect(() => transportStep.flag.parse('websocket')).toThrow(/http.*gateway/);
     });
 });
 

--- a/cli/create-seedcord/tests/interview/steps.test.ts
+++ b/cli/create-seedcord/tests/interview/steps.test.ts
@@ -16,6 +16,21 @@ describe('directoryStep', () => {
     it('rejects an empty directory', () => {
         expect(() => directoryStep.flag.parse('   ')).toThrow();
     });
+
+    it('keeps a nested path, checking only the folder the project goes in', () => {
+        expect(directoryStep.flag.parse('bots/my-bot')).toBe('bots/my-bot');
+    });
+
+    it('rejects a name npm would refuse as a package name', () => {
+        expect(() => directoryStep.flag.parse('My Bot')).toThrow();
+        expect(() => directoryStep.flag.parse('MyBot')).toThrow();
+        expect(() => directoryStep.flag.parse('_bot')).toThrow();
+        expect(() => directoryStep.flag.parse('bots/My Bot')).toThrow();
+    });
+
+    it('takes the punctuation npm allows', () => {
+        expect(directoryStep.flag.parse('my-bot_2.0')).toBe('my-bot_2.0');
+    });
 });
 
 describe('transportStep', () => {

--- a/cli/create-seedcord/tests/interview/steps.test.ts
+++ b/cli/create-seedcord/tests/interview/steps.test.ts
@@ -47,6 +47,17 @@ describe('the JavaScript replies', () => {
         expect(new Set(JAVASCRIPT_REPLIES).size).toBe(JAVASCRIPT_REPLIES.length);
     });
 
+    // clack leaves JavaScript on screen as the picked label
+    it('names TypeScript in every line', () => {
+        expect(JAVASCRIPT_REPLIES.filter((reply) => !reply.includes('TypeScript'))).toEqual([]);
+    });
+
+    it('opens each line differently', () => {
+        const openers = JAVASCRIPT_REPLIES.map((reply) => reply.split(' ')[0]?.replace(/\W+$/, ''));
+
+        expect(new Set(openers).size).toBe(openers.length);
+    });
+
     it('picks one from the pool', () => {
         expect(JAVASCRIPT_REPLIES).toContain(pickReply(() => 0));
         expect(pickReply(() => 0)).toBe(JAVASCRIPT_REPLIES[0]);

--- a/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
+++ b/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { installHint, missingNotice, probeCloudflared } from '@scaffold/cloudflared';
@@ -31,5 +35,17 @@ describe('probeCloudflared', () => {
 
     it('reports true for one that does', async () => {
         await expect(probeCloudflared('node')).resolves.toBe(true);
+    });
+
+    it('gives up on a binary that never answers', async () => {
+        const directory = await mkdtemp(join(tmpdir(), 'create-seedcord-probe-'));
+        const hangs = join(directory, 'hangs');
+        await writeFile(hangs, '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+
+        try {
+            await expect(probeCloudflared(hangs, 200)).resolves.toBe(false);
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
     });
 });

--- a/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
+++ b/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { installHint, missingNotice, probeCloudflared } from '@scaffold/cloudflared';
+
+describe('installHint', () => {
+    it('gives the package manager each platform ships with', () => {
+        expect(installHint('darwin')).toBe('brew install cloudflared');
+        expect(installHint('win32')).toContain('winget install');
+    });
+
+    it('sends everyone else to the download page', () => {
+        expect(installHint('linux')).toContain('https://');
+    });
+});
+
+describe('missingNotice', () => {
+    it('names the command that needs it', () => {
+        expect(missingNotice('darwin')).toContain('seedcord dev');
+    });
+
+    it('carries the platform install line', () => {
+        expect(missingNotice('darwin')).toContain('brew install cloudflared');
+        expect(missingNotice('linux')).toContain('https://');
+    });
+});
+
+describe('probeCloudflared', () => {
+    it('reports false for a binary that does not exist', async () => {
+        await expect(probeCloudflared('cloudflared-that-is-not-installed')).resolves.toBe(false);
+    });
+
+    it('reports true for one that does', async () => {
+        await expect(probeCloudflared('node')).resolves.toBe(true);
+    });
+});

--- a/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
+++ b/cli/create-seedcord/tests/scaffold/cloudflared.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import process from 'node:process';
 
 import { describe, expect, it } from 'vitest';
 
@@ -34,7 +35,7 @@ describe('probeCloudflared', () => {
     });
 
     it('reports true for one that does', async () => {
-        await expect(probeCloudflared('node')).resolves.toBe(true);
+        await expect(probeCloudflared(process.execPath)).resolves.toBe(true);
     });
 
     it('gives up on a binary that never answers', async () => {

--- a/cli/create-seedcord/tests/scaffold/exec.test.ts
+++ b/cli/create-seedcord/tests/scaffold/exec.test.ts
@@ -1,0 +1,55 @@
+import process from 'node:process';
+
+import { describe, expect, it } from 'vitest';
+
+import { execRunner } from '@scaffold/exec';
+
+function noise(prefix: string, count: number): string {
+    return `for (let i = 0; i < ${count}; i++) console.log('${prefix} ' + i);`;
+}
+
+async function failureOf(...statements: string[]): Promise<string> {
+    try {
+        await execRunner(process.execPath, ['-e', `${statements.join(' ')} process.exit(1);`], process.cwd());
+    } catch (error) {
+        return Error.isError(error) ? error.message : String(error);
+    }
+
+    throw new Error('the script was supposed to exit non-zero');
+}
+
+// the first line repeats the whole script back
+async function capturedBy(...statements: string[]): Promise<string> {
+    const message = await failureOf(...statements);
+
+    return message.split('\n').slice(1).join('\n');
+}
+
+describe('execRunner', () => {
+    it('resolves when the command exits zero', async () => {
+        await expect(execRunner(process.execPath, ['-e', ''], process.cwd())).resolves.toBeUndefined();
+    });
+
+    it('keeps the line naming the cause, which sits above the boilerplate npm ends on', async () => {
+        const captured = await capturedBy(
+            noise('resolving', 40),
+            `console.log('npm error code ECONNREFUSED');`,
+            noise('A complete log', 40)
+        );
+
+        expect(captured).toContain('ECONNREFUSED');
+        expect(captured).not.toContain('A complete log');
+    });
+
+    it('falls back to the tail when no line names itself an error', async () => {
+        expect(await capturedBy(noise('plain output', 40))).toContain('plain output 39');
+    });
+
+    it('names the command that failed', async () => {
+        expect(await failureOf('')).toContain(process.execPath);
+    });
+
+    it('reports the exit code when the command printed nothing', async () => {
+        expect(await failureOf('')).toContain('exited with 1');
+    });
+});

--- a/cli/create-seedcord/tests/scaffold/git.test.ts
+++ b/cli/create-seedcord/tests/scaffold/git.test.ts
@@ -4,9 +4,9 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { gitPlanFrom, probeGit } from '@src/scaffold/git';
+import { gitPlanFrom, probeGit } from '@scaffold/git';
 
-import type { GitProbe } from '@src/scaffold/git';
+import type { GitProbe } from '@scaffold/git';
 
 const PRESENT: GitProbe = {
     installed: true,

--- a/cli/create-seedcord/tests/scaffold/git.test.ts
+++ b/cli/create-seedcord/tests/scaffold/git.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { gitPlanFrom, probeGit } from '@src/scaffold/git';
+
+import type { GitProbe } from '@src/scaffold/git';
+
+const PRESENT: GitProbe = {
+    installed: true,
+    insideRepo: false,
+    userName: 'dhruv'
+};
+
+describe('gitPlanFrom', () => {
+    it('initializes and commits in a plain empty directory', () => {
+        const plan = gitPlanFrom(PRESENT, true);
+
+        expect(plan.init).toBe(true);
+        expect(plan.developerUsername).toBe('dhruv');
+        expect(plan.notice).toBeNull();
+    });
+
+    it('skips init inside an existing repo', () => {
+        const plan = gitPlanFrom({ ...PRESENT, insideRepo: true }, true);
+
+        expect(plan.init).toBe(false);
+        expect(plan.notice).toContain('already');
+    });
+
+    it('skips init when the user passed --no-git', () => {
+        const plan = gitPlanFrom(PRESENT, false);
+
+        expect(plan.init).toBe(false);
+        expect(plan.notice).toBeNull();
+    });
+
+    it('keeps the git name even when init is off, since the config reads it', () => {
+        const plan = gitPlanFrom(PRESENT, false);
+
+        expect(plan.developerUsername).toBe('dhruv');
+    });
+
+    it('names the knock-on when git is absent', () => {
+        const plan = gitPlanFrom({ installed: false, insideRepo: false, userName: null }, true);
+
+        expect(plan.init).toBe(false);
+        expect(plan.developerUsername).toBe('the developer');
+        expect(plan.notice).toContain('the developer');
+    });
+
+    it('falls back to the placeholder when git has no name set', () => {
+        const plan = gitPlanFrom({ ...PRESENT, userName: null }, true);
+
+        expect(plan.init).toBe(true);
+        expect(plan.developerUsername).toBe('the developer');
+        expect(plan.notice).toContain('the developer');
+    });
+});
+
+describe('probeGit against the real git', () => {
+    it('finds this repo from inside it', async () => {
+        const probe = await probeGit(import.meta.dirname);
+
+        expect(probe.installed).toBe(true);
+        expect(probe.insideRepo).toBe(true);
+    });
+
+    it('reports a temp directory as outside any repo', async () => {
+        const outside = await mkdtemp(join(tmpdir(), 'create-seedcord-git-'));
+        const probe = await probeGit(outside);
+
+        expect(probe.installed).toBe(true);
+        expect(probe.insideRepo).toBe(false);
+    });
+});

--- a/cli/create-seedcord/tests/scaffold/git.test.ts
+++ b/cli/create-seedcord/tests/scaffold/git.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -70,9 +70,14 @@ describe('probeGit against the real git', () => {
 
     it('reports a temp directory as outside any repo', async () => {
         const outside = await mkdtemp(join(tmpdir(), 'create-seedcord-git-'));
-        const probe = await probeGit(outside);
 
-        expect(probe.installed).toBe(true);
-        expect(probe.insideRepo).toBe(false);
+        try {
+            const probe = await probeGit(outside);
+
+            expect(probe.installed).toBe(true);
+            expect(probe.insideRepo).toBe(false);
+        } finally {
+            await rm(outside, { recursive: true, force: true });
+        }
     });
 });

--- a/cli/create-seedcord/tests/scaffold/scaffold.test.ts
+++ b/cli/create-seedcord/tests/scaffold/scaffold.test.ts
@@ -61,7 +61,7 @@ function stepRecorder(): { steps: StepUi; seen: string[] } {
         steps: {
             run: async (labels, work) => {
                 seen.push(labels.running);
-                const result = await work(() => undefined);
+                const result = await work();
                 seen.push(`done: ${labels.done}`);
                 return result;
             },

--- a/cli/create-seedcord/tests/scaffold/scaffold.test.ts
+++ b/cli/create-seedcord/tests/scaffold/scaffold.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import { scaffold } from '@scaffold/scaffold';
 
+import type { StepUi } from '@cli/steps';
 import type { CommandRunner } from '@scaffold/scaffold';
 import type { ScaffoldAnswers } from '@template/context';
 
@@ -52,14 +53,34 @@ async function scratchTarget(): Promise<string> {
     return join(await mkdtemp(join(tmpdir(), 'create-seedcord-scaffold-')), 'my-bot');
 }
 
-function baseInput(target: string): Parameters<typeof scaffold>[0] {
+function stepRecorder(): { steps: StepUi; seen: string[] } {
+    const seen: string[] = [];
+
+    return {
+        seen,
+        steps: {
+            run: async (labels, work) => {
+                seen.push(labels.running);
+                const result = await work(() => undefined);
+                seen.push(`done: ${labels.done}`);
+                return result;
+            },
+            skip: (label) => {
+                seen.push(`skipped: ${label}`);
+            }
+        }
+    };
+}
+
+function baseInput(target: string, steps: StepUi = stepRecorder().steps): Parameters<typeof scaffold>[0] {
     return {
         target,
         templatesRoot: TEMPLATES,
         answers: GATEWAY,
         agent: 'pnpm',
         install: true,
-        git: true
+        git: true,
+        steps
     };
 }
 
@@ -99,7 +120,7 @@ describe('scaffold', () => {
         expect(dev?.args).toContain('@types/node');
     });
 
-    it('holds typescript on 6, which is the last major typescript-eslint supports', async () => {
+    it('pins typescript to the last major typescript-eslint supports', async () => {
         const target = await scratchTarget();
         const { runner, calls } = recorder();
 
@@ -125,6 +146,49 @@ describe('scaffold', () => {
         await scaffold({ ...baseInput(target), install: false }, runner);
 
         expect(calls.map((call) => call.command)).toEqual(['git', 'git', 'git']);
+    });
+
+    it('reports every step in order', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder();
+        const { steps, seen } = stepRecorder();
+
+        await scaffold(baseInput(target, steps), runner);
+
+        expect(seen).toEqual([
+            'Writing files',
+            'done: Files written',
+            'Installing dependencies',
+            'done: Dependencies installed',
+            'Formatting',
+            'done: Code formatted',
+            'Generating types',
+            'done: Types generated',
+            'Setting up git',
+            'done: Committed'
+        ]);
+    });
+
+    it('marks the three install steps skipped rather than dropping them', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder();
+        const { steps, seen } = stepRecorder();
+
+        await scaffold({ ...baseInput(target, steps), install: false }, runner);
+
+        expect(seen).toContain('skipped: Dependencies installed');
+        expect(seen).toContain('skipped: Code formatted');
+        expect(seen).toContain('skipped: Types generated');
+    });
+
+    it('marks git skipped when git is off', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder();
+        const { steps, seen } = stepRecorder();
+
+        await scaffold({ ...baseInput(target, steps), git: false }, runner);
+
+        expect(seen).toContain('skipped: Committed');
     });
 
     it('skips git when git is off', async () => {

--- a/cli/create-seedcord/tests/scaffold/scaffold.test.ts
+++ b/cli/create-seedcord/tests/scaffold/scaffold.test.ts
@@ -1,0 +1,177 @@
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { scaffold } from '@scaffold/scaffold';
+
+import type { CommandRunner } from '@scaffold/scaffold';
+import type { ScaffoldAnswers } from '@template/context';
+
+const TEMPLATES = resolve(import.meta.dirname, '../../templates');
+
+const GATEWAY: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'gateway',
+    capabilities: ['guild-messages'],
+    token: 'aaa.bbb.ccc',
+    botColor: 'Blurple'
+};
+
+const HTTP: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'http',
+    token: 'aaa.bbb.ccc',
+    publicKey: 'a'.repeat(64),
+    botColor: 'Blurple'
+};
+
+interface Recorded {
+    command: string;
+    args: string[];
+}
+
+function recorder(failOn?: string): { runner: CommandRunner; calls: Recorded[] } {
+    const calls: Recorded[] = [];
+    const runner: CommandRunner = (command, args) => {
+        calls.push({ command, args });
+        if (failOn !== undefined && args.join(' ').includes(failOn)) {
+            return Promise.reject(new Error(`${failOn} blew up`));
+        }
+
+        return Promise.resolve();
+    };
+
+    return { runner, calls };
+}
+
+async function scratchTarget(): Promise<string> {
+    return join(await mkdtemp(join(tmpdir(), 'create-seedcord-scaffold-')), 'my-bot');
+}
+
+function baseInput(target: string): Parameters<typeof scaffold>[0] {
+    return {
+        target,
+        templatesRoot: TEMPLATES,
+        answers: GATEWAY,
+        agent: 'pnpm',
+        install: true,
+        git: true
+    };
+}
+
+describe('scaffold', () => {
+    it('writes the rendered tree to the target', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        const written = await readdir(target);
+        expect(written).toContain('package.json');
+        expect(written).toContain('src');
+        expect(written).toContain('.env');
+    });
+
+    it('runs install, then format, then codegen, then git', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        const order = calls.map((call) => `${call.command} ${call.args[0]}`);
+        expect(order).toEqual(['pnpm add', 'pnpm add', 'pnpm exec', 'pnpm exec', 'git init', 'git add', 'git commit']);
+    });
+
+    it('installs the gateway packages and the shared dev ones', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        const [deps, dev] = calls;
+        expect(deps?.args).toContain('@seedcord/gateway');
+        expect(deps?.args).toContain('discord.js');
+        expect(dev?.args).toContain('-D');
+        expect(dev?.args).toContain('@types/node');
+    });
+
+    it('holds typescript on 6, which is the last major typescript-eslint supports', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        expect(calls[1]?.args).toContain('typescript@~6.0');
+    });
+
+    it('swaps the transport package on http', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold({ ...baseInput(target), answers: HTTP }, runner);
+
+        expect(calls[0]?.args).toContain('@seedcord/http');
+        expect(calls[0]?.args).not.toContain('discord.js');
+    });
+
+    it('skips install, format, and codegen when install is off', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold({ ...baseInput(target), install: false }, runner);
+
+        expect(calls.map((call) => call.command)).toEqual(['git', 'git', 'git']);
+    });
+
+    it('skips git when git is off', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+
+        await scaffold({ ...baseInput(target), git: false }, runner);
+
+        expect(calls.every((call) => call.command !== 'git')).toBe(true);
+    });
+
+    it('writes the token the interview collected', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        expect(await readFile(join(target, '.env'), 'utf8')).toContain('DISCORD_BOT_TOKEN=aaa.bbb.ccc');
+    });
+});
+
+describe('scaffold cleanup', () => {
+    it('removes the directory it created when a step fails', async () => {
+        const target = await scratchTarget();
+        const { runner } = recorder('add');
+
+        await expect(scaffold(baseInput(target), runner)).rejects.toThrow();
+        await expect(readdir(target)).rejects.toThrow();
+    });
+
+    it('empties a directory that already existed and leaves it standing', async () => {
+        const target = await scratchTarget();
+        await mkdir(target, { recursive: true });
+        const { runner } = recorder('add');
+
+        await expect(scaffold(baseInput(target), runner)).rejects.toThrow();
+        await expect(readdir(target)).resolves.toEqual([]);
+    });
+
+    it('refuses a target with anything in it before writing', async () => {
+        const target = await scratchTarget();
+        const { runner, calls } = recorder();
+        await mkdir(target, { recursive: true });
+        await writeFile(join(target, 'mine.txt'), 'mine');
+
+        await expect(scaffold(baseInput(target), runner)).rejects.toThrow();
+        expect(calls).toEqual([]);
+        await expect(readdir(target)).resolves.toEqual(['mine.txt']);
+    });
+});

--- a/cli/create-seedcord/tests/scaffold/scaffold.test.ts
+++ b/cli/create-seedcord/tests/scaffold/scaffold.test.ts
@@ -200,6 +200,15 @@ describe('scaffold', () => {
         expect(calls.every((call) => call.command !== 'git')).toBe(true);
     });
 
+    it('still finds git when the target sits under directories that do not exist yet', async () => {
+        const target = join(await mkdtemp(join(tmpdir(), 'create-seedcord-nested-')), 'a', 'b', 'my-bot');
+        const { runner, calls } = recorder();
+
+        await scaffold(baseInput(target), runner);
+
+        expect(calls.map((call) => call.command)).toContain('git');
+    });
+
     it('writes the token the interview collected', async () => {
         const target = await scratchTarget();
         const { runner } = recorder();

--- a/cli/create-seedcord/tests/scaffold/target.test.ts
+++ b/cli/create-seedcord/tests/scaffold/target.test.ts
@@ -25,14 +25,14 @@ describe('claimTarget', () => {
     it('accepts a path that does not exist yet', async () => {
         const target = join(await scratch(), 'my-bot');
 
-        await expect(claimTarget(target)).resolves.toBeUndefined();
+        await expect(claimTarget(target)).resolves.toEqual({ existed: false });
     });
 
-    it('accepts an existing empty directory', async () => {
+    it('reports an existing empty directory, which the cleanup leaves behind', async () => {
         const target = join(await scratch(), 'my-bot');
         await mkdir(target);
 
-        await expect(claimTarget(target)).resolves.toBeUndefined();
+        await expect(claimTarget(target)).resolves.toEqual({ existed: true });
     });
 
     it('refuses a directory with anything in it', async () => {

--- a/cli/create-seedcord/tests/scaffold/target.test.ts
+++ b/cli/create-seedcord/tests/scaffold/target.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
 import { describe, expect, it } from 'vitest';
 
-import { claimTarget } from '@src/scaffold/target';
+import { claimTarget } from '@scaffold/target';
 
 async function scratch(): Promise<string> {
     return mkdtemp(join(tmpdir(), 'create-seedcord-'));

--- a/cli/create-seedcord/tests/scaffold/target.test.ts
+++ b/cli/create-seedcord/tests/scaffold/target.test.ts
@@ -1,0 +1,67 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, expect, it } from 'vitest';
+
+import { claimTarget } from '@src/scaffold/target';
+
+async function scratch(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'create-seedcord-'));
+}
+
+async function thrownBy(run: () => Promise<unknown>): Promise<unknown> {
+    try {
+        await run();
+    } catch (error) {
+        return error;
+    }
+
+    return undefined;
+}
+
+describe('claimTarget', () => {
+    it('accepts a path that does not exist yet', async () => {
+        const target = join(await scratch(), 'my-bot');
+
+        await expect(claimTarget(target)).resolves.toBeUndefined();
+    });
+
+    it('accepts an existing empty directory', async () => {
+        const target = join(await scratch(), 'my-bot');
+        await mkdir(target);
+
+        await expect(claimTarget(target)).resolves.toBeUndefined();
+    });
+
+    it('refuses a directory with anything in it', async () => {
+        const target = join(await scratch(), 'my-bot');
+        await mkdir(target);
+        await writeFile(join(target, 'README.md'), 'mine');
+
+        const thrown = await thrownBy(() => claimTarget(target));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateTargetNotEmpty)).toBe(true);
+        expect((thrown as Error).message).toContain('my-bot');
+    });
+
+    it('counts a dotfile as content', async () => {
+        const target = join(await scratch(), 'my-bot');
+        await mkdir(target);
+        await writeFile(join(target, '.env'), 'SECRET=1');
+
+        const thrown = await thrownBy(() => claimTarget(target));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateTargetNotEmpty)).toBe(true);
+    });
+
+    it('refuses a path that is a file', async () => {
+        const target = join(await scratch(), 'my-bot');
+        await writeFile(target, 'not a directory');
+
+        const thrown = await thrownBy(() => claimTarget(target));
+
+        expect(isSeedcordError(thrown, undefined, SeedcordErrorCode.CreateTargetNotEmpty)).toBe(true);
+    });
+});

--- a/cli/create-seedcord/tests/template/context.test.ts
+++ b/cli/create-seedcord/tests/template/context.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildContext } from '@src/template/context';
+
+import type { ScaffoldAnswers } from '@src/template/context';
+
+const GATEWAY: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'gateway',
+    capabilities: ['reactions'],
+    token: 'aaa.bbb.ccc',
+    botColor: 'Blurple'
+};
+
+const HTTP: ScaffoldAnswers = {
+    directory: 'edge/my-bot',
+    language: 'typescript',
+    transport: 'http',
+    token: 'aaa.bbb.ccc',
+    publicKey: 'a'.repeat(64),
+    botColor: '#ff8800'
+};
+
+const EXTRAS = { developerUsername: 'dhruv', runCommand: 'pnpm run' };
+
+describe('buildContext on gateway', () => {
+    const context = buildContext(GATEWAY, EXTRAS);
+
+    it('names the project after the last part of the directory', () => {
+        expect(context.projectName).toBe('my-bot');
+    });
+
+    it('points the imports at the gateway package', () => {
+        expect(context.isGateway).toBe(true);
+        expect(context.transportPackage).toBe('@seedcord/gateway');
+    });
+
+    it('resolves the picked capabilities into intents and partials', () => {
+        expect(context.intents).toEqual(['Guilds', 'GuildMessageReactions', 'DirectMessageReactions']);
+        expect(context.partials).toEqual(['Message', 'Channel', 'Reaction']);
+    });
+
+    it('writes an events directory once a capability was picked', () => {
+        expect(context.hasEvents).toBe(true);
+    });
+
+    it('leaves the public key empty, since gateway never asks for one', () => {
+        expect(context.publicKey).toBe('');
+    });
+});
+
+describe('buildContext on http', () => {
+    const context = buildContext(HTTP, EXTRAS);
+
+    it('takes the project name from a nested path', () => {
+        expect(context.projectName).toBe('my-bot');
+    });
+
+    it('points the imports at the http package', () => {
+        expect(context.isGateway).toBe(false);
+        expect(context.transportPackage).toBe('@seedcord/http');
+    });
+
+    it('carries no intents or partials', () => {
+        expect(context.intents).toEqual([]);
+        expect(context.partials).toEqual([]);
+        expect(context.hasEvents).toBe(false);
+    });
+
+    it('carries the public key through', () => {
+        expect(context.publicKey).toBe('a'.repeat(64));
+    });
+});
+
+describe('buildContext on a gateway bot that picked nothing', () => {
+    const context = buildContext({ ...GATEWAY, capabilities: [] }, EXTRAS);
+
+    it('still writes Guilds', () => {
+        expect(context.intents).toEqual(['Guilds']);
+    });
+
+    it('skips the events directory', () => {
+        expect(context.hasEvents).toBe(false);
+    });
+});
+
+describe('buildContext extras', () => {
+    it('carries the developer name and the run command', () => {
+        const context = buildContext(GATEWAY, EXTRAS);
+
+        expect(context.developerUsername).toBe('dhruv');
+        expect(context.pm.run).toBe('pnpm run');
+    });
+});

--- a/cli/create-seedcord/tests/template/context.test.ts
+++ b/cli/create-seedcord/tests/template/context.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildContext } from '@src/template/context';
+import { buildContext } from '@template/context';
 
-import type { ScaffoldAnswers } from '@src/template/context';
+import type { ScaffoldAnswers } from '@template/context';
 
 const GATEWAY: ScaffoldAnswers = {
     directory: 'my-bot',

--- a/cli/create-seedcord/tests/template/context.test.ts
+++ b/cli/create-seedcord/tests/template/context.test.ts
@@ -41,8 +41,8 @@ describe('buildContext on gateway', () => {
         expect(context.partials).toEqual(['Message', 'Channel', 'Reaction']);
     });
 
-    it('writes an events directory once a capability was picked', () => {
-        expect(context.hasEvents).toBe(true);
+    it('sees no message capability behind reactions alone', () => {
+        expect(context.hasMessages).toBe(false);
     });
 
     it('leaves the public key empty, since gateway never asks for one', () => {
@@ -65,7 +65,7 @@ describe('buildContext on http', () => {
     it('carries no intents or partials', () => {
         expect(context.intents).toEqual([]);
         expect(context.partials).toEqual([]);
-        expect(context.hasEvents).toBe(false);
+        expect(context.hasMessages).toBe(false);
     });
 
     it('carries the public key through', () => {
@@ -80,8 +80,18 @@ describe('buildContext on a gateway bot that picked nothing', () => {
         expect(context.intents).toEqual(['Guilds']);
     });
 
-    it('skips the events directory', () => {
-        expect(context.hasEvents).toBe(false);
+    it('sees no message capability', () => {
+        expect(context.hasMessages).toBe(false);
+    });
+});
+
+describe('the message capabilities', () => {
+    it.each(['guild-messages', 'message-text', 'direct-messages'])('counts %s', (id) => {
+        expect(buildContext({ ...GATEWAY, capabilities: [id] }, EXTRAS).hasMessages).toBe(true);
+    });
+
+    it.each(['reactions', 'voice', 'polls', 'automod'])('leaves %s out', (id) => {
+        expect(buildContext({ ...GATEWAY, capabilities: [id] }, EXTRAS).hasMessages).toBe(false);
     });
 });
 

--- a/cli/create-seedcord/tests/template/render.test.ts
+++ b/cli/create-seedcord/tests/template/render.test.ts
@@ -1,0 +1,129 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildContext } from '@src/template/context';
+import { renderTemplates } from '@src/template/render';
+
+import type { ScaffoldAnswers } from '@src/template/context';
+
+const TEMPLATES = resolve(import.meta.dirname, '../../templates');
+const EXTRAS = { developerUsername: 'dhruv', runCommand: 'pnpm run' };
+
+const GATEWAY: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'gateway',
+    capabilities: ['reactions'],
+    token: 'aaa.bbb.ccc',
+    botColor: 'Blurple'
+};
+
+const HTTP: ScaffoldAnswers = {
+    directory: 'my-bot',
+    language: 'typescript',
+    transport: 'http',
+    token: 'aaa.bbb.ccc',
+    publicKey: 'a'.repeat(64),
+    botColor: 'Blurple'
+};
+
+async function render(answers: ScaffoldAnswers): Promise<Map<string, string>> {
+    const files = await renderTemplates(TEMPLATES, buildContext(answers, EXTRAS));
+    return new Map(files.map((file) => [file.path, file.contents]));
+}
+
+async function renderOne(answers: ScaffoldAnswers, path: string): Promise<string> {
+    const files = await render(answers);
+    return files.get(path) ?? '';
+}
+
+describe('renderTemplates', () => {
+    it('drops the .hbs extension', async () => {
+        const files = await render(GATEWAY);
+
+        expect([...files.keys()].filter((path) => path.endsWith('.hbs'))).toEqual([]);
+    });
+
+    it('restores the leading dot on the three files npm would drop', async () => {
+        const files = await render(GATEWAY);
+
+        expect(files.has('.env')).toBe(true);
+        expect(files.has('.gitignore')).toBe(true);
+        expect(files.has('.prettierignore')).toBe(true);
+    });
+
+    it('keeps nested paths', async () => {
+        const files = await render(GATEWAY);
+
+        expect(files.has('src/commands/Ping.ts')).toBe(true);
+        expect(files.has('src/handlers/Ping.ts')).toBe(true);
+    });
+
+    it('writes the same file set for both transports', async () => {
+        const gateway = await render(GATEWAY);
+        const http = await render(HTTP);
+
+        expect([...http.keys()].sort()).toEqual([...gateway.keys()].sort());
+    });
+});
+
+describe('the rendered gateway config', () => {
+    it('imports the gateway package and its intents', async () => {
+        const bot = await renderOne(GATEWAY, 'src/bot.ts');
+
+        expect(bot).toContain("from '@seedcord/gateway'");
+        expect(bot).toContain('GatewayIntentBits.Guilds');
+        expect(bot).toContain('GatewayIntentBits.GuildMessageReactions');
+        expect(bot).toContain('Partials.Reaction');
+    });
+
+    it('points events at the directory once a capability was picked', async () => {
+        const bot = await renderOne(GATEWAY, 'src/bot.ts');
+
+        expect(bot).toContain("'./events'");
+        expect(bot).not.toContain('path: null,');
+    });
+
+    it('leaves events null when nothing was picked', async () => {
+        const bot = await renderOne({ ...GATEWAY, capabilities: [] }, 'src/bot.ts');
+
+        expect(bot).toContain('GatewayIntentBits.Guilds');
+        expect(bot).not.toContain('./events');
+    });
+});
+
+describe('the rendered http config', () => {
+    it('imports the http package and declares no intents', async () => {
+        const bot = await renderOne(HTTP, 'src/bot.ts');
+
+        expect(bot).toContain("from '@seedcord/http'");
+        expect(bot).not.toContain('GatewayIntentBits');
+        expect(bot).not.toContain('clientOptions');
+    });
+
+    it('writes the public key into the env file', async () => {
+        const env = await renderOne(HTTP, '.env');
+
+        expect(env).toContain(`DISCORD_PUBLIC_KEY=${'a'.repeat(64)}`);
+    });
+
+    it('leaves the public key out on gateway', async () => {
+        const env = await renderOne(GATEWAY, '.env');
+
+        expect(env).not.toContain('DISCORD_PUBLIC_KEY');
+    });
+});
+
+describe('escaping', () => {
+    it('leaves an apostrophe in a git user name alone', async () => {
+        const files = await renderTemplates(
+            TEMPLATES,
+            buildContext(GATEWAY, { ...EXTRAS, developerUsername: "Conor O'Brien" })
+        );
+        const bot = files.find((file) => file.path === 'src/bot.ts')?.contents ?? '';
+
+        expect(bot).toContain("O'Brien");
+        expect(bot).not.toContain('&#x27;');
+    });
+});

--- a/cli/create-seedcord/tests/template/render.test.ts
+++ b/cli/create-seedcord/tests/template/render.test.ts
@@ -35,7 +35,11 @@ async function render(answers: ScaffoldAnswers): Promise<Map<string, string>> {
 
 async function renderOne(answers: ScaffoldAnswers, path: string): Promise<string> {
     const files = await render(answers);
-    return files.get(path) ?? '';
+    const contents = files.get(path);
+    // an empty string would satisfy every not.toContain below
+    if (contents === undefined) throw new Error(`${path} was never rendered`);
+
+    return contents;
 }
 
 describe('renderTemplates', () => {

--- a/cli/create-seedcord/tests/template/render.test.ts
+++ b/cli/create-seedcord/tests/template/render.test.ts
@@ -2,10 +2,10 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { buildContext } from '@src/template/context';
-import { renderTemplates } from '@src/template/render';
+import { buildContext } from '@template/context';
+import { renderTemplates } from '@template/render';
 
-import type { ScaffoldAnswers } from '@src/template/context';
+import type { ScaffoldAnswers } from '@template/context';
 
 const TEMPLATES = resolve(import.meta.dirname, '../../templates');
 const EXTRAS = { developerUsername: 'dhruv', runCommand: 'pnpm run' };

--- a/cli/create-seedcord/tests/template/render.test.ts
+++ b/cli/create-seedcord/tests/template/render.test.ts
@@ -60,11 +60,41 @@ describe('renderTemplates', () => {
         expect(files.has('src/handlers/Ping.ts')).toBe(true);
     });
 
-    it('writes the same file set for both transports', async () => {
+    it('gives http every file except the events one', async () => {
         const gateway = await render(GATEWAY);
         const http = await render(HTTP);
+        const onlyOnGateway = [...gateway.keys()].filter((path) => !http.has(path));
 
-        expect([...http.keys()].sort()).toEqual([...gateway.keys()].sort());
+        expect(onlyOnGateway).toEqual(['src/events/Ready.ts']);
+    });
+});
+
+describe('the sample event handler', () => {
+    it('replies to a mention once a message capability is picked', async () => {
+        const files = await render({ ...GATEWAY, capabilities: ['guild-messages'] });
+
+        expect(files.has('src/events/Mentioned.ts')).toBe(true);
+        expect(files.has('src/events/Ready.ts')).toBe(false);
+    });
+
+    it('falls back to the boot handler for any other capability', async () => {
+        const files = await render(GATEWAY);
+
+        expect(files.has('src/events/Ready.ts')).toBe(true);
+        expect(files.has('src/events/Mentioned.ts')).toBe(false);
+    });
+
+    it('ships the boot handler even when nothing was picked', async () => {
+        const files = await render({ ...GATEWAY, capabilities: [] });
+
+        expect(files.has('src/events/Ready.ts')).toBe(true);
+    });
+
+    it('writes neither on http', async () => {
+        const files = await render(HTTP);
+
+        expect(files.has('src/events/Ready.ts')).toBe(false);
+        expect(files.has('src/events/Mentioned.ts')).toBe(false);
     });
 });
 
@@ -78,18 +108,10 @@ describe('the rendered gateway config', () => {
         expect(bot).toContain('Partials.Reaction');
     });
 
-    it('points events at the directory once a capability was picked', async () => {
-        const bot = await renderOne(GATEWAY, 'src/bot.ts');
-
-        expect(bot).toContain("'./events'");
-        expect(bot).not.toContain('path: null,');
-    });
-
-    it('leaves events null when nothing was picked', async () => {
+    it('always points events at the directory', async () => {
         const bot = await renderOne({ ...GATEWAY, capabilities: [] }, 'src/bot.ts');
 
-        expect(bot).toContain('GatewayIntentBits.Guilds');
-        expect(bot).not.toContain('./events');
+        expect(bot).toContain("'./events'");
     });
 });
 

--- a/cli/create-seedcord/tsconfig.json
+++ b/cli/create-seedcord/tsconfig.json
@@ -5,7 +5,10 @@
         "rootDir": "./",
         "outDir": "./dist",
         "paths": {
-            "@src/*": ["./src/*"]
+            "@cli/*": ["./src/cli/*"],
+            "@interview/*": ["./src/interview/*"],
+            "@scaffold/*": ["./src/scaffold/*"],
+            "@template/*": ["./src/template/*"]
         }
     },
     "include": ["src/**/*.ts", "tests/**/*.ts", "tsdown.config.ts", "vitest.config.ts"],

--- a/cli/create-seedcord/tsdown.config.ts
+++ b/cli/create-seedcord/tsdown.config.ts
@@ -1,4 +1,9 @@
 import { createTsdownConfig } from '@seedcord/tsdown-config';
 
 // every create call is a cold download
-export default createTsdownConfig({ entry: ['src/index.ts'], deps: {}, format: ['esm'], dts: false });
+export default createTsdownConfig({
+    entry: ['src/index.ts'],
+    deps: { alwaysBundle: [/./], onlyBundle: false },
+    format: ['esm'],
+    dts: false
+});

--- a/cli/seedcord/bin/seedcord.mjs
+++ b/cli/seedcord/bin/seedcord.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';

--- a/cli/seedcord/src/ui/components/Banner.tsx
+++ b/cli/seedcord/src/ui/components/Banner.tsx
@@ -1,11 +1,8 @@
+import { BRAND } from '@seedcord/errors/internal';
 import { Text } from 'ink';
 import React from 'react';
 
 import type { ReactElement } from 'react';
-
-const SEED_COLOR = '#f04e36';
-const CORD_COLOR = '#6fab49';
-const VERSION_COLOR = '#f7f5e8';
 
 interface BannerProps {
     readonly version: string | null;
@@ -14,13 +11,13 @@ interface BannerProps {
 export function Banner({ version }: BannerProps): ReactElement {
     return (
         <Text>
-            <Text bold color={SEED_COLOR}>
+            <Text bold color={BRAND.flesh}>
                 seed
             </Text>
-            <Text bold color={CORD_COLOR}>
+            <Text bold color={BRAND.rind}>
                 cord
             </Text>
-            {version === null ? null : <Text color={VERSION_COLOR}> • v{version}</Text>}
+            {version === null ? null : <Text color={BRAND.pith}> • v{version}</Text>}
         </Text>
     );
 }

--- a/mocks/gateway/src/events/Mentioned.ts
+++ b/mocks/gateway/src/events/Mentioned.ts
@@ -1,0 +1,16 @@
+import { EventHandler, Gated, IgnoreBots, RegisterEvent } from '@seedcord/gateway';
+import { Events } from 'discord.js';
+
+@Gated(IgnoreBots)
+@RegisterEvent([Events.MessageCreate])
+export class Mentioned extends EventHandler<Events.MessageCreate> {
+    public async execute(): Promise<void> {
+        const [message] = this.event;
+        if (!message.inGuild()) return;
+
+        // discord sends the content of a message that mentions your app without the privileged intent
+        if (!message.mentions.users.has(message.client.user.id)) return;
+
+        await message.reply(`hey ${message.author.displayName}`);
+    }
+}

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -257,5 +257,7 @@ export enum SeedcordErrorCode {
     /** A flag supplied an answer for a question the earlier answers skip. */
     CreateFlagNotApplicable = 3202,
     /** A flag carried a value its question rejects. */
-    CreateInvalidAnswer = 3203
+    CreateInvalidAnswer = 3203,
+    /** The command line did not parse. */
+    CreateBadUsage = 3204
 }

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -261,5 +261,7 @@ export enum SeedcordErrorCode {
     /** The command line did not parse. */
     CreateBadUsage = 3204,
     /** The target path already holds something. */
-    CreateTargetNotEmpty = 3205
+    CreateTargetNotEmpty = 3205,
+    /** A command the scaffolder shelled out to exited non-zero. */
+    CreateStepFailed = 3206
 }

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -259,5 +259,7 @@ export enum SeedcordErrorCode {
     /** A flag carried a value its question rejects. */
     CreateInvalidAnswer = 3203,
     /** The command line did not parse. */
-    CreateBadUsage = 3204
+    CreateBadUsage = 3204,
+    /** The target path already holds something. */
+    CreateTargetNotEmpty = 3205
 }

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -250,5 +250,12 @@ export enum SeedcordErrorCode {
     /** Discord rejected the tunnel URL as an interactions endpoint. */
     CliTunnelNotVerified = 3134,
     /** The tunnel URL never answered its health probe. */
-    CliTunnelUnreachable = 3135
+    CliTunnelUnreachable = 3135,
+
+    /** A create prompt was cancelled (Ctrl-C), and nothing has been written yet. */
+    CreateCancelled = 3201,
+    /** A flag supplied an answer for a question the earlier answers skip. */
+    CreateFlagNotApplicable = 3202,
+    /** A flag carried a value its question rejects. */
+    CreateInvalidAnswer = 3203
 }

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -238,7 +238,8 @@ const messages = {
     // node's parseArgs message ends on an unclosed quote
     [SeedcordErrorCode.CreateBadUsage]: (reason: string) => `${reason}\nRun with --help for the flag list.`,
     [SeedcordErrorCode.CreateTargetNotEmpty]: (target: string) =>
-        `${target} already has files in it. Pick an empty directory or a name that does not exist yet.`
+        `${target} already has files in it. Pick an empty directory or a name that does not exist yet.`,
+    [SeedcordErrorCode.CreateStepFailed]: (command: string, reason: string) => `\`${command}\` failed.\n${reason}`
 } satisfies Record<SeedcordErrorCode, (...args: never[]) => string>;
 
 /** @internal */

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -236,7 +236,9 @@ const messages = {
         `The --${flag} flag does not apply to the answers you gave.`,
     [SeedcordErrorCode.CreateInvalidAnswer]: (flag: string, reason: string) => `--${flag}: ${reason}`,
     // node's parseArgs message ends on an unclosed quote
-    [SeedcordErrorCode.CreateBadUsage]: (reason: string) => `${reason}\nRun with --help for the flag list.`
+    [SeedcordErrorCode.CreateBadUsage]: (reason: string) => `${reason}\nRun with --help for the flag list.`,
+    [SeedcordErrorCode.CreateTargetNotEmpty]: (target: string) =>
+        `${target} already has files in it. Pick an empty directory or a name that does not exist yet.`
 } satisfies Record<SeedcordErrorCode, (...args: never[]) => string>;
 
 /** @internal */

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -234,7 +234,9 @@ const messages = {
     [SeedcordErrorCode.CreateCancelled]: () => 'Cancelled.',
     [SeedcordErrorCode.CreateFlagNotApplicable]: (flag: string) =>
         `The --${flag} flag does not apply to the answers you gave.`,
-    [SeedcordErrorCode.CreateInvalidAnswer]: (flag: string, reason: string) => `--${flag}: ${reason}`
+    [SeedcordErrorCode.CreateInvalidAnswer]: (flag: string, reason: string) => `--${flag}: ${reason}`,
+    // node's parseArgs message ends on an unclosed quote
+    [SeedcordErrorCode.CreateBadUsage]: (reason: string) => `${reason}\nRun with --help for the flag list.`
 } satisfies Record<SeedcordErrorCode, (...args: never[]) => string>;
 
 /** @internal */

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -230,7 +230,11 @@ const messages = {
         `cloudflared did not report a tunnel URL within ${seconds}s. Check that the binary runs and that the network allows it.`,
     [SeedcordErrorCode.CliTunnelNotVerified]: (url: string) => `Discord rejected ${url} as an interactions endpoint.`,
     [SeedcordErrorCode.CliTunnelUnreachable]: (url: string, seconds: number) =>
-        `${url} did not answer within ${seconds}s, so nothing was PATCHed to Discord.`
+        `${url} did not answer within ${seconds}s, so nothing was PATCHed to Discord.`,
+    [SeedcordErrorCode.CreateCancelled]: () => 'Cancelled.',
+    [SeedcordErrorCode.CreateFlagNotApplicable]: (flag: string) =>
+        `The --${flag} flag does not apply to the answers you gave.`,
+    [SeedcordErrorCode.CreateInvalidAnswer]: (flag: string, reason: string) => `--${flag}: ${reason}`
 } satisfies Record<SeedcordErrorCode, (...args: never[]) => string>;
 
 /** @internal */

--- a/packages/errors/src/internal.index.ts
+++ b/packages/errors/src/internal.index.ts
@@ -1,5 +1,5 @@
 export { SeedcordError, SeedcordTypeError, SeedcordRangeError } from './SeedcordError';
 
 // these files don't exactly belong in this package but are used in places logger isn't imported
-export { paint } from './palette';
+export { BRAND, paint } from './palette';
 export { validateDiscordToken } from './validateDiscordToken';

--- a/packages/errors/src/internal.index.ts
+++ b/packages/errors/src/internal.index.ts
@@ -1,2 +1,5 @@
 export { SeedcordError, SeedcordTypeError, SeedcordRangeError } from './SeedcordError';
+
+// these files don't exactly belong in this package but are used in places logger isn't imported
+export { paint } from './palette';
 export { validateDiscordToken } from './validateDiscordToken';

--- a/packages/errors/src/palette.ts
+++ b/packages/errors/src/palette.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+
+// truecolor because a terminal theme remaps chalk's 16-color names (blue turns orange in monokai)
+export const paint = {
+    sky: chalk.hex('#8fc7ff'),
+    iris: chalk.hex('#e29bff'),
+    mint: chalk.hex('#66d98a'),
+    amber: chalk.hex('#ffc061'),
+    coral: chalk.hex('#ff6b85'),
+    mute: chalk.dim
+} as const;

--- a/packages/errors/src/palette.ts
+++ b/packages/errors/src/palette.ts
@@ -1,5 +1,12 @@
 import chalk from 'chalk';
 
+// @seedcord/ui carries the same three for the web
+export const BRAND = {
+    flesh: '#f04e36',
+    rind: '#6fab49',
+    pith: '#f8f6e8'
+} as const;
+
 // truecolor because a terminal theme remaps chalk's 16-color names (blue turns orange in monokai)
 export const paint = {
     sky: chalk.hex('#8fc7ff'),
@@ -7,5 +14,8 @@ export const paint = {
     mint: chalk.hex('#66d98a'),
     amber: chalk.hex('#ffc061'),
     coral: chalk.hex('#ff6b85'),
+    flesh: chalk.hex(BRAND.flesh),
+    rind: chalk.hex(BRAND.rind),
+    pith: chalk.hex(BRAND.pith),
     mute: chalk.dim
 } as const;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -56,6 +56,7 @@
         "typescript": "catalog:peer"
     },
     "dependencies": {
+        "@seedcord/errors": "workspace:*",
         "@seedcord/types": "workspace:*",
         "@seedcord/utils": "workspace:*",
         "chalk": "catalog:deps",

--- a/packages/logger/src/LoggerUtilities.ts
+++ b/packages/logger/src/LoggerUtilities.ts
@@ -1,7 +1,6 @@
+import { paint } from '@seedcord/errors/internal';
 import { formatFilePath } from '@seedcord/utils';
 import chalk from 'chalk';
-
-import { paint } from './palette';
 
 import type { LogLevel } from './types';
 import type { ILogger } from '@seedcord/types';

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -2,7 +2,8 @@ export { FRAMEWORK_CHANNELS } from './channels';
 export { Logger } from './Logger';
 export { LoggerChannelRegistry } from './LoggerChannelRegistry';
 export { ObjectConsoleSink } from './ObjectConsoleSink';
-export { LEVEL_COLOR, paint } from './palette';
+export { paint } from '@seedcord/errors/internal';
+export { LEVEL_COLOR } from './palette';
 
 export type {
     FrameworkChannel,

--- a/packages/logger/src/node/LogFormatter.ts
+++ b/packages/logger/src/node/LogFormatter.ts
@@ -1,8 +1,9 @@
+import { paint } from '@seedcord/errors/internal';
 import { stripAnsi } from '@seedcord/utils';
 import chalk from 'chalk';
 import { format } from 'winston';
 
-import { LEVEL_COLOR, paint } from '../palette';
+import { LEVEL_COLOR } from '../palette';
 
 import type { Logform } from 'winston';
 

--- a/packages/logger/src/palette.ts
+++ b/packages/logger/src/palette.ts
@@ -1,5 +1,3 @@
-import chalk from 'chalk';
-
 import type { LogLevel } from './types';
 
 // truecolor because a terminal theme remaps chalk's 16-color names (blue turns orange in monokai)
@@ -10,12 +8,3 @@ export const LEVEL_COLOR: Record<LogLevel, string> = {
     debug: '#66b3ff',
     trace: '#b399e6'
 };
-
-export const paint = {
-    sky: chalk.hex('#8fc7ff'),
-    iris: chalk.hex('#e29bff'),
-    mint: chalk.hex('#66d98a'),
-    amber: chalk.hex('#ffc061'),
-    coral: chalk.hex('#ff6b85'),
-    mute: chalk.dim
-} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,163 +9,16 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
-    '@discordjs/builders':
-      specifier: ^1.14.1
-      version: 1.14.1
-    '@discordjs/rest':
-      specifier: ^2.6.3
-      version: 2.6.3
-    '@tailwindcss/postcss':
-      specifier: ^4.3.3
-      version: 4.3.3
-    '@types/node':
-      specifier: ^26.1.2
-      version: 26.1.2
-    chalk:
-      specifier: ^6.0.0
-      version: 6.0.0
-    envapt:
-      specifier: ^8.1.1
-      version: 8.1.1
-    lodash.merge:
-      specifier: ^4.6.2
-      version: 4.6.2
-    lucide-react:
-      specifier: ^1.28.0
-      version: 1.28.0
-    motion:
-      specifier: ^12.43.0
-      version: 12.43.0
-    next:
-      specifier: ^16.2.12
-      version: 16.2.12
-    prettier:
-      specifier: ^3.9.6
-      version: 3.9.6
-    prettier-plugin-tailwindcss:
-      specifier: ^0.8.1
-      version: 0.8.1
-    reflect-metadata:
-      specifier: ^0.2.2
-      version: 0.2.2
-    shiki:
-      specifier: ^4.4.1
-      version: 4.4.1
-    tailwindcss:
-      specifier: ^4.3.3
-      version: 4.3.3
-    tsdown:
-      specifier: ^0.22.14
-      version: 0.22.14
     tsx:
       specifier: ^4.23.5
       version: 4.23.5
-    type-fest:
-      specifier: ^5.8.0
-      version: 5.8.0
-    vite:
-      specifier: ^8.2.0
-      version: 8.2.0
-  eslint:
-    '@types/eslint-plugin-security':
-      specifier: ^3.0.1
-      version: 3.0.1
-    '@typescript-eslint/parser':
-      specifier: ^8.65.0
-      version: 8.65.0
-    '@typescript-eslint/rule-tester':
-      specifier: ^8.65.0
-      version: 8.65.0
-    '@typescript-eslint/utils':
-      specifier: ^8.65.0
-      version: 8.65.0
-    eslint:
-      specifier: ^10.8.0
-      version: 10.8.0
-    eslint-config-next:
-      specifier: ^16.2.12
-      version: 16.2.12
-    eslint-config-prettier:
-      specifier: ^10.1.8
-      version: 10.1.8
-    eslint-import-resolver-typescript:
-      specifier: ^4.4.5
-      version: 4.4.5
-    eslint-plugin-better-tailwindcss:
-      specifier: ^4.7.0
-      version: 4.7.0
-    eslint-plugin-import-x:
-      specifier: ^4.17.1
-      version: 4.17.1
-    eslint-plugin-mdx:
-      specifier: ^3.8.1
-      version: 3.8.1
-    eslint-plugin-prettier:
-      specifier: ^5.5.6
-      version: 5.5.6
-    eslint-plugin-react-compiler:
-      specifier: 19.1.0-rc.2
-      version: 19.1.0-rc.2
-    eslint-plugin-security:
-      specifier: ^4.0.1
-      version: 4.0.1
-    eslint-plugin-tailwind-canonical-classes:
-      specifier: ^1.4.1
-      version: 1.4.1
-    eslint-plugin-tsdoc:
-      specifier: ^0.5.2
-      version: 0.5.2
-    eslint-plugin-unicorn:
-      specifier: ^72.0.0
-      version: 72.0.0
-    typescript-eslint:
-      specifier: ^8.65.0
-      version: 8.65.0
   peer:
     discord.js:
       specifier: ^14.27.0
       version: 14.27.0
-    mongoose:
-      specifier: ^9.9.1
-      version: 9.9.1
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
-  react:
-    '@types/react':
-      specifier: ^19.2.18
-      version: 19.2.18
-    '@types/react-dom':
-      specifier: ^19.2.4
-      version: 19.2.4
-    react:
-      specifier: ^19.2.8
-      version: 19.2.8
-    react-dom:
-      specifier: ^19.2.8
-      version: 19.2.8
-  test:
-    '@testing-library/dom':
-      specifier: ^10.4.1
-      version: 10.4.1
-    '@testing-library/jest-dom':
-      specifier: ^7.0.0
-      version: 7.0.0
-    '@testing-library/react':
-      specifier: ^16.3.2
-      version: 16.3.2
-    '@vitest/coverage-v8':
-      specifier: ^4.1.10
-      version: 4.1.10
-    dedent:
-      specifier: ^1.7.2
-      version: 1.7.2
-    jsdom:
-      specifier: ^30.0.1
-      version: 30.0.1
-    vitest:
-      specifier: ^4.1.10
-      version: 4.1.10
 
 overrides:
   discord.js>undici: ^6.27.0
@@ -482,9 +335,6 @@ importers:
       '@seedcord/vitest-config':
         specifier: workspace:*
         version: link:../../tooling/vitest-config
-      chalk:
-        specifier: catalog:deps
-        version: 6.0.0
       discord.js:
         specifier: catalog:peer
         version: 14.27.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
+      package-manager-detector:
+        specifier: ^1.8.0
+        version: 1.8.0
       tsx:
         specifier: catalog:deps
         version: 4.23.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,163 +9,16 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
-    '@discordjs/builders':
-      specifier: ^1.14.1
-      version: 1.14.1
-    '@discordjs/rest':
-      specifier: ^2.6.3
-      version: 2.6.3
-    '@tailwindcss/postcss':
-      specifier: ^4.3.3
-      version: 4.3.3
-    '@types/node':
-      specifier: ^26.1.2
-      version: 26.1.2
-    chalk:
-      specifier: ^6.0.0
-      version: 6.0.0
-    envapt:
-      specifier: ^8.1.1
-      version: 8.1.1
-    lodash.merge:
-      specifier: ^4.6.2
-      version: 4.6.2
-    lucide-react:
-      specifier: ^1.28.0
-      version: 1.28.0
-    motion:
-      specifier: ^12.43.0
-      version: 12.43.0
-    next:
-      specifier: ^16.2.12
-      version: 16.2.12
-    prettier:
-      specifier: ^3.9.6
-      version: 3.9.6
-    prettier-plugin-tailwindcss:
-      specifier: ^0.8.1
-      version: 0.8.1
-    reflect-metadata:
-      specifier: ^0.2.2
-      version: 0.2.2
-    shiki:
-      specifier: ^4.4.1
-      version: 4.4.1
-    tailwindcss:
-      specifier: ^4.3.3
-      version: 4.3.3
-    tsdown:
-      specifier: ^0.22.14
-      version: 0.22.14
     tsx:
       specifier: ^4.23.5
       version: 4.23.5
-    type-fest:
-      specifier: ^5.8.0
-      version: 5.8.0
-    vite:
-      specifier: ^8.2.0
-      version: 8.2.0
-  eslint:
-    '@types/eslint-plugin-security':
-      specifier: ^3.0.1
-      version: 3.0.1
-    '@typescript-eslint/parser':
-      specifier: ^8.65.0
-      version: 8.65.0
-    '@typescript-eslint/rule-tester':
-      specifier: ^8.65.0
-      version: 8.65.0
-    '@typescript-eslint/utils':
-      specifier: ^8.65.0
-      version: 8.65.0
-    eslint:
-      specifier: ^10.8.0
-      version: 10.8.0
-    eslint-config-next:
-      specifier: ^16.2.12
-      version: 16.2.12
-    eslint-config-prettier:
-      specifier: ^10.1.8
-      version: 10.1.8
-    eslint-import-resolver-typescript:
-      specifier: ^4.4.5
-      version: 4.4.5
-    eslint-plugin-better-tailwindcss:
-      specifier: ^4.7.0
-      version: 4.7.0
-    eslint-plugin-import-x:
-      specifier: ^4.17.1
-      version: 4.17.1
-    eslint-plugin-mdx:
-      specifier: ^3.8.1
-      version: 3.8.1
-    eslint-plugin-prettier:
-      specifier: ^5.5.6
-      version: 5.5.6
-    eslint-plugin-react-compiler:
-      specifier: 19.1.0-rc.2
-      version: 19.1.0-rc.2
-    eslint-plugin-security:
-      specifier: ^4.0.1
-      version: 4.0.1
-    eslint-plugin-tailwind-canonical-classes:
-      specifier: ^1.4.1
-      version: 1.4.1
-    eslint-plugin-tsdoc:
-      specifier: ^0.5.2
-      version: 0.5.2
-    eslint-plugin-unicorn:
-      specifier: ^72.0.0
-      version: 72.0.0
-    typescript-eslint:
-      specifier: ^8.65.0
-      version: 8.65.0
   peer:
     discord.js:
       specifier: ^14.27.0
       version: 14.27.0
-    mongoose:
-      specifier: ^9.9.1
-      version: 9.9.1
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
-  react:
-    '@types/react':
-      specifier: ^19.2.18
-      version: 19.2.18
-    '@types/react-dom':
-      specifier: ^19.2.4
-      version: 19.2.4
-    react:
-      specifier: ^19.2.8
-      version: 19.2.8
-    react-dom:
-      specifier: ^19.2.8
-      version: 19.2.8
-  test:
-    '@testing-library/dom':
-      specifier: ^10.4.1
-      version: 10.4.1
-    '@testing-library/jest-dom':
-      specifier: ^7.0.0
-      version: 7.0.0
-    '@testing-library/react':
-      specifier: ^16.3.2
-      version: 16.3.2
-    '@vitest/coverage-v8':
-      specifier: ^4.1.10
-      version: 4.1.10
-    dedent:
-      specifier: ^1.7.2
-      version: 1.7.2
-    jsdom:
-      specifier: ^30.0.1
-      version: 30.0.1
-    vitest:
-      specifier: ^4.1.10
-      version: 4.1.10
 
 overrides:
   discord.js>undici: ^6.27.0
@@ -460,11 +313,13 @@ importers:
         version: 4.118.0(@types/node@26.1.2)
 
   cli/create-seedcord:
-    dependencies:
+    devDependencies:
       '@clack/prompts':
         specifier: catalog:deps
         version: 1.7.0
-    devDependencies:
+      '@seedcord/errors':
+        specifier: workspace:*
+        version: link:../../packages/errors
       '@seedcord/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,9 @@ importers:
 
   packages/logger:
     dependencies:
+      '@seedcord/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@seedcord/types':
         specifier: workspace:*
         version: link:../types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,9 +317,6 @@ importers:
       '@clack/prompts':
         specifier: catalog:deps
         version: 1.7.0
-      '@seedcord/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@seedcord/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,9 @@ importers:
       '@seedcord/vitest-config':
         specifier: workspace:*
         version: link:../../tooling/vitest-config
+      chalk:
+        specifier: ^6.0.0
+        version: 6.0.0
       discord.js:
         specifier: catalog:peer
         version: 14.27.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,7 +483,7 @@ importers:
         specifier: workspace:*
         version: link:../../tooling/vitest-config
       chalk:
-        specifier: ^6.0.0
+        specifier: catalog:deps
         version: 6.0.0
       discord.js:
         specifier: catalog:peer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
       discord.js:
         specifier: catalog:peer
         version: 14.27.0
+      handlebars:
+        specifier: ^4.7.9
+        version: 4.7.9
       tsx:
         specifier: catalog:deps
         version: 4.23.5
@@ -5986,6 +5989,11 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -7011,6 +7019,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -8215,6 +8226,11 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
@@ -8553,6 +8569,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   workerd@1.20260730.1:
     resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
@@ -13464,6 +13483,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -14694,6 +14722,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  neo-async@2.6.2: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -16028,6 +16058,9 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   uint8array-extras@1.5.0: {}
 
   unbash@4.0.4: {}
@@ -16419,6 +16452,8 @@ snapshots:
       winston-transport: 4.9.0
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   workerd@1.20260730.1:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,163 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
+    '@discordjs/builders':
+      specifier: ^1.14.1
+      version: 1.14.1
+    '@discordjs/rest':
+      specifier: ^2.6.3
+      version: 2.6.3
+    '@tailwindcss/postcss':
+      specifier: ^4.3.3
+      version: 4.3.3
+    '@types/node':
+      specifier: ^26.1.2
+      version: 26.1.2
+    chalk:
+      specifier: ^6.0.0
+      version: 6.0.0
+    envapt:
+      specifier: ^8.1.1
+      version: 8.1.1
+    lodash.merge:
+      specifier: ^4.6.2
+      version: 4.6.2
+    lucide-react:
+      specifier: ^1.28.0
+      version: 1.28.0
+    motion:
+      specifier: ^12.43.0
+      version: 12.43.0
+    next:
+      specifier: ^16.2.12
+      version: 16.2.12
+    prettier:
+      specifier: ^3.9.6
+      version: 3.9.6
+    prettier-plugin-tailwindcss:
+      specifier: ^0.8.1
+      version: 0.8.1
+    reflect-metadata:
+      specifier: ^0.2.2
+      version: 0.2.2
+    shiki:
+      specifier: ^4.4.1
+      version: 4.4.1
+    tailwindcss:
+      specifier: ^4.3.3
+      version: 4.3.3
+    tsdown:
+      specifier: ^0.22.14
+      version: 0.22.14
     tsx:
       specifier: ^4.23.5
       version: 4.23.5
+    type-fest:
+      specifier: ^5.8.0
+      version: 5.8.0
+    vite:
+      specifier: ^8.2.0
+      version: 8.2.0
+  eslint:
+    '@types/eslint-plugin-security':
+      specifier: ^3.0.1
+      version: 3.0.1
+    '@typescript-eslint/parser':
+      specifier: ^8.65.0
+      version: 8.65.0
+    '@typescript-eslint/rule-tester':
+      specifier: ^8.65.0
+      version: 8.65.0
+    '@typescript-eslint/utils':
+      specifier: ^8.65.0
+      version: 8.65.0
+    eslint:
+      specifier: ^10.8.0
+      version: 10.8.0
+    eslint-config-next:
+      specifier: ^16.2.12
+      version: 16.2.12
+    eslint-config-prettier:
+      specifier: ^10.1.8
+      version: 10.1.8
+    eslint-import-resolver-typescript:
+      specifier: ^4.4.5
+      version: 4.4.5
+    eslint-plugin-better-tailwindcss:
+      specifier: ^4.7.0
+      version: 4.7.0
+    eslint-plugin-import-x:
+      specifier: ^4.17.1
+      version: 4.17.1
+    eslint-plugin-mdx:
+      specifier: ^3.8.1
+      version: 3.8.1
+    eslint-plugin-prettier:
+      specifier: ^5.5.6
+      version: 5.5.6
+    eslint-plugin-react-compiler:
+      specifier: 19.1.0-rc.2
+      version: 19.1.0-rc.2
+    eslint-plugin-security:
+      specifier: ^4.0.1
+      version: 4.0.1
+    eslint-plugin-tailwind-canonical-classes:
+      specifier: ^1.4.1
+      version: 1.4.1
+    eslint-plugin-tsdoc:
+      specifier: ^0.5.2
+      version: 0.5.2
+    eslint-plugin-unicorn:
+      specifier: ^72.0.0
+      version: 72.0.0
+    typescript-eslint:
+      specifier: ^8.65.0
+      version: 8.65.0
   peer:
     discord.js:
       specifier: ^14.27.0
       version: 14.27.0
+    mongoose:
+      specifier: ^9.9.1
+      version: 9.9.1
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+  react:
+    '@types/react':
+      specifier: ^19.2.18
+      version: 19.2.18
+    '@types/react-dom':
+      specifier: ^19.2.4
+      version: 19.2.4
+    react:
+      specifier: ^19.2.8
+      version: 19.2.8
+    react-dom:
+      specifier: ^19.2.8
+      version: 19.2.8
+  test:
+    '@testing-library/dom':
+      specifier: ^10.4.1
+      version: 10.4.1
+    '@testing-library/jest-dom':
+      specifier: ^7.0.0
+      version: 7.0.0
+    '@testing-library/react':
+      specifier: ^16.3.2
+      version: 16.3.2
+    '@vitest/coverage-v8':
+      specifier: ^4.1.10
+      version: 4.1.10
+    dedent:
+      specifier: ^1.7.2
+      version: 1.7.2
+    jsdom:
+      specifier: ^30.0.1
+      version: 30.0.1
+    vitest:
+      specifier: ^4.1.10
+      version: 4.1.10
 
 overrides:
   discord.js>undici: ^6.27.0
@@ -234,7 +381,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
       eslint-config-next:
         specifier: catalog:eslint
-        version: 16.2.12(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 16.2.12(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-react-compiler:
         specifier: catalog:eslint
         version: 19.1.0-rc.2(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
@@ -249,7 +396,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:test
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/home:
     dependencies:
@@ -317,6 +464,9 @@ importers:
       '@clack/prompts':
         specifier: catalog:deps
         version: 1.7.0
+      '@seedcord/errors':
+        specifier: workspace:*
+        version: link:../../packages/errors
       '@seedcord/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config
@@ -406,7 +556,7 @@ importers:
         version: 4.23.5
       vite:
         specifier: catalog:deps
-        version: 8.2.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0
@@ -560,7 +710,7 @@ importers:
         version: 5.8.0
       vite:
         specifier: catalog:deps
-        version: 8.2.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
   packages/errors:
     dependencies:
@@ -837,7 +987,7 @@ importers:
         version: 0.28.1
       vitest:
         specifier: catalog:test
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/logger:
     dependencies:
@@ -3907,9 +4057,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
@@ -3942,9 +4089,6 @@ packages:
 
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
-
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -3987,26 +4131,11 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.61.1':
-    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.61.1
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.65.0
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/parser@8.61.1':
-    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
@@ -4022,12 +4151,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.61.1':
-    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.65.0':
     resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
@@ -4046,10 +4169,6 @@ packages:
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.61.1':
-    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.65.0':
     resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4060,29 +4179,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/tsconfig-utils@8.61.1':
-    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/tsconfig-utils@8.62.1':
-    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/tsconfig-utils@8.65.0':
     resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.61.1':
-    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.65.0':
@@ -4096,10 +4196,6 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.61.1':
-    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4109,12 +4205,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/typescript-estree@8.61.1':
-    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/typescript-estree@8.65.0':
     resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
@@ -4129,13 +4219,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.61.1':
-    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/utils@8.65.0':
     resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4145,10 +4228,6 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.56.1':
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.61.1':
-    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.65.0':
@@ -5242,10 +5321,6 @@ packages:
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -5302,9 +5377,6 @@ packages:
   es-iterator-helpers@1.3.3:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -7035,10 +7107,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
-    engines: {node: '>=12.20.0'}
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -7963,10 +8031,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -8123,13 +8187,6 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-eslint@8.61.1:
-    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   typescript-eslint@8.65.0:
     resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -8178,9 +8235,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -9211,7 +9265,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 5.20260730.0-alpha(@types/node@26.1.2)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
       wrangler: 4.118.0(@types/node@26.1.2)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -10121,10 +10175,10 @@ snapshots:
       '@microsoft/api-extractor-model': 7.33.8(@types/node@26.1.2)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.23.1(@types/node@26.1.2)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
-      '@rushstack/ts-command-line': 5.3.10(@types/node@25.9.3)
+      '@rushstack/terminal': 0.24.0(@types/node@26.1.2)
+      '@rushstack/ts-command-line': 5.3.10(@types/node@26.1.2)
       diff: 8.0.4
       minimatch: 10.2.6
       resolve: 1.22.12
@@ -10819,19 +10873,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/node-core-library@5.23.1(@types/node@25.9.3)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.5
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.12
-      semver: 7.7.4
-    optionalDependencies:
-      '@types/node': 25.9.3
-
   '@rushstack/node-core-library@5.23.1(@types/node@26.1.2)':
     dependencies:
       ajv: 8.18.0
@@ -10845,26 +10886,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.2
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.3)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@26.1.2)':
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.2
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/terminal@0.24.0(@types/node@25.9.3)':
+  '@rushstack/terminal@0.24.0(@types/node@26.1.2)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.23.1(@types/node@26.1.2)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@26.1.2)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.2
 
-  '@rushstack/ts-command-line@5.3.10(@types/node@25.9.3)':
+  '@rushstack/ts-command-line@5.3.10(@types/node@26.1.2)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
+      '@rushstack/terminal': 0.24.0(@types/node@26.1.2)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -11175,7 +11216,7 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -11199,10 +11240,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
-
-  '@types/hast@3.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
 
   '@types/hast@3.0.5':
     dependencies:
@@ -11234,17 +11271,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
 
   '@types/pg@8.20.3':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.2
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
@@ -11279,22 +11312,6 @@ snapshots:
     dependencies:
       '@types/node': 26.1.2
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -11311,14 +11328,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
-      debug: 4.4.3(supports-color@10.2.2)
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -11346,20 +11367,10 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@typescript-eslint/project-service@8.56.1(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3(supports-color@10.2.2)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.61.1(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@10.2.2)
       typescript: 6.0.3
@@ -11394,11 +11405,6 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.61.1':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
-
   '@typescript-eslint/scope-manager@8.65.0':
     dependencies:
       '@typescript-eslint/types': 8.65.0
@@ -11408,29 +11414,9 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
-  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
@@ -11444,9 +11430,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.56.1': {}
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
-  '@typescript-eslint/types@8.61.1': {}
+  '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/types@8.65.0': {}
 
@@ -11456,21 +11452,6 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 10.2.6
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.61.1(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.61.1(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.6
       semver: 7.8.5
@@ -11506,17 +11487,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -11538,16 +11508,10 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@typescript-eslint/visitor-keys@8.56.1':
     dependencies:
       '@typescript-eslint/types': 8.56.1
-      eslint-visitor-keys: 5.0.1
-
-  '@typescript-eslint/visitor-keys@8.61.1':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
 
   '@typescript-eslint/visitor-keys@8.65.0':
@@ -12451,11 +12415,6 @@ snapshots:
 
   enabled@2.0.0: {}
 
-  enhanced-resolve@5.24.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -12566,8 +12525,6 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
-  es-module-lexer@2.3.0: {}
-
   es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
@@ -12628,26 +12585,6 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.12(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.12
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      globals: 16.4.0
-      typescript-eslint: 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-config-next@16.2.12(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.12
@@ -12659,7 +12596,7 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       globals: 16.4.0
-      typescript-eslint: 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      typescript-eslint: 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12692,13 +12629,13 @@ snapshots:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.14.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -12708,7 +12645,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.14.1
       is-bun-module: 2.0.0
       stable-hash-x: 0.2.0
       tinyglobby: 0.2.17
@@ -12736,17 +12673,6 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - bluebird
-      - supports-color
-
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
-    dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-    transitivePeerDependencies:
       - supports-color
 
   eslint-module-utils@2.13.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
@@ -12826,35 +12752,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@10.2.2)
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 10.2.6
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
@@ -13591,7 +13488,7 @@ snapshots:
 
   hast-util-to-html@9.0.5:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
@@ -13605,7 +13502,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hermes-estree@0.25.1: {}
 
@@ -14362,7 +14259,7 @@ snapshots:
   mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
@@ -14373,7 +14270,7 @@ snapshots:
   mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
@@ -14400,7 +14297,7 @@ snapshots:
   mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
@@ -14415,7 +14312,7 @@ snapshots:
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
@@ -14911,8 +14808,6 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
-
-  obug@2.1.3: {}
 
   obug@2.1.4: {}
 
@@ -15920,8 +15815,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -15972,7 +15865,7 @@ snapshots:
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.24.5
       tapable: 2.3.3
       tsconfig-paths: 4.2.0
 
@@ -16081,17 +15974,6 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
@@ -16099,6 +15981,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.65.0(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -16160,8 +16053,6 @@ snapshots:
       unconfig-core: 7.5.0
 
   undici-types@6.21.0: {}
-
-  undici-types@7.24.6: {}
 
   undici-types@8.3.0: {}
 
@@ -16347,21 +16238,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.2.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.25
-      rolldown: 1.2.1
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.3
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.23.5
-      yaml: 2.9.0
-
   vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -16377,37 +16253,6 @@ snapshots:
       tsx: 4.23.5
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.3
-      '@vitest/coverage-istanbul': 4.1.10(supports-color@10.2.2)(vitest@4.1.10)
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      jsdom: 30.0.1
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -16417,15 +16262,15 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)

--- a/tooling/ui/src/brandTheme.ts
+++ b/tooling/ui/src/brandTheme.ts
@@ -1,5 +1,5 @@
 const SEED_DARK = '#2d3328';
-const PITH = '#f4f1e3';
+const PITH = '#f8f6e8';
 
 const CREAM = '#f4f0df';
 const INK = '#3a4233';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `pnpm create seedcord` command for scaffolding Discord bot projects.
  * Added interactive and non-interactive setup, help output, package-manager detection, Git setup, dependency installation, and cleanup on failure.
  * Added gateway event templates, Cloudflared guidance, reproducible next-step commands, and secret-safe summaries.
  * Added clearer prompts, capability guidance, validation, standardized creation errors, and sample mention/ready event handlers.
* **Bug Fixes**
  * Fixed CLI execution through npm.
* **Documentation**
  * Expanded scaffolding usage, options, generated contents, development workflow, and reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->