### PR TITLE
feat: docs homepage

### DIFF
--- a/apps/docs/src/app/(docs)/page.tsx
+++ b/apps/docs/src/app/(docs)/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 import { loadDocsCatalog } from '#lib/docs/catalog';
 import { pageMetadata, SITE_DESCRIPTION } from '#lib/site';
-import { getToneConfig, TONE_ORDER } from '#lib/tonePresentation';
+import { getToneConfig, getToneTitle, TONE_ORDER } from '#lib/tonePresentation';
 
 import type { PackageCatalogEntry } from '#lib/docs/types';
 import type { EntityTone } from '@seedcord/docs-engine/client';
@@ -51,6 +51,7 @@ function ToneCounts({ card }: { card: PackageCard }): ReactElement {
                         )}
                     >
                         <ToneIcon size={12} strokeWidth={2} aria-hidden />
+                        <span className={cn('sr-only')}>{getToneTitle(tone)}: </span>
                         {card.entry.symbolCounts.get(tone)}
                     </span>
                 );
@@ -159,7 +160,7 @@ export default async function DocsIndexPage(): Promise<ReactElement> {
     const rest = cards.filter((card) => !TRANSPORT_PACKAGES.has(card.entry.manifestName));
 
     return (
-        <main className={cn('mx-auto w-full max-w-5xl space-y-8 px-5 py-10 sm:px-6 sm:py-14')}>
+        <main className={cn('mx-auto w-full max-w-6xl space-y-8 px-5 py-10 sm:px-6 sm:py-14')}>
             <div className={cn('space-y-1')}>
                 <p className={cn('text-subtle text-xs font-semibold tracking-[0.35em] uppercase')}>Docs</p>
                 <h1 className={cn('font-display text-2xl font-semibold text-(--text)')}>Reference</h1>

--- a/apps/docs/src/app/(docs)/page.tsx
+++ b/apps/docs/src/app/(docs)/page.tsx
@@ -1,5 +1,179 @@
-import { redirect } from 'next/navigation';
+import { cn, tw } from '@seedcord/ui';
+import Link from 'next/link';
 
-export default function DocsIndexPage(): never {
-    redirect('/packages/seedcord/latest');
+import { loadDocsCatalog } from '#lib/docs/catalog';
+import { pageMetadata, SITE_DESCRIPTION } from '#lib/site';
+import { getToneConfig, TONE_ORDER } from '#lib/tonePresentation';
+
+import type { PackageCatalogEntry } from '#lib/docs/types';
+import type { EntityTone } from '@seedcord/docs-engine/client';
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+
+export const metadata: Metadata = pageMetadata({
+    title: 'seedcord reference',
+    description: SITE_DESCRIPTION,
+    path: '/',
+    image: '/og'
+});
+
+const TRANSPORT_PACKAGES = new Set(['@seedcord/gateway', '@seedcord/http']);
+
+// matches the entity chips on a package's reference tab
+const cardClassName = tw`bg-surface-moderate shadow-soft border-border flex flex-col gap-3 rounded-md border p-4 transition`;
+
+interface PackageCard {
+    entry: PackageCatalogEntry;
+    href: string;
+    version: string;
+}
+
+function toCard(entry: PackageCatalogEntry): PackageCard {
+    const latest = entry.versions.find((version) => version.isLatest) ?? entry.versions[0];
+    return { entry, href: latest?.basePath ?? '/', version: latest?.label ?? '' };
+}
+
+function tonesOf(card: PackageCard): EntityTone[] {
+    return TONE_ORDER.filter((tone) => (card.entry.symbolCounts.get(tone) ?? 0) > 0);
+}
+
+function ToneCounts({ card }: { card: PackageCard }): ReactElement {
+    return (
+        <div className={cn('mt-auto flex flex-wrap items-center gap-1.5')}>
+            {tonesOf(card).map((tone) => {
+                const { icon: ToneIcon, styles } = getToneConfig(tone);
+                return (
+                    <span
+                        key={tone}
+                        className={cn(
+                            'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 font-mono text-xs',
+                            styles.badge
+                        )}
+                    >
+                        <ToneIcon size={12} strokeWidth={2} aria-hidden />
+                        {card.entry.symbolCounts.get(tone)}
+                    </span>
+                );
+            })}
+        </div>
+    );
+}
+
+// the divider between segments is the page ground colour
+function ToneBar({ card }: { card: PackageCard }): ReactElement | null {
+    const tones = tonesOf(card);
+    const total = tones.reduce((sum, tone) => sum + (card.entry.symbolCounts.get(tone) ?? 0), 0);
+    if (total === 0) return null;
+
+    return (
+        <div className={cn('flex h-1.5 w-full overflow-hidden rounded-full bg-(--surface-subtle)')}>
+            {tones.map((tone, index) => (
+                <span
+                    key={tone}
+                    aria-hidden
+                    className={cn(
+                        'h-full',
+                        getToneConfig(tone).styles.dot,
+                        index < tones.length - 1 && 'border-r border-(--color-bg)'
+                    )}
+                    style={{ width: `${((card.entry.symbolCounts.get(tone) ?? 0) / total) * 100}%` }}
+                />
+            ))}
+        </div>
+    );
+}
+
+function PackageCardLink({ card, bar = false }: { card: PackageCard; bar?: boolean }): ReactElement {
+    return (
+        <Link href={card.href} className={cn(cardClassName, 'hover:border-(--border-accent-b-subtle)')}>
+            <div className={cn('space-y-1')}>
+                <div className={cn('flex items-baseline justify-between gap-3')}>
+                    <span className={cn('font-mono text-sm font-medium wrap-break-word text-(--text)')}>
+                        {card.entry.manifestName}
+                    </span>
+                    <span className={cn('shrink-0 font-mono text-xs text-(--text-muted)')}>{card.version}</span>
+                </div>
+                <p className={cn('text-subtle text-sm')}>{card.entry.description}</p>
+            </div>
+            <ToneCounts card={card} />
+            {bar ? <ToneBar card={card} /> : null}
+        </Link>
+    );
+}
+
+function Section({
+    title,
+    cards,
+    columns,
+    bar = false
+}: {
+    title: string;
+    cards: PackageCard[];
+    columns: string;
+    bar?: boolean;
+}): ReactElement {
+    return (
+        <section className={cn('space-y-3')}>
+            <header className={cn('flex items-center gap-2')}>
+                <span className={cn('text-subtle text-sm font-semibold tracking-wide uppercase')}>{title}</span>
+                <span className={cn('text-xs text-(--text-faint)')}>
+                    {cards.length} package{cards.length === 1 ? '' : 's'}
+                </span>
+            </header>
+            <div className={cn('grid gap-3', columns)}>
+                {cards.map((card) => (
+                    <PackageCardLink key={card.entry.manifestName} card={card} bar={bar} />
+                ))}
+            </div>
+        </section>
+    );
+}
+
+const WORKSPACE_TITLES: Record<string, string> = {
+    packages: 'Packages',
+    plugins: 'Plugins',
+    cli: 'CLI',
+    tooling: 'Tooling'
+};
+
+const WORKSPACE_ORDER = Object.keys(WORKSPACE_TITLES);
+
+function workspaceRank(workspace: string): number {
+    const index = WORKSPACE_ORDER.indexOf(workspace);
+    return index === -1 ? WORKSPACE_ORDER.length : index;
+}
+
+function groupByWorkspace(cards: PackageCard[]): [string, PackageCard[]][] {
+    const groups = new Map<string, PackageCard[]>();
+    for (const card of cards) {
+        const key = card.entry.workspace ?? 'packages';
+        groups.set(key, [...(groups.get(key) ?? []), card]);
+    }
+
+    return [...groups.entries()].sort(([a], [b]) => workspaceRank(a) - workspaceRank(b));
+}
+
+export default async function DocsIndexPage(): Promise<ReactElement> {
+    const cards = (await loadDocsCatalog()).map(toCard);
+    const transports = cards.filter((card) => TRANSPORT_PACKAGES.has(card.entry.manifestName));
+    const rest = cards.filter((card) => !TRANSPORT_PACKAGES.has(card.entry.manifestName));
+
+    return (
+        <main className={cn('mx-auto w-full max-w-5xl space-y-8 px-5 py-10 sm:px-6 sm:py-14')}>
+            <div className={cn('space-y-1')}>
+                <p className={cn('text-subtle text-xs font-semibold tracking-[0.35em] uppercase')}>Docs</p>
+                <h1 className={cn('font-display text-2xl font-semibold text-(--text)')}>Reference</h1>
+            </div>
+
+            <Section title="Transports" cards={transports} columns="sm:grid-cols-2" bar />
+            {groupByWorkspace(rest).map(([workspace, group]) => (
+                <Section
+                    key={workspace}
+                    title={WORKSPACE_TITLES[workspace] ?? workspace}
+                    cards={group}
+                    columns="sm:grid-cols-2 lg:grid-cols-3"
+                />
+            ))}
+        </main>
+    );
 }

--- a/apps/docs/src/app/og/[[...path]]/route.tsx
+++ b/apps/docs/src/app/og/[[...path]]/route.tsx
@@ -41,7 +41,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ path?: 
             pill: 'docs',
             accent: BRAND.seedDark,
             meta: [],
-            name: 'seedcord',
+            name: 'Reference',
             description: SITE_DESCRIPTION
         });
     }

--- a/apps/docs/src/components/docs/PackageVersionOverview.tsx
+++ b/apps/docs/src/components/docs/PackageVersionOverview.tsx
@@ -1,10 +1,11 @@
 import { cn, tw } from '@seedcord/ui';
 import Link from 'next/link';
 
-import { getToneConfig } from '#lib/tonePresentation';
+import { getToneConfig, getToneTitle, TONE_ORDER } from '#lib/tonePresentation';
 
 import type { ReexportLink } from '#lib/docs/catalog';
 import type { NavigationCategory } from '#lib/docs/types';
+import type { EntityTone } from '@seedcord/docs-engine/client';
 import type { ReactElement } from 'react';
 
 const chipBaseClassName = tw`bg-surface-moderate shadow-soft border-border inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium text-(--text) transition focus-visible:outline-2 focus-visible:outline-offset-2`;
@@ -45,9 +46,38 @@ function groupReexports(reexports: readonly ReexportLink[]): [string, ReexportLi
     return [...groups.entries()];
 }
 
+// re-exports open the owning package's page in a new tab, matching the cross-package link convention
+function renderReexportLink(link: ReexportLink): ReactElement {
+    const toneStyles = link.tone ? getToneConfig(link.tone).styles : null;
+    return (
+        <Link
+            key={link.name}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(chipBaseClassName, toneStyles?.item)}
+        >
+            {toneStyles ? <span aria-hidden className={cn('size-1.5 shrink-0 rounded-full', toneStyles.dot)} /> : null}
+            {link.name}
+        </Link>
+    );
+}
+
+function toneRank(tone: EntityTone | null): number {
+    return tone ? TONE_ORDER.indexOf(tone) : TONE_ORDER.length;
+}
+
+function groupByTone(links: readonly ReexportLink[]): [EntityTone | null, ReexportLink[]][] {
+    const groups = new Map<EntityTone | null, ReexportLink[]>();
+    for (const link of links) {
+        groups.set(link.tone, [...(groups.get(link.tone) ?? []), link]);
+    }
+    return [...groups.entries()].sort(([a], [b]) => toneRank(a) - toneRank(b));
+}
+
 function renderReexportGroup([owner, links]: [string, ReexportLink[]]): ReactElement {
     return (
-        <section key={owner} className={cn('space-y-3')}>
+        <section key={owner} className={cn('space-y-4')}>
             <header className={cn('flex flex-wrap items-baseline gap-x-2 gap-y-1')}>
                 <span className={cn('text-subtle text-sm font-semibold tracking-wide uppercase')}>
                     Re-exported from {owner}
@@ -56,26 +86,29 @@ function renderReexportGroup([owner, links]: [string, ReexportLink[]]): ReactEle
                     {links.length} symbol{links.length === 1 ? '' : 's'}
                 </span>
             </header>
-            <div className={cn('flex flex-wrap gap-2')}>
-                {links.map((link) => {
-                    const toneStyles = link.tone ? getToneConfig(link.tone).styles : null;
-                    // re-exports open the owning package's page in a new tab, matching the cross-package link convention
-                    return (
-                        <Link
-                            key={link.name}
-                            href={link.href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={cn(chipBaseClassName, toneStyles?.item)}
-                        >
-                            {toneStyles ? (
-                                <span aria-hidden className={cn('size-1.5 shrink-0 rounded-full', toneStyles.dot)} />
+            {groupByTone(links).map(([tone, toneLinks]) => {
+                const config = tone ? getToneConfig(tone) : null;
+                const ToneIcon = config?.icon;
+                return (
+                    <div key={tone ?? 'untoned'} className={cn('space-y-2 pl-1')}>
+                        <header className={cn('flex items-center gap-2')}>
+                            {ToneIcon ? (
+                                <ToneIcon
+                                    size={14}
+                                    strokeWidth={2}
+                                    aria-hidden
+                                    className={cn('shrink-0', config?.styles.iconColor)}
+                                />
                             ) : null}
-                            {link.name}
-                        </Link>
-                    );
-                })}
-            </div>
+                            <span className={cn('text-xs font-semibold tracking-wide text-(--text-muted) uppercase')}>
+                                {tone ? getToneTitle(tone) : 'Other'}
+                            </span>
+                            <span className={cn('text-xs text-(--text-faint)')}>{toneLinks.length}</span>
+                        </header>
+                        <div className={cn('flex flex-wrap gap-2')}>{toneLinks.map(renderReexportLink)}</div>
+                    </div>
+                );
+            })}
         </section>
     );
 }

--- a/apps/docs/src/lib/docs/catalog.ts
+++ b/apps/docs/src/lib/docs/catalog.ts
@@ -9,6 +9,8 @@ import {
 } from '@seedcord/docs-engine';
 import { cache } from 'react';
 
+import { getToneTitle, TONE_ORDER } from '../tonePresentation';
+
 import { getDocsEngine } from './engine';
 
 import type { VersionedDocsEngine } from './engine';
@@ -20,19 +22,25 @@ import type {
     PackageCatalogEntry,
     PackageVersionCatalog
 } from './types';
-import type { PackageIndexEntry } from '@seedcord/docs-engine';
+import type { DirectoryEntity, PackageIndexEntry } from '@seedcord/docs-engine';
 import type { EntityTone } from '@seedcord/docs-engine/client';
 
 type GetPackageDirectoryReturn = ReturnType<VersionedDocsEngine['getPackageDirectory']>;
 
-const CATEGORY_CONFIG: readonly CategoryConfig[] = [
-    { entity: 'classes', title: 'Classes', tone: 'class' },
-    { entity: 'interfaces', title: 'Interfaces', tone: 'interface' },
-    { entity: 'functions', title: 'Functions', tone: 'function' },
-    { entity: 'enums', title: 'Enums', tone: 'enum' },
-    { entity: 'types', title: 'Types', tone: 'type' },
-    { entity: 'variables', title: 'Variables', tone: 'variable' }
-] as const;
+const TONE_ENTITIES = {
+    class: 'classes',
+    interface: 'interfaces',
+    function: 'functions',
+    enum: 'enums',
+    type: 'types',
+    variable: 'variables'
+} as const satisfies Record<EntityTone, DirectoryEntity>;
+
+const CATEGORY_CONFIG: readonly CategoryConfig[] = TONE_ORDER.map((tone) => ({
+    entity: TONE_ENTITIES[tone],
+    tone,
+    title: getToneTitle(tone)
+}));
 
 const createNavigationItem = (
     manifestPackage: string,
@@ -117,6 +125,14 @@ function buildVersions(fullName: string, entry: PackageIndexEntry): PackageVersi
     return versions;
 }
 
+function countByTone(entities: PackageIndexEntry['entities']): ReadonlyMap<EntityTone, number> {
+    const counts = new Map<EntityTone, number>();
+    for (const tone of Object.values(entities ?? {})) {
+        counts.set(tone, (counts.get(tone) ?? 0) + 1);
+    }
+    return counts;
+}
+
 function buildPackageEntry(fullName: string, entry: PackageIndexEntry): PackageCatalogEntry {
     const displayName = formatDisplayPackageName(fullName);
 
@@ -125,6 +141,8 @@ function buildPackageEntry(fullName: string, entry: PackageIndexEntry): PackageC
         manifestName: fullName,
         label: displayName,
         description: entry.description ?? `Reference documentation for ${displayName}.`,
+        workspace: entry.workspace ?? null,
+        symbolCounts: countByTone(entry.entities),
         versions: buildVersions(fullName, entry)
     } satisfies PackageCatalogEntry;
 }

--- a/apps/docs/src/lib/docs/types.ts
+++ b/apps/docs/src/lib/docs/types.ts
@@ -119,6 +119,8 @@ export interface PackageCatalogEntry {
     manifestName: string;
     label: string;
     description: string;
+    workspace: string | null;
+    symbolCounts: ReadonlyMap<EntityTone, number>;
     versions: readonly PackageVersionCatalog[];
 }
 

--- a/apps/docs/src/lib/tonePresentation.ts
+++ b/apps/docs/src/lib/tonePresentation.ts
@@ -88,6 +88,21 @@ const TONE_PRESENTATION = {
 type EntityToneConfig = (typeof TONE_PRESENTATION)[EntityTone];
 export type EntityToneStyle = EntityToneConfig['styles'];
 
+const TONE_TITLES = {
+    class: 'Classes',
+    interface: 'Interfaces',
+    function: 'Functions',
+    enum: 'Enums',
+    type: 'Types',
+    variable: 'Variables'
+} as const satisfies Record<EntityTone, string>;
+
+export const TONE_ORDER = Object.keys(TONE_TITLES) as (keyof typeof TONE_TITLES)[];
+
 export function getToneConfig(tone: EntityTone): EntityToneConfig {
     return TONE_PRESENTATION[tone];
+}
+
+export function getToneTitle(tone: EntityTone): string {
+    return TONE_TITLES[tone];
 }

--- a/apps/docs/tests/lib/docs/catalog.test.ts
+++ b/apps/docs/tests/lib/docs/catalog.test.ts
@@ -43,6 +43,8 @@ function makeEntry(versions: PackageVersionCatalog[]): PackageCatalogEntry {
         manifestName: 'seedcord',
         label: 'seedcord',
         description: 'desc',
+        workspace: 'packages',
+        symbolCounts: new Map(),
         versions
     };
 }

--- a/scripts/docs/build-docs-artifacts.ts
+++ b/scripts/docs/build-docs-artifacts.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console -- CLI script so console is ok */
-import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -72,8 +72,24 @@ async function writeArtifacts(index: IndexJson, projects: readonly ProjectArtifa
     }
 }
 
+// manifest.json records source files relative to the repo root. first segment is the workspace glob
+async function readWorkspaces(): Promise<Map<string, string>> {
+    const raw = await readFile(path.join(GENERATED_ROOT, 'manifest.json'), 'utf8');
+    const manifest = JSON.parse(raw) as { packages?: { name: string; sources?: Record<string, { file: string }[]> }[] };
+    const workspaces = new Map<string, string>();
+
+    for (const pkg of manifest.packages ?? []) {
+        const file = Object.values(pkg.sources ?? {})[0]?.[0]?.file;
+        const workspace = file?.split('/')[0];
+        if (workspace) workspaces.set(pkg.name, workspace);
+    }
+
+    return workspaces;
+}
+
 async function main(): Promise<void> {
     const engine = await DocsEngine.create({ generatedRoot: GENERATED_ROOT });
+    const workspaces = await readWorkspaces();
 
     const inputs: PackageVersionsInput[] = [];
     const projects: ProjectArtifact[] = [];
@@ -89,6 +105,7 @@ async function main(): Promise<void> {
         // display folder when a displayName override is set.
         const apiSource = path.join(GENERATED_ROOT, `${fullName.split('/').pop() ?? fullName}.api.json`);
         const file = serializeProject(pkg);
+        const workspace = workspaces.get(fullName);
         const versions = USE_FIXTURES
             ? syntheticVersions(real)
             : [{ version: real, channel: isPrerelease(real) ? 'prerelease' : 'stable' } satisfies SyntheticVersion];
@@ -98,7 +115,8 @@ async function main(): Promise<void> {
             fullName,
             versions: versions.map((entry) => entry.version),
             entities: pkg.directory.toneMap(),
-            ...(pkg.manifest.description && { description: pkg.manifest.description })
+            ...(pkg.manifest.description && { description: pkg.manifest.description }),
+            ...(workspace && { workspace })
         });
         for (const { version, channel } of versions) {
             projects.push({ folder, version, channel, file, apiSource });

--- a/tooling/docs-engine/src/remote/index-builder.ts
+++ b/tooling/docs-engine/src/remote/index-builder.ts
@@ -9,6 +9,7 @@ export interface PackageVersionsInput {
     versions: readonly string[];
     entities?: Record<string, EntityTone>;
     description?: string;
+    workspace?: string;
 }
 
 export interface BuildIndexOptions {
@@ -57,6 +58,10 @@ function buildEntry(pkg: PackageVersionsInput): PackageIndexEntry {
 
     if (pkg.description) {
         entry.description = pkg.description;
+    }
+
+    if (pkg.workspace) {
+        entry.workspace = pkg.workspace;
     }
 
     return entry;

--- a/tooling/docs-engine/src/remote/index-json.ts
+++ b/tooling/docs-engine/src/remote/index-json.ts
@@ -26,11 +26,12 @@ export interface PackageIndexEntry {
     prerelease: { latest: string } | null;
     // Entity slug -> tone for the latest version (`logger` -> `class`). The lazy engine reads this to
     // build `/tone/version/slug` URLs for an unloaded package and to drop links to non-entities
-    // (params, mis-attributed externals). Absent on legacy indexes.
-    entities?: Record<string, EntityTone>;
-    // package.json description of the latest version, version-independent so the catalog reads it
-    // without loading a project.json. Absent on legacy indexes.
-    description?: string;
+    // (params, mis-attributed externals).
+    entities?: Record<string, EntityTone>; // Absent on legacy indexes.
+    // package.json description of the latest version.
+    description?: string; // Absent on legacy indexes.
+    // the workspace glob the package sits under.
+    workspace?: string; // Absent on legacy indexes.
 }
 
 export function validateIndex(value: unknown): IndexJson {
@@ -80,6 +81,10 @@ function validateEntry(folder: string, value: unknown): PackageIndexEntry {
 
     if (typeof entry.description === 'string') {
         base.description = entry.description;
+    }
+
+    if (typeof entry.workspace === 'string') {
+        base.workspace = entry.workspace;
     }
 
     return base;


### PR DESCRIPTION
## What and why

docs didn't have a homepage

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [-] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documentation reference homepage with package cards grouped by workspace.
  - Added package metadata, entity counts, tone-based sections, and optional distribution bars.
  - Improved re-export browsing with tone-specific headings, icons, counts, sorting, and styling.
  - Added workspace information to package documentation indexes.
  - Updated the homepage metadata and Open Graph label to “Reference.”

- **Bug Fixes**
  - Documentation visitors now land on a browsable reference index instead of being redirected to a single package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->