### PR TITLE
fix: missing docs subpaths in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ dist/
 # scratch projects a test compiles, removed in afterAll unless the run dies
 **/.build-fixture
 
+# the docs-engine suite copies the docs-generator mock here so the two never share a dist
+/tooling/docs-engine/tests/mock/
+
 # Package manager caches
 .pnpm-store/
 .yarn/

--- a/apps/docs/src/components/docs/ReadmeBlock.tsx
+++ b/apps/docs/src/components/docs/ReadmeBlock.tsx
@@ -19,7 +19,8 @@ const readmeProseClassName = cn(
     tw`[&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit`,
     tw`[&_blockquote]:my-4 [&_blockquote]:border-l-2 [&_blockquote]:border-(--border) [&_blockquote]:pl-4 [&_blockquote]:italic`,
     tw`[&_hr]:my-6 [&_hr]:border-(--border)`,
-    tw`[&_img]:mx-auto [&_img]:my-4 [&_img]:block [&_img]:w-full [&_img]:max-w-lg [&_img]:rounded-md`,
+    // badges and the wordmark carry their own size
+    tw`[&_img]:inline [&_img]:h-auto [&_img]:max-w-full [&_img]:align-middle`,
     tw`[&_table]:my-4 [&_table]:w-full [&_table]:text-left`,
     tw`[&_th]:border-b [&_th]:border-(--border) [&_th]:py-1 [&_th]:pr-4 [&_th]:font-semibold [&_th]:text-(--text)`,
     tw`[&_td]:border-b [&_td]:border-(--border) [&_td]:py-1 [&_td]:pr-4`

--- a/apps/docs/src/lib/docs/builders/buildEntityModel.ts
+++ b/apps/docs/src/lib/docs/builders/buildEntityModel.ts
@@ -15,6 +15,14 @@ import { resolveHeaderSignature } from './utils';
 import type { EntityModel } from '#lib/docs/types';
 import type { DocNode, VersionedDocsEngine } from '@seedcord/docs-engine';
 
+// mergeEntries seeds `entries` with the root entry before appending any subpath
+function importPath(manifestPackage: string, entries: DocNode['entries']): string {
+    const display = formatDisplayPackageName(manifestPackage);
+    const [subpath] = entries ?? [];
+    if (!subpath || subpath === '.') return display;
+    return `${display}${subpath.replace(/^\./, '')}`;
+}
+
 export async function buildEntityModel(engine: VersionedDocsEngine, node: DocNode): Promise<EntityModel> {
     const manifestPackage = node.packageName;
     const context = createFormatContext(engine, manifestPackage);
@@ -26,7 +34,7 @@ export async function buildEntityModel(engine: VersionedDocsEngine, node: DocNod
         node,
         kind,
         manifestPackage,
-        displayPackage: formatDisplayPackageName(manifestPackage),
+        displayPackage: importPath(manifestPackage, node.entries),
         summary: formattedSummary.paragraphs,
         summaryExamples: formattedSummary.examples,
         signature,

--- a/apps/docs/tests/lib/docs/builders/buildEntityModel.test.ts
+++ b/apps/docs/tests/lib/docs/builders/buildEntityModel.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CodeRepresentation } from '#lib/docs/types';
+import type { DocNode, VersionedDocsEngine } from '@seedcord/docs-engine';
+
+// justified: the real modules pull in @lib/sanitizeHtml + @lib/shiki, which vitest can't resolve here.
+vi.mock('../../../../src/lib/docs/comments/creators', () => ({
+    createFormatContext: vi.fn(() => ({}))
+}));
+vi.mock('../../../../src/lib/docs/comments/formatter', () => ({
+    formatCommentRich: vi.fn(() => Promise.resolve({ paragraphs: [], examples: [] }))
+}));
+vi.mock('../../../../src/lib/docs/builders/utils', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    resolveHeaderSignature: vi.fn(() => Promise.resolve({ text: '', html: null } satisfies CodeRepresentation))
+}));
+
+const { buildEntityModel } = await import('#lib/docs/builders/buildEntityModel');
+
+const DOC_KIND_VARIABLE = 32;
+const engine = {} as VersionedDocsEngine;
+
+function makeNode(entries: string[] | undefined): DocNode {
+    return {
+        name: 'thing',
+        slug: 'thing',
+        qualifiedName: 'thing',
+        packageName: '@seedcord/core',
+        kind: DOC_KIND_VARIABLE,
+        flags: {},
+        signatures: [],
+        children: [],
+        comment: null,
+        ...(entries && { entries })
+    } as unknown as DocNode;
+}
+
+describe('buildEntityModel package badge', () => {
+    it('names the subpath when only a subpath exports the symbol', async () => {
+        const model = await buildEntityModel(engine, makeNode(['./hmr']));
+        expect(model.displayPackage).toBe('core/hmr');
+    });
+
+    it('names the package alone when the root entry exports it too', async () => {
+        const model = await buildEntityModel(engine, makeNode(['.', './plugin']));
+        expect(model.displayPackage).toBe('core');
+    });
+
+    it('names the package alone when no entry is recorded', async () => {
+        const model = await buildEntityModel(engine, makeNode(undefined));
+        expect(model.displayPackage).toBe('core');
+    });
+});

--- a/tooling/docs-engine/src/ManifestReader.ts
+++ b/tooling/docs-engine/src/ManifestReader.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 
 import { resolveManifestPath } from '#src/constants';
 
-import type { DocManifest, DocManifestPackage, PackageSourceIndex } from '#src/types';
+import type { DocManifest, DocManifestEntry, DocManifestPackage, PackageSourceIndex } from '#src/types';
 
 export interface ManifestReaderOptions {
     rootDir?: string;
@@ -75,6 +75,7 @@ function normalizePackage(value: unknown): DocManifestPackage | null {
         name,
         version,
         entryPoints,
+        entries: normalizeEntries(pkg.entries),
         output: typeof pkg.output === 'string' ? pkg.output : null,
         warnings,
         errors,
@@ -86,6 +87,22 @@ function normalizePackage(value: unknown): DocManifestPackage | null {
     attachOptionalFields(result, pkg);
 
     return result;
+}
+
+function normalizeEntries(value: unknown): DocManifestEntry[] {
+    if (!Array.isArray(value)) return [];
+
+    return value.reduce<DocManifestEntry[]>((acc, raw) => {
+        if (!raw || typeof raw !== 'object') return acc;
+        const entry = raw as Partial<DocManifestEntry>;
+        if (typeof entry.subpath !== 'string' || entry.subpath.length === 0) return acc;
+
+        acc.push({
+            subpath: entry.subpath,
+            output: typeof entry.output === 'string' ? entry.output : null
+        });
+        return acc;
+    }, []);
 }
 
 function attachOptionalFields(result: DocManifestPackage, pkg: Partial<DocManifestPackage>): void {

--- a/tooling/docs-engine/src/builders/collection-builder.ts
+++ b/tooling/docs-engine/src/builders/collection-builder.ts
@@ -4,9 +4,10 @@ import path from 'node:path';
 import { buildPackageFromApi } from '#builders/package-builder';
 import { createApiModel, loadApiPackage } from '#model/load-model';
 
+import type { AdapterEntry } from '#model/merge-entries';
 import type { GlobalId } from '#src/ids';
 import type { DocCollection, DocManifest, DocManifestPackage, DocPackageModel } from '#src/types';
-import type { ApiPackage } from '@microsoft/api-extractor-model';
+import type { ApiModel } from '@microsoft/api-extractor-model';
 
 export interface ResolveOptions {
     workspaceRoot?: string;
@@ -37,11 +38,11 @@ function collectBaseCandidates(options: ResolveOptions): string[] {
 }
 
 function resolvePackageJsonPath(
-    pkg: DocManifestPackage,
+    manifestOutput: string | null,
     baseCandidates: string[],
     options: ResolveOptions
 ): string | null {
-    const output = pkg.output?.trim();
+    const output = manifestOutput?.trim();
     if (!output) {
         return null;
     }
@@ -132,21 +133,38 @@ function relativizeFromManifestOutput(output: string, manifestOutputDir: string)
     return relative;
 }
 
+// A package's root entry and its subpaths all carry the same package name, and one ApiModel holding
+// two packages of one name throws the moment any @link resolves.
+function loadEntries(
+    pkg: DocManifestPackage,
+    sharedModel: ApiModel,
+    resolveOutput: (output: string | null) => string | null
+): AdapterEntry[] {
+    return pkg.entries.reduce<AdapterEntry[]>((acc, entry) => {
+        const apiJsonPath = resolveOutput(entry.output);
+        if (!apiJsonPath) return acc;
+
+        const model = entry.subpath === '.' ? sharedModel : createApiModel();
+        acc.push({ subpath: entry.subpath, apiPackage: loadApiPackage(model, apiJsonPath), model });
+        return acc;
+    }, []);
+}
+
 export function buildCollection(manifest: DocManifest, options: ResolveOptions): DocCollection {
     const baseCandidates = collectBaseCandidates(options);
-    const resolveProject = (pkg: DocManifestPackage): string | null =>
-        resolvePackageJsonPath(pkg, baseCandidates, options);
+    const resolveOutput = (output: string | null): string | null =>
+        resolvePackageJsonPath(output, baseCandidates, options);
 
     const model = createApiModel();
     // Load every package into the shared model before adapting any, so cross-package @link
     // references resolve against the full set.
-    const loaded: { pkg: DocManifestPackage; apiPackage: ApiPackage }[] = [];
+    const loaded: { pkg: DocManifestPackage; entries: AdapterEntry[] }[] = [];
     for (const pkg of manifest.packages) {
-        const apiJsonPath = resolveProject(pkg);
-        if (!apiJsonPath) continue;
-        loaded.push({ pkg, apiPackage: loadApiPackage(model, apiJsonPath) });
+        const entries = loadEntries(pkg, model, resolveOutput);
+        if (entries.length === 0) continue;
+        loaded.push({ pkg, entries });
     }
-    const packages = loaded.map(({ pkg, apiPackage }) => buildPackageFromApi(pkg, apiPackage, model));
+    const packages = loaded.map(({ pkg, entries }) => buildPackageFromApi(pkg, entries, model));
 
     const { byKey, byGlobalSlug } = buildGlobalMaps(packages);
     return { manifest, packages, byKey, byGlobalSlug };

--- a/tooling/docs-engine/src/builders/package-builder.ts
+++ b/tooling/docs-engine/src/builders/package-builder.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { ApiAdapter } from '#model/adapter';
 import { DocKind } from '#model/kinds';
+import { mergeEntries, type AdapterEntry } from '#model/merge-entries';
 import { PackageDirectory } from '#src/PackageDirectory';
 import { inlineTypeToText, sigPartsToText } from '#transformers/signature-renderer';
 
@@ -17,7 +18,7 @@ import type {
     RenderedSignature,
     SigPart
 } from '#src/types';
-import type { ApiModel, ApiPackage } from '@microsoft/api-extractor-model';
+import type { ApiModel } from '@microsoft/api-extractor-model';
 
 function buildIndexes(root: DocNode, manifest: DocManifestPackage): DocIndexes {
     const byId = new Map<number, DocNode>();
@@ -254,9 +255,13 @@ function collectTokens(node: DocNode, summary: string, file: string | undefined,
     return [...tokens];
 }
 
-// Requires apiPackage already loaded into the shared model so cross-package @link refs resolve.
-export function buildPackageFromApi(pkg: DocManifestPackage, apiPackage: ApiPackage, model: ApiModel): DocPackageModel {
-    return buildPackageFromModel(pkg, new ApiAdapter(pkg, model).transform(apiPackage));
+// Requires the root entry already loaded into the shared model so cross-package @link refs resolve.
+export function buildPackageFromApi(
+    pkg: DocManifestPackage,
+    entries: readonly AdapterEntry[],
+    model: ApiModel
+): DocPackageModel {
+    return buildPackageFromModel(pkg, mergeEntries(new ApiAdapter(pkg, model), entries));
 }
 
 // buildPackageFromApi runs this after adapting, and the remote project.json loader reuses it directly with no AE adapter.

--- a/tooling/docs-engine/src/model/adapter.ts
+++ b/tooling/docs-engine/src/model/adapter.ts
@@ -30,6 +30,7 @@ import { excerptToInlineType } from '#model/excerpt-renderer';
 import { buildFlags, type DerivedFlagBits } from '#model/flags';
 import { apiKindToDocKind, DocKind, frozenKindLabel } from '#model/kinds';
 import { createLinkResolver } from '#model/link-resolver';
+import { entryMembers } from '#model/merge-entries';
 import {
     buildComment,
     buildParamComment,
@@ -65,25 +66,31 @@ const TOP_LEVEL: MemberContext = { inheritedFrom: null, ownClassMember: false };
 
 export class ApiAdapter {
     private readonly slugger = new Slugger();
+    private readonly reexportOwners: ReadonlyMap<string, string>;
     private idCounter = 1;
-    private readonly makeResolveLink: (fromItem: ApiItem) => LinkResolver;
+    private makeResolveLink: (fromItem: ApiItem) => LinkResolver;
 
     constructor(
         private readonly manifest: DocManifestPackage,
         model: ApiModel
     ) {
-        const reexportOwners = new Map((manifest.reexports ?? []).map((entry) => [entry.name, entry.owner] as const));
-        this.makeResolveLink = createLinkResolver(model, reexportOwners);
+        this.reexportOwners = new Map((manifest.reexports ?? []).map((entry) => [entry.name, entry.owner] as const));
+        this.makeResolveLink = createLinkResolver(model, this.reexportOwners);
     }
 
     transform(pkg: ApiPackage): DocNode {
         const root = this.baseNode(pkg, [], pkg.displayName, true);
-        const members = pkg.entryPoints[0]?.members ?? [];
-        root.children = this.visitMembers(members, []);
+        root.children = this.visitMembers(entryMembers(pkg), []);
         root.groups = synthGroups(root.children);
         const reexports = this.buildReexports();
         if (reexports.length > 0) root.reexports = reexports;
         return root;
+    }
+
+    /** Adapt members of one subpath, resolving their `{@link}`s against that subpath's own model. */
+    adaptSubpath(model: ApiModel, members: readonly ApiItem[]): DocNode[] {
+        this.makeResolveLink = createLinkResolver(model, this.reexportOwners);
+        return this.visitMembers(members, []);
     }
 
     private buildReexports(): DocReference[] {

--- a/tooling/docs-engine/src/model/merge-entries.ts
+++ b/tooling/docs-engine/src/model/merge-entries.ts
@@ -1,9 +1,10 @@
+import { ApiExportedMixin, type ApiItem, type ApiModel, type ApiPackage } from '@microsoft/api-extractor-model';
+
 import { groupOverloads, synthGroups } from '#model/adapter-helpers';
 import { apiKindToDocKind } from '#model/kinds';
 
 import type { ApiAdapter } from '#model/adapter';
 import type { DocNode } from '#src/types';
-import type { ApiItem, ApiModel, ApiPackage } from '@microsoft/api-extractor-model';
 
 /** One entry point of a package, its `exports` map subpath paired with that subpath's own API model. */
 export interface AdapterEntry {
@@ -21,10 +22,12 @@ const nodeKey = (kind: number, name: string): string => `${kind}:${name}`;
 
 const memberKey = (member: ApiItem): string => nodeKey(apiKindToDocKind(member), member.displayName);
 
+const exportsMember = (member: ApiItem): boolean => (ApiExportedMixin.isBaseClassOf(member) ? member.isExported : true);
+
 // groupOverloads matches how the adapter builds nodes
-function nodeKeysOf(apiPackage: ApiPackage): string[] {
+function exportedKeysOf(apiPackage: ApiPackage): string[] {
     return groupOverloads(entryMembers(apiPackage)).reduce<string[]>((acc, [primary]) => {
-        if (primary) acc.push(memberKey(primary));
+        if (primary && exportsMember(primary)) acc.push(memberKey(primary));
         return acc;
     }, []);
 }
@@ -47,8 +50,12 @@ export function mergeEntries(adapter: ApiAdapter, entries: readonly AdapterEntry
     }
 
     for (const entry of subpaths) {
-        for (const key of nodeKeysOf(entry.apiPackage)) {
-            byKey.get(key)?.entries?.push(entry.subpath);
+        for (const key of exportedKeysOf(entry.apiPackage)) {
+            const node = byKey.get(key);
+            if (!node) continue;
+            // the root model can carry this as a forgotten declaration while the subpath exports it
+            node.isExported = true;
+            (node.entries ??= []).push(entry.subpath);
         }
 
         // every overload of an unseen member stays in the list, since visitMembers regroups them

--- a/tooling/docs-engine/src/model/merge-entries.ts
+++ b/tooling/docs-engine/src/model/merge-entries.ts
@@ -1,0 +1,65 @@
+import { groupOverloads, synthGroups } from '#model/adapter-helpers';
+import { apiKindToDocKind } from '#model/kinds';
+
+import type { ApiAdapter } from '#model/adapter';
+import type { DocNode } from '#src/types';
+import type { ApiItem, ApiModel, ApiPackage } from '@microsoft/api-extractor-model';
+
+/** One entry point of a package, its `exports` map subpath paired with that subpath's own API model. */
+export interface AdapterEntry {
+    subpath: string;
+    apiPackage: ApiPackage;
+    model: ApiModel;
+}
+
+export function entryMembers(apiPackage: ApiPackage): readonly ApiItem[] {
+    return apiPackage.entryPoints[0]?.members ?? [];
+}
+
+// `export const X` and `export interface X` are two doc nodes under one name
+const nodeKey = (kind: number, name: string): string => `${kind}:${name}`;
+
+const memberKey = (member: ApiItem): string => nodeKey(apiKindToDocKind(member), member.displayName);
+
+// groupOverloads matches how the adapter builds nodes
+function nodeKeysOf(apiPackage: ApiPackage): string[] {
+    return groupOverloads(entryMembers(apiPackage)).reduce<string[]>((acc, [primary]) => {
+        if (primary) acc.push(memberKey(primary));
+        return acc;
+    }, []);
+}
+
+/**
+ * Adapt every entry point into one package tree. The root entry supplies the package node and its
+ * members. Each later subpath contributes only the symbols no earlier entry exported. A symbol several
+ * subpaths re-export is one node whose `entries` lists all of them.
+ */
+export function mergeEntries(adapter: ApiAdapter, entries: readonly AdapterEntry[]): DocNode {
+    const [root, ...subpaths] = entries;
+    if (!root) throw new Error('mergeEntries needs at least one entry point.');
+
+    const tree = adapter.transform(root.apiPackage);
+    const byKey = new Map<string, DocNode>();
+    for (const child of tree.children) {
+        // includeForgottenExports pulls in declarations no entry point exports
+        if (child.isExported) child.entries = [root.subpath];
+        byKey.set(nodeKey(child.kind, child.name), child);
+    }
+
+    for (const entry of subpaths) {
+        for (const key of nodeKeysOf(entry.apiPackage)) {
+            byKey.get(key)?.entries?.push(entry.subpath);
+        }
+
+        // every overload of an unseen member stays in the list, since visitMembers regroups them
+        const unseen = entryMembers(entry.apiPackage).filter((member) => !byKey.has(memberKey(member)));
+        for (const node of adapter.adaptSubpath(entry.model, unseen)) {
+            if (node.isExported) node.entries = [entry.subpath];
+            tree.children.push(node);
+            byKey.set(nodeKey(node.kind, node.name), node);
+        }
+    }
+
+    tree.groups = synthGroups(tree.children);
+    return tree;
+}

--- a/tooling/docs-engine/src/remote/project-file.ts
+++ b/tooling/docs-engine/src/remote/project-file.ts
@@ -67,6 +67,7 @@ function manifestShell(pkg: DocProjectFile['package'], readme?: string, changelo
         name: pkg.name,
         version: pkg.version,
         entryPoints: [],
+        entries: [],
         output: null,
         warnings: [],
         errors: [],

--- a/tooling/docs-engine/src/types.ts
+++ b/tooling/docs-engine/src/types.ts
@@ -45,10 +45,17 @@ export interface RenderedDeclarationHeader {
     };
 }
 
+/** One import path a package documents, paired with the api model extracted for it. */
+export interface DocManifestEntry {
+    subpath: string;
+    output: string | null;
+}
+
 export interface DocManifestPackage {
     name: string;
     version: string;
     entryPoints: string[];
+    entries: DocManifestEntry[];
     output: string | null;
     warnings: string[];
     errors: string[];
@@ -244,6 +251,9 @@ export interface DocNode {
     // Set on the package root only: symbols re-exported from a workspace dependency, each a
     // cross-package reference to its owner's page.
     reexports?: DocReference[];
+    // Set on top-level members only: the `exports` map subpaths that expose this symbol, `.` for the
+    // root entry.
+    entries?: string[];
 }
 
 export interface DocSearchEntry {

--- a/tooling/docs-engine/tests/PackageDirectory.test.ts
+++ b/tooling/docs-engine/tests/PackageDirectory.test.ts
@@ -40,7 +40,7 @@ describe('PackageDirectory', () => {
                 'mock-tuple',
                 'mock-union'
             ],
-            functions: ['log-decorator', 'mock-function', 'mock-function-with-rest'],
+            functions: ['extra-function', 'log-decorator', 'mock-function', 'mock-function-with-rest'],
             variables: ['mock-variable']
         });
     });
@@ -74,7 +74,7 @@ describe('PackageDirectory', () => {
 
     it('returns sorted listings for each entity', () => {
         const functionNames = directory.listNames('functions');
-        expect(functionNames).toEqual(['log-decorator', 'mock-function', 'mock-function-with-rest']);
+        expect(functionNames).toEqual(['extra-function', 'log-decorator', 'mock-function', 'mock-function-with-rest']);
     });
 
     it('hides @internal entities from the directory but keeps them resolvable by slug', async () => {

--- a/tooling/docs-engine/tests/PackageDirectory.test.ts
+++ b/tooling/docs-engine/tests/PackageDirectory.test.ts
@@ -22,7 +22,8 @@ describe('PackageDirectory', () => {
                 'indexable-interface',
                 'mock-interface',
                 'mock-object',
-                'mock-recursive'
+                'mock-recursive',
+                'promoted-shape'
             ],
             enums: ['mock-enum'],
             types: [
@@ -40,7 +41,7 @@ describe('PackageDirectory', () => {
                 'mock-tuple',
                 'mock-union'
             ],
-            functions: ['extra-function', 'log-decorator', 'mock-function', 'mock-function-with-rest'],
+            functions: ['extra-function', 'log-decorator', 'mock-function', 'mock-function-with-rest', 'uses-promoted'],
             variables: ['mock-variable']
         });
     });
@@ -74,7 +75,13 @@ describe('PackageDirectory', () => {
 
     it('returns sorted listings for each entity', () => {
         const functionNames = directory.listNames('functions');
-        expect(functionNames).toEqual(['extra-function', 'log-decorator', 'mock-function', 'mock-function-with-rest']);
+        expect(functionNames).toEqual([
+            'extra-function',
+            'log-decorator',
+            'mock-function',
+            'mock-function-with-rest',
+            'uses-promoted'
+        ]);
     });
 
     it('hides @internal entities from the directory but keeps them resolvable by slug', async () => {

--- a/tooling/docs-engine/tests/adapter-reexport.test.ts
+++ b/tooling/docs-engine/tests/adapter-reexport.test.ts
@@ -21,6 +21,7 @@ function transformMock(reexports: DocManifestPackage['reexports']): DocNode {
         name: '@seedcord/mock-docs',
         version: '0.0.0',
         entryPoints: ['index.d.ts'],
+        entries: [],
         output: null,
         warnings: [],
         errors: [],

--- a/tooling/docs-engine/tests/mock-package.test.ts
+++ b/tooling/docs-engine/tests/mock-package.test.ts
@@ -37,7 +37,7 @@ describe('DocsEngine mock package integration', () => {
         expect(manifest.packages).toHaveLength(1);
         const [manifestPackage] = manifest.packages;
         expect(manifestPackage!.name).toBe(MOCK_PACKAGE_FULL_NAME);
-        expect(manifestPackage!.entryPoints).toEqual(['dist/index.d.ts']);
+        expect(manifestPackage!.entryPoints).toEqual(['dist/index.d.ts', 'dist/extra.d.ts']);
         expect(manifestPackage!.version).toBe('0.0.0');
         expect(engine.getPackageDirectory(MOCK_PACKAGE_FULL_NAME)).toBe(pkg.directory);
     });
@@ -220,8 +220,7 @@ describe('DocsEngine mock package integration', () => {
     });
 
     it('extracts @see blocks as @see block tags (entity comment and function signature)', async () => {
-        // @see is a standard TSDoc tag (parsed into seeBlocks, not customBlocks); the engine must
-        // still surface it so the app's see-also renderer can resolve the targets.
+        // @see parses into seeBlocks. The app's see-also renderer needs it surfaced.
         const mockClass = await getNodeBySlug('mock-class');
         const classSee = mockClass.comment?.blockTags.filter((tag) => tag.tag === '@see') ?? [];
         expect(classSee.length).toBeGreaterThan(0);

--- a/tooling/docs-engine/tests/mock-package.test.ts
+++ b/tooling/docs-engine/tests/mock-package.test.ts
@@ -37,7 +37,12 @@ describe('DocsEngine mock package integration', () => {
         expect(manifest.packages).toHaveLength(1);
         const [manifestPackage] = manifest.packages;
         expect(manifestPackage!.name).toBe(MOCK_PACKAGE_FULL_NAME);
-        expect(manifestPackage!.entryPoints).toEqual(['dist/index.d.ts', 'dist/extra.d.ts']);
+        expect(manifestPackage!.entryPoints).toEqual([
+            'dist/index.d.ts',
+            'dist/variable.d.ts',
+            'dist/variable.d.ts',
+            'dist/extra.d.ts'
+        ]);
         expect(manifestPackage!.version).toBe('0.0.0');
         expect(engine.getPackageDirectory(MOCK_PACKAGE_FULL_NAME)).toBe(pkg.directory);
     });

--- a/tooling/docs-engine/tests/package-builder.test.ts
+++ b/tooling/docs-engine/tests/package-builder.test.ts
@@ -50,6 +50,7 @@ const manifest: DocManifestPackage = {
     name: '@seedcord/mock',
     version: '0.0.0',
     entryPoints: ['index.d.ts'],
+    entries: [],
     output: null,
     warnings: [],
     errors: [],

--- a/tooling/docs-engine/tests/subpath-entries.test.ts
+++ b/tooling/docs-engine/tests/subpath-entries.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { MOCK_PACKAGE_FULL_NAME } from './utils/constants';
+import { getEngine, getMockPackage } from './utils/test-helpers';
+
+import type { DocsEngine } from '#src/DocsEngine';
+import type { DocPackageModel } from '#src/types';
+
+let engine: DocsEngine;
+let pkg: DocPackageModel;
+
+describe('subpath entry points', () => {
+    beforeAll(async () => {
+        engine = await getEngine();
+        pkg = await getMockPackage();
+    });
+
+    it('documents a symbol only the subpath exports', () => {
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'extra-function');
+        expect(node).not.toBeNull();
+        expect(node?.entries).toEqual(['./extra']);
+    });
+
+    // the page badge renders `entries` as the import path a reader types
+    it('claims no entry for a symbol the subpath references without exporting', () => {
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'extra-only');
+        expect(node?.isExported).toBe(false);
+        expect(node?.entries).toBeUndefined();
+    });
+
+    it('keeps a symbol both entries export to a single node', () => {
+        const variables = pkg.directory.listNames('variables').filter((slug) => slug.startsWith('mock-variable'));
+        expect(variables).toEqual(['mock-variable']);
+
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'mock-variable');
+        expect(node?.entries).toEqual(['.', './extra']);
+    });
+
+    it('records an overloaded symbol once per entry, not once per overload', () => {
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'mock-function');
+        expect(node?.signatures.length).toBeGreaterThan(1);
+        expect(node?.entries).toEqual(['.', './extra']);
+    });
+
+    it('records the root entry alone for a symbol no subpath re-exports', () => {
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'mock-class');
+        expect(node?.entries).toEqual(['.']);
+    });
+});

--- a/tooling/docs-engine/tests/subpath-entries.test.ts
+++ b/tooling/docs-engine/tests/subpath-entries.test.ts
@@ -28,12 +28,20 @@ describe('subpath entry points', () => {
         expect(node?.entries).toBeUndefined();
     });
 
-    it('keeps a symbol both entries export to a single node', () => {
+    // the root model carries PromotedShape as a forgotten declaration, and `./extra` exports it
+    it('promotes a forgotten root node when a subpath exports the same symbol', () => {
+        const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'promoted-shape');
+        expect(node?.isExported).toBe(true);
+        expect(node?.entries).toEqual(['./extra']);
+        expect(pkg.directory.listNames('interfaces')).toContain('promoted-shape');
+    });
+
+    it('keeps a symbol four entries export to a single node', () => {
         const variables = pkg.directory.listNames('variables').filter((slug) => slug.startsWith('mock-variable'));
         expect(variables).toEqual(['mock-variable']);
 
         const node = engine.getNodeBySlug(MOCK_PACKAGE_FULL_NAME, 'mock-variable');
-        expect(node?.entries).toEqual(['.', './extra']);
+        expect(node?.entries).toEqual(['.', './deep-entry', './deep/entry', './extra']);
     });
 
     it('records an overloaded symbol once per entry, not once per overload', () => {

--- a/tooling/docs-engine/tests/utils/constants.ts
+++ b/tooling/docs-engine/tests/utils/constants.ts
@@ -2,7 +2,14 @@ import { resolve } from 'node:path';
 
 const TEST_DIR = resolve(__dirname, '..');
 const DOCS_GENERATOR_ROOT = resolve(TEST_DIR, '../../docs-generator');
-export const PACKAGES_DIR = resolve(DOCS_GENERATOR_ROOT, 'tests');
+
+/** Read-only source of the shared fixture. globalSetup copies it before building anything. */
+export const MOCK_SOURCE_DIR = resolve(DOCS_GENERATOR_ROOT, 'tests/mock');
+
+// the copy sits one level under PACKAGES_DIR so discoverWorkspacePackages globs it, and four levels
+// under the repo root so the fixture's `extends: ../../../../tsconfig.json` still resolves
+export const PACKAGES_DIR = TEST_DIR;
+export const MOCK_DIR = resolve(TEST_DIR, 'mock');
 export const TEMP_DIR = resolve(TEST_DIR, 'temp');
 export const MOCK_PACKAGE_NAME = 'mock-docs';
 export const MOCK_PACKAGE_FULL_NAME = '@seedcord/mock-docs';

--- a/tooling/docs-engine/tests/utils/globalSetup.ts
+++ b/tooling/docs-engine/tests/utils/globalSetup.ts
@@ -1,14 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { cp, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 
 import { ApiDocsGenerator } from '@seedcord/docs-generator';
 
-import { MOCK_PACKAGE_NAME, PACKAGES_DIR, TEMP_DIR } from './constants';
-
-const MOCK_DIR = resolve(PACKAGES_DIR, 'mock');
+import { MOCK_DIR, MOCK_PACKAGE_NAME, MOCK_SOURCE_DIR, PACKAGES_DIR, TEMP_DIR } from './constants';
 
 // API Extractor consumes built `.d.ts`, so emit the mock's declarations before extracting.
 function buildMockDeclarations(): void {
@@ -16,11 +14,22 @@ function buildMockDeclarations(): void {
     execFileSync(process.execPath, [tsc, '-p', resolve(MOCK_DIR, 'tsconfig.build.json')], { stdio: 'inherit' });
 }
 
+// The docs-generator suite builds and deletes its own copy of this fixture. Sharing one directory
+// made the two suites clobber each other's `dist` whenever they ran at the same time.
+async function copyMockFixture(): Promise<void> {
+    await rm(MOCK_DIR, { recursive: true, force: true });
+    await cp(MOCK_SOURCE_DIR, MOCK_DIR, {
+        recursive: true,
+        filter: (source) => !source.endsWith(`${sep}dist`)
+    });
+}
+
 export async function setup(): Promise<void> {
     if (existsSync(TEMP_DIR)) {
         await rm(TEMP_DIR, { recursive: true, force: true });
     }
 
+    await copyMockFixture();
     buildMockDeclarations();
 
     const generator = new ApiDocsGenerator({
@@ -38,8 +47,6 @@ export async function setup(): Promise<void> {
 }
 
 export async function teardown(): Promise<void> {
-    if (existsSync(TEMP_DIR)) {
-        await rm(TEMP_DIR, { recursive: true, force: true });
-    }
-    await rm(resolve(MOCK_DIR, 'dist'), { recursive: true, force: true });
+    await rm(TEMP_DIR, { recursive: true, force: true });
+    await rm(MOCK_DIR, { recursive: true, force: true });
 }

--- a/tooling/docs-generator/src/ae-extractor.ts
+++ b/tooling/docs-generator/src/ae-extractor.ts
@@ -3,10 +3,10 @@ import path from 'node:path';
 import { Extractor, ExtractorConfig, ExtractorLogLevel, type IConfigFile } from '@microsoft/api-extractor';
 
 import { pathExists } from './utils';
-import { readPackageManifest, resolveEntryPoints, unscopedName } from './workspace';
+import { readPackageManifest, resolveDocEntryPoints, unscopedName } from './workspace';
 
 import type { ApiDocsPaths } from './paths';
-import type { PackageDocResult } from './types';
+import type { EntryDocResult, PackageDocResult } from './types';
 
 function buildConfigObject(options: {
     packageDir: string;
@@ -52,57 +52,21 @@ function buildConfigObject(options: {
     };
 }
 
-// tsdown emits `index.d.mts` and tsc emits `index.d.ts`. The bundler output comes first because
-// that is what the published packages contain. The tsc output only exists for the test fixture.
-const DECLARATION_ENTRY_CANDIDATES = ['dist/index.d.mts', 'dist/index.d.ts'];
-
-async function resolveDeclarationEntry(packageDir: string): Promise<string | null> {
-    for (const candidate of DECLARATION_ENTRY_CANDIDATES) {
-        const absolute = path.join(packageDir, candidate);
-        if (await pathExists(absolute)) return absolute;
-    }
-    return null;
+function apiJsonNameFor(packageName: string, subpath: string): string {
+    const unscoped = unscopedName(packageName);
+    if (subpath === '.') return `${unscoped}.api.json`;
+    return `${unscoped}.${subpath.replace(/^\.\//, '').replaceAll('/', '-')}.api.json`;
 }
 
-/**
- * Extract one package's API doc model with API Extractor, emitting `<unscoped>.api.json`.
- */
-export async function extractPackageApiModel(
-    packageDir: string,
-    paths: ApiDocsPaths
-): Promise<PackageDocResult | null> {
-    const manifest = await readPackageManifest(packageDir);
-    if (manifest.private) return null;
-
-    const srcEntries = await resolveEntryPoints(packageDir, manifest);
-    const primaryEntry = srcEntries[0];
-    if (!primaryEntry) return null;
-
-    const entryPoint = await resolveDeclarationEntry(packageDir);
-    if (!entryPoint) {
-        throw new Error(
-            `API Extractor needs a built declaration entry for ${manifest.name}: ${paths.toRepoRelative(
-                path.join(packageDir, 'dist/index.d.mts')
-            )} is missing. Run the package build first.`
-        );
-    }
-
-    const tsconfigPath = path.join(packageDir, 'tsconfig.json');
-    if (!(await pathExists(tsconfigPath))) {
-        throw new Error(`Missing tsconfig for ${manifest.name} at ${paths.toRepoRelative(tsconfigPath)}.`);
-    }
-
-    const apiJsonPath = path.join(paths.outputDir, `${unscopedName(manifest.name)}.api.json`);
-
+function runExtractor(options: { packageDir: string; entryPoint: string; tsconfigPath: string; apiJsonPath: string }): {
+    succeeded: boolean;
+    warnings: string[];
+    errors: string[];
+} {
     const config = ExtractorConfig.prepare({
-        configObjectFullPath: path.join(packageDir, 'api-extractor.json'),
-        packageJsonFullPath: path.join(packageDir, 'package.json'),
-        configObject: buildConfigObject({
-            packageDir,
-            entryPoint,
-            tsconfigPath,
-            apiJsonPath
-        })
+        configObjectFullPath: path.join(options.packageDir, 'api-extractor.json'),
+        packageJsonFullPath: path.join(options.packageDir, 'package.json'),
+        configObject: buildConfigObject(options)
     });
 
     const warnings: string[] = [];
@@ -117,15 +81,61 @@ export async function extractPackageApiModel(
         }
     });
 
+    return { succeeded: result.succeeded, warnings, errors };
+}
+
+/**
+ * Extract one package's API doc models with API Extractor, one `.api.json` per public entry point.
+ */
+export async function extractPackageApiModel(
+    packageDir: string,
+    paths: ApiDocsPaths
+): Promise<PackageDocResult | null> {
+    const manifest = await readPackageManifest(packageDir);
+    if (manifest.private) return null;
+
+    // @seedcord/tsconfig publishes json presets and declares no types
+    const entryPoints = await resolveDocEntryPoints(packageDir, manifest);
+    if (entryPoints.length === 0) return null;
+
+    const tsconfigPath = path.join(packageDir, 'tsconfig.json');
+    if (!(await pathExists(tsconfigPath))) {
+        throw new Error(`Missing tsconfig for ${manifest.name} at ${paths.toRepoRelative(tsconfigPath)}.`);
+    }
+
+    const entries: EntryDocResult[] = entryPoints.map((entry) => {
+        const apiJsonPath = path.join(paths.outputDir, apiJsonNameFor(manifest.name, entry.subpath));
+        const run = runExtractor({
+            packageDir,
+            entryPoint: entry.declaration,
+            tsconfigPath,
+            apiJsonPath
+        });
+
+        return {
+            subpath: entry.subpath,
+            entryPoint: path.relative(packageDir, entry.declaration),
+            ...(entry.sourceEntry && { sourceEntry: entry.sourceEntry }),
+            outputPath: run.succeeded ? apiJsonPath : null,
+            warnings: run.warnings,
+            errors: run.errors,
+            succeeded: run.succeeded
+        };
+    });
+
+    const [first] = entries;
+    const root = entries.find((entry) => entry.subpath === '.') ?? first;
+    if (!root) return null;
+
     return {
         name: manifest.name,
         version: manifest.version,
-        entryPoints: [path.relative(packageDir, entryPoint)],
-        // the source pass walks this, and a `seedcordDocs` override can move it off src/index.ts
-        sourceEntry: path.relative(packageDir, primaryEntry).split(path.sep).join('/'),
-        outputPath: result.succeeded ? apiJsonPath : null,
-        warnings,
-        errors,
-        succeeded: result.succeeded
+        entries,
+        entryPoints: entries.map((entry) => entry.entryPoint),
+        ...(root.sourceEntry && { sourceEntry: root.sourceEntry }),
+        outputPath: root.outputPath,
+        warnings: entries.flatMap((entry) => entry.warnings),
+        errors: entries.flatMap((entry) => entry.errors),
+        succeeded: entries.every((entry) => entry.succeeded)
     };
 }

--- a/tooling/docs-generator/src/ae-extractor.ts
+++ b/tooling/docs-generator/src/ae-extractor.ts
@@ -52,10 +52,12 @@ function buildConfigObject(options: {
     };
 }
 
+// doubling the hyphen first keeps `./a/b` and `./a-b` on separate files
 function apiJsonNameFor(packageName: string, subpath: string): string {
     const unscoped = unscopedName(packageName);
     if (subpath === '.') return `${unscoped}.api.json`;
-    return `${unscoped}.${subpath.replace(/^\.\//, '').replaceAll('/', '-')}.api.json`;
+    const slug = subpath.replace(/^\.\//, '').replaceAll('-', '--').replaceAll('/', '-');
+    return `${unscoped}.${slug}.api.json`;
 }
 
 function runExtractor(options: { packageDir: string; entryPoint: string; tsconfigPath: string; apiJsonPath: string }): {

--- a/tooling/docs-generator/src/generator.ts
+++ b/tooling/docs-generator/src/generator.ts
@@ -142,16 +142,7 @@ export class ApiDocsGenerator {
                 throw new Error(`API Extractor extraction failed for ${result.name}. see logs above.`);
             }
 
-            const scan = buildSourceIndex({
-                packageDir,
-                repoRoot: this.paths.repoRoot,
-                githubBase: this.githubBase ?? '',
-                ref: this.ref,
-                packageNames,
-                ...(result.sourceEntry && { entry: result.sourceEntry })
-            });
-            result.sources = scan.sources;
-            if (scan.reexports.length > 0) result.reexports = scan.reexports;
+            this.attachSourceIndex(result, packageDir, packageNames);
 
             const readme = await readReadme(packageDir);
             if (readme) result.readme = readme;
@@ -184,6 +175,25 @@ export class ApiDocsGenerator {
             relativeOutputDir: this.paths.toRepoRelative(this.paths.outputDir),
             relativeManifestPath: this.paths.toRepoRelative(this.paths.manifestPath)
         };
+    }
+
+    // one scan covers every entry point, because buildSourceIndex walks the whole `src` tree
+    private attachSourceIndex(
+        result: PackageDocResult,
+        packageDir: string,
+        packageNames: Record<string, string>
+    ): void {
+        const scan = buildSourceIndex({
+            packageDir,
+            repoRoot: this.paths.repoRoot,
+            githubBase: this.githubBase ?? '',
+            ref: this.ref,
+            packageNames,
+            ...(result.sourceEntry && { entry: result.sourceEntry })
+        });
+
+        result.sources = scan.sources;
+        if (scan.reexports.length > 0) result.reexports = scan.reexports;
     }
 
     private logPackageResult(result: PackageDocResult): void {

--- a/tooling/docs-generator/src/manifest.ts
+++ b/tooling/docs-generator/src/manifest.ts
@@ -22,6 +22,10 @@ export async function writeManifest(
             name: result.name,
             version: result.version,
             entryPoints: result.entryPoints,
+            entries: result.entries.map((entry) => ({
+                subpath: entry.subpath,
+                output: entry.outputPath ? paths.toRepoRelative(entry.outputPath) : null
+            })),
             output: result.outputPath ? paths.toRepoRelative(result.outputPath) : null,
             warningCount: result.warnings.length,
             errorCount: result.errors.length,

--- a/tooling/docs-generator/src/types.ts
+++ b/tooling/docs-generator/src/types.ts
@@ -2,10 +2,12 @@
  * Per-package doc config under `seedcordDocs` in package.json.
  */
 export interface SeedcordDocsConfig {
-    entryPoints?: string[];
     /** Keeps a published package out of the docs */
     skip?: boolean;
 }
+
+/** One `exports` condition, nested to whatever depth the manifest wrote it. */
+export type ExportCondition = string | { [condition: string]: ExportCondition | undefined };
 
 export interface PackageManifest {
     name: string;
@@ -15,6 +17,16 @@ export interface PackageManifest {
     types?: string;
     dependencies?: Record<string, string>;
     seedcordDocs?: SeedcordDocsConfig;
+    exports?: Record<string, ExportCondition>;
+}
+
+/** One documented import path, `.` for the package root and `./hmr` for a subpath. */
+export interface DocEntryPoint {
+    subpath: string;
+    /** Absolute path to the built declaration api-extractor reads. */
+    declaration: string;
+    /** Package-relative path to the `src` file the source pass walks. */
+    sourceEntry?: string;
 }
 
 export interface SourceEntry {
@@ -50,12 +62,26 @@ export interface ManifestRepository {
     commit?: string;
 }
 
+/** One extracted import path and the model api-extractor wrote for it. */
+export interface EntryDocResult {
+    subpath: string;
+    /** Package-relative declaration api-extractor read. */
+    entryPoint: string;
+    /** Package-relative `src` file the source pass walked. */
+    sourceEntry?: string;
+    outputPath: string | null;
+    warnings: string[];
+    errors: string[];
+    succeeded: boolean;
+}
+
 /**
  * API Extractor run summary for one package.
  */
 export interface PackageDocResult {
     name: string;
     version: string;
+    entries: EntryDocResult[];
     entryPoints: string[];
     /** Primary `src` entry (relative to the package dir) the source pass walks. this matches AE's entry. */
     sourceEntry?: string;

--- a/tooling/docs-generator/src/workspace.ts
+++ b/tooling/docs-generator/src/workspace.ts
@@ -7,10 +7,7 @@ import { defaultPaths } from './paths';
 import { normalizeRelativePath, pathExists } from './utils';
 
 import type { ApiDocsPaths } from './paths';
-import type { PackageManifest } from './types';
-
-// Fallback entry when package.json has no seedcordDocs.entryPoints override.
-const DEFAULT_ENTRY_POINTS = ['src/index.ts'];
+import type { DocEntryPoint, ExportCondition, PackageManifest } from './types';
 
 const WORKSPACE_FILE = 'pnpm-workspace.yaml';
 
@@ -82,27 +79,54 @@ export function unscopedName(name: string): string {
     return name.split('/').pop() ?? name;
 }
 
+// `./internal` and `./node/internal` are framework wiring, and CLAUDE.md keeps them off the docs
+const INTERNAL_SUBPATH = /(^|\/)internal$/;
+
+function declarationOf(condition: ExportCondition | undefined): string | undefined {
+    if (typeof condition === 'string')
+        return condition.endsWith('.d.ts') || condition.endsWith('.d.mts') ? condition : undefined;
+    if (!condition) return undefined;
+
+    for (const key of ['types', 'import', 'default']) {
+        const found = declarationOf(condition[key]);
+        if (found) return found;
+    }
+    return undefined;
+}
+
+// tsdown names a subpath's output after its source
+async function sourceForDeclaration(packageDir: string, declaration: string): Promise<string | undefined> {
+    const stem = path.basename(declaration).replace(/\.d\.[cm]?ts$/, '');
+    for (const candidate of [`src/${stem}.ts`, `${stem}.ts`, `src/${stem}.tsx`]) {
+        if (await pathExists(path.join(packageDir, candidate))) return candidate;
+    }
+    return undefined;
+}
+
 /**
- * Resolve a package's existing source entry points: `seedcordDocs.entryPoints` overrides, then
- * `src/index.ts`, then the `types` entry. A package with none is treated as not documentable.
+ * Resolve every import path a package documents, taken from its `exports` map. That map is the
+ * authority on what a package exposes.
  */
-export async function resolveEntryPoints(packageDir: string, manifest: PackageManifest): Promise<string[]> {
-    const configured = manifest.seedcordDocs?.entryPoints ?? [];
-    const candidateRelPaths = [...configured, ...DEFAULT_ENTRY_POINTS];
-    const absolute: string[] = [];
+export async function resolveDocEntryPoints(packageDir: string, manifest: PackageManifest): Promise<DocEntryPoint[]> {
+    const entries: DocEntryPoint[] = [];
 
-    for (const candidate of candidateRelPaths) {
-        const normalized = normalizeRelativePath(candidate);
-        if (!normalized) continue;
+    for (const [subpath, condition] of Object.entries(manifest.exports ?? {})) {
+        if (INTERNAL_SUBPATH.test(subpath)) continue;
 
-        const absolutePath = path.join(packageDir, normalized);
-        if (await pathExists(absolutePath)) absolute.push(absolutePath);
+        // a package like @seedcord/tsconfig exports json presets and declares no types at all
+        const declared = declarationOf(condition);
+        if (!declared) continue;
+
+        const declaration = path.join(packageDir, normalizeRelativePath(declared));
+        if (!(await pathExists(declaration))) {
+            throw new Error(
+                `${manifest.name} exports "${subpath}" as ${declared}, which does not exist. Build the package first.`
+            );
+        }
+
+        const sourceEntry = await sourceForDeclaration(packageDir, declared);
+        entries.push({ subpath, declaration, ...(sourceEntry && { sourceEntry }) });
     }
 
-    if (absolute.length === 0 && manifest.types) {
-        const declarationCandidate = path.join(packageDir, normalizeRelativePath(manifest.types));
-        if (await pathExists(declarationCandidate)) absolute.push(declarationCandidate);
-    }
-
-    return absolute;
+    return entries.sort((a, b) => a.subpath.localeCompare(b.subpath));
 }

--- a/tooling/docs-generator/tests/generator.test.ts
+++ b/tooling/docs-generator/tests/generator.test.ts
@@ -47,7 +47,7 @@ describe('ApiDocsGenerator', () => {
             expect(entry!.version).toBe('0.0.0');
             expect(entry!.succeeded).toBe(true);
             expect(entry!.output).toMatch(/mock-docs\.api\.json$/);
-            expect(entry!.entryPoints).toEqual(['dist/index.d.ts']);
+            expect(entry!.entryPoints).toEqual(['dist/index.d.ts', 'dist/extra.d.ts']);
         });
 
         it('captures the package.json description', () => {

--- a/tooling/docs-generator/tests/generator.test.ts
+++ b/tooling/docs-generator/tests/generator.test.ts
@@ -47,7 +47,13 @@ describe('ApiDocsGenerator', () => {
             expect(entry!.version).toBe('0.0.0');
             expect(entry!.succeeded).toBe(true);
             expect(entry!.output).toMatch(/mock-docs\.api\.json$/);
-            expect(entry!.entryPoints).toEqual(['dist/index.d.ts', 'dist/extra.d.ts']);
+            // the repeat is deliberate. `./deep-entry` and `./deep/entry` share one declaration.
+            expect(entry!.entryPoints).toEqual([
+                'dist/index.d.ts',
+                'dist/variable.d.ts',
+                'dist/variable.d.ts',
+                'dist/extra.d.ts'
+            ]);
         });
 
         it('captures the package.json description', () => {

--- a/tooling/docs-generator/tests/mock/extra.ts
+++ b/tooling/docs-generator/tests/mock/extra.ts
@@ -10,6 +10,9 @@ export { mockVariable } from './variable.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
 export { mockFunction } from './function.js';
 
+// the root references PromotedShape through usesPromoted and never exports it. this subpath does.
+export type { PromotedShape } from './promoted.js';
+
 // never exported, the way @seedcord/core/hmr references HmrModuleHandlerOptions without exporting it.
 // includeForgottenExports still puts it in the model.
 interface ExtraOnly {

--- a/tooling/docs-generator/tests/mock/extra.ts
+++ b/tooling/docs-generator/tests/mock/extra.ts
@@ -1,0 +1,22 @@
+/**
+ * A second public entry point, reached as `@seedcord/mock-docs/extra`.
+ *
+ * @packageDocumentation
+ */
+
+// the root entry exports both of these too, the way @seedcord/http/edge re-exports the http root.
+// mockFunction is overloaded.
+export { mockVariable } from './variable';
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
+export { mockFunction } from './function';
+
+// never exported, the way @seedcord/core/hmr references HmrModuleHandlerOptions without exporting it.
+// includeForgottenExports still puts it in the model.
+interface ExtraOnly {
+    tag: 'extra';
+}
+
+/** Returns the tag the extra subpath is known by. */
+export function extraFunction(): ExtraOnly {
+    return { tag: 'extra' };
+}

--- a/tooling/docs-generator/tests/mock/extra.ts
+++ b/tooling/docs-generator/tests/mock/extra.ts
@@ -6,9 +6,9 @@
 
 // the root entry exports both of these too, the way @seedcord/http/edge re-exports the http root.
 // mockFunction is overloaded.
-export { mockVariable } from './variable';
+export { mockVariable } from './variable.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
-export { mockFunction } from './function';
+export { mockFunction } from './function.js';
 
 // never exported, the way @seedcord/core/hmr references HmrModuleHandlerOptions without exporting it.
 // includeForgottenExports still puts it in the model.

--- a/tooling/docs-generator/tests/mock/function.ts
+++ b/tooling/docs-generator/tests/mock/function.ts
@@ -1,3 +1,10 @@
+import type { PromotedShape } from './promoted.js';
+
+/** Puts PromotedShape in the root model without the root exporting it. */
+export function usesPromoted(): PromotedShape {
+    return { tag: 'promoted' };
+}
+
 /**
  * A complex mock function for testing documentation generation.
  *

--- a/tooling/docs-generator/tests/mock/index.ts
+++ b/tooling/docs-generator/tests/mock/index.ts
@@ -11,7 +11,7 @@
 export { BaseClass, MockClass } from './class.js';
 export { MockEnum } from './enum.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
-export { mockFunction, mockFunctionWithRest, asyncMockFunction, LogDecorator } from './function.js';
+export { mockFunction, mockFunctionWithRest, asyncMockFunction, LogDecorator, usesPromoted } from './function.js';
 export type { MockInterface, RecursiveInterface, IndexableInterface, ExtendedInterface } from './interface.js';
 export type {
     MockUnion,

--- a/tooling/docs-generator/tests/mock/internal.ts
+++ b/tooling/docs-generator/tests/mock/internal.ts
@@ -1,0 +1,9 @@
+/**
+ * Framework wiring reached as `@seedcord/mock-docs/internal`.
+ *
+ * @packageDocumentation
+ */
+
+export function internalOnlyFunction(): string {
+    return 'internal';
+}

--- a/tooling/docs-generator/tests/mock/node-internal.ts
+++ b/tooling/docs-generator/tests/mock/node-internal.ts
@@ -1,0 +1,9 @@
+/**
+ * Node-only wiring reached as `@seedcord/mock-docs/node/internal`.
+ *
+ * @packageDocumentation
+ */
+
+export function nodeInternalFunction(): string {
+    return 'node-internal';
+}

--- a/tooling/docs-generator/tests/mock/package.json
+++ b/tooling/docs-generator/tests/mock/package.json
@@ -4,9 +4,30 @@
     "type": "module",
     "private": false,
     "description": "Mock package exercised by the docs generator tests.",
-    "seedcordDocs": {
-        "entryPoints": [
-            "index.ts"
-        ]
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        },
+        "./extra": {
+            "import": {
+                "types": "./dist/extra.d.ts",
+                "default": "./dist/extra.js"
+            }
+        },
+        "./internal": {
+            "import": {
+                "types": "./dist/internal.d.ts",
+                "default": "./dist/internal.js"
+            }
+        },
+        "./node/internal": {
+            "import": {
+                "types": "./dist/node-internal.d.ts",
+                "default": "./dist/node-internal.js"
+            }
+        }
     }
 }

--- a/tooling/docs-generator/tests/mock/package.json
+++ b/tooling/docs-generator/tests/mock/package.json
@@ -17,6 +17,18 @@
                 "default": "./dist/extra.js"
             }
         },
+        "./deep-entry": {
+            "import": {
+                "types": "./dist/variable.d.ts",
+                "default": "./dist/variable.js"
+            }
+        },
+        "./deep/entry": {
+            "import": {
+                "types": "./dist/variable.d.ts",
+                "default": "./dist/variable.js"
+            }
+        },
         "./internal": {
             "import": {
                 "types": "./dist/internal.d.ts",

--- a/tooling/docs-generator/tests/mock/promoted.ts
+++ b/tooling/docs-generator/tests/mock/promoted.ts
@@ -1,0 +1,4 @@
+/** Referenced by a root export and exported by the extra subpath alone. */
+export interface PromotedShape {
+    tag: 'promoted';
+}

--- a/tooling/docs-generator/tests/resolve-doc-entry-points.test.ts
+++ b/tooling/docs-generator/tests/resolve-doc-entry-points.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveDocEntryPoints } from '../src/workspace';
+
+import type { PackageManifest } from '../src/types';
+
+let packageDir: string;
+
+async function writeDeclaration(relative: string): Promise<void> {
+    const full = join(packageDir, relative);
+    await mkdir(join(full, '..'), { recursive: true });
+    await writeFile(full, 'export {};\n', 'utf8');
+}
+
+const manifestWith = (exports: PackageManifest['exports']): PackageManifest => ({
+    name: '@seedcord/fixture',
+    version: '0.0.0',
+    ...(exports && { exports })
+});
+
+beforeEach(async () => {
+    packageDir = await mkdtemp(join(tmpdir(), 'doc-entries-'));
+});
+
+afterEach(async () => {
+    await rm(packageDir, { recursive: true, force: true });
+});
+
+describe('resolveDocEntryPoints', () => {
+    it('names the package and the subpath when a declared entry is not built', async () => {
+        const manifest = manifestWith({ '.': { import: { types: './dist/index.d.mts' } } });
+
+        await expect(resolveDocEntryPoints(packageDir, manifest)).rejects.toThrow(
+            /@seedcord\/fixture exports "\." as \.\/dist\/index\.d\.mts, which does not exist/
+        );
+    });
+
+    // @seedcord/tsconfig ships json presets. resolving nothing has to stay a skip, never a throw.
+    it('resolves nothing for a package whose every export declares no types', async () => {
+        const manifest = manifestWith({
+            '.': { default: './base.json' },
+            './node': { default: './node.json' }
+        });
+
+        await expect(resolveDocEntryPoints(packageDir, manifest)).resolves.toEqual([]);
+    });
+
+    it('skips a subpath that declares no types', async () => {
+        await writeDeclaration('dist/index.d.mts');
+        const manifest = manifestWith({
+            '.': { import: { types: './dist/index.d.mts' } },
+            './base.json': './base.json'
+        });
+
+        const entries = await resolveDocEntryPoints(packageDir, manifest);
+
+        expect(entries.map((entry) => entry.subpath)).toEqual(['.']);
+    });
+
+    it('pairs a subpath declaration with the src file tsdown built it from', async () => {
+        await writeDeclaration('dist/hmr.index.d.mts');
+        await writeDeclaration('src/hmr.index.ts');
+        const manifest = manifestWith({ './hmr': { import: { types: './dist/hmr.index.d.mts' } } });
+
+        const [entry] = await resolveDocEntryPoints(packageDir, manifest);
+
+        expect(entry?.sourceEntry).toBe('src/hmr.index.ts');
+    });
+
+    it('sorts the root entry ahead of every subpath', async () => {
+        await writeDeclaration('dist/index.d.mts');
+        await writeDeclaration('dist/edge.d.mts');
+        const manifest = manifestWith({
+            './edge': { import: { types: './dist/edge.d.mts' } },
+            '.': { import: { types: './dist/index.d.mts' } }
+        });
+
+        const entries = await resolveDocEntryPoints(packageDir, manifest);
+
+        expect(entries.map((entry) => entry.subpath)).toEqual(['.', './edge']);
+    });
+});

--- a/tooling/docs-generator/tests/subpath-entries.test.ts
+++ b/tooling/docs-generator/tests/subpath-entries.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { TEMP_DIR } from './utils';
+
+interface ManifestEntry {
+    subpath: string;
+    output: string;
+    sourceEntry?: string;
+}
+interface ManifestPackage {
+    name: string;
+    entries: ManifestEntry[];
+}
+interface Manifest {
+    packages: ManifestPackage[];
+}
+
+const MOCK_FULL_NAME = '@seedcord/mock-docs';
+
+describe('a package with more than one public entry point', () => {
+    let mock: ManifestPackage;
+
+    beforeAll(() => {
+        const manifest = JSON.parse(readFileSync(resolve(TEMP_DIR, 'manifest.json'), 'utf8')) as Manifest;
+        mock = manifest.packages.find((entry) => entry.name === MOCK_FULL_NAME)!;
+    });
+
+    it('documents the root and every public subpath', () => {
+        expect(mock.entries.map((entry) => entry.subpath).sort()).toEqual(['.', './extra']);
+    });
+
+    it('skips a top-level and a nested internal subpath', () => {
+        expect(mock.entries.some((entry) => entry.subpath.includes('internal'))).toBe(false);
+    });
+
+    it('writes one api model per entry', () => {
+        for (const entry of mock.entries) {
+            expect(existsSync(resolve(TEMP_DIR, basename(entry.output)))).toBe(true);
+        }
+        expect(new Set(mock.entries.map((entry) => entry.output)).size).toBe(mock.entries.length);
+    });
+
+    it('extracts a subpath model holding that subpath surface alone', () => {
+        const extra = mock.entries.find((entry) => entry.subpath === './extra')!;
+        const model = readFileSync(resolve(TEMP_DIR, basename(extra.output)), 'utf8');
+        expect(model).toContain('extraFunction');
+        // extra.ts re-exports mockFunction. mockFunctionWithRest stays behind on the root entry.
+        expect(model).toContain('mockFunction');
+        expect(model).not.toContain('mockFunctionWithRest');
+    });
+});

--- a/tooling/docs-generator/tests/subpath-entries.test.ts
+++ b/tooling/docs-generator/tests/subpath-entries.test.ts
@@ -29,7 +29,19 @@ describe('a package with more than one public entry point', () => {
     });
 
     it('documents the root and every public subpath', () => {
-        expect(mock.entries.map((entry) => entry.subpath).sort()).toEqual(['.', './extra']);
+        expect(mock.entries.map((entry) => entry.subpath).sort()).toEqual([
+            '.',
+            './deep-entry',
+            './deep/entry',
+            './extra'
+        ]);
+    });
+
+    // `./deep-entry` and `./deep/entry` collided on one filename before the hyphen got doubled
+    it('names a nested subpath apart from a hyphenated one', () => {
+        const names = mock.entries.map((entry) => basename(entry.output));
+        expect(names).toContain('mock-docs.deep--entry.api.json');
+        expect(names).toContain('mock-docs.deep-entry.api.json');
     });
 
     it('skips a top-level and a nested internal subpath', () => {


### PR DESCRIPTION
## What and why

Closes #239

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [-] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation generation now supports multiple public package entry points and subpaths.
  * Generated documentation identifies the import path for each package entry.
  * Symbols shared across entry points are merged and displayed without duplication.
* **Style**
  * README images now preserve their natural size and inline alignment.
* **Bug Fixes**
  * Internal and untyped package paths are excluded from generated documentation.
  * Entry-specific documentation now shows only the relevant exported API.
  * Package metadata now accurately records each documented entry point and its output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->