### PR TITLE
refactor: access level cleanup

### DIFF
--- a/.changeset/encapsulate-framework-internals.md
+++ b/.changeset/encapsulate-framework-internals.md
@@ -1,0 +1,9 @@
+---
+'@seedcord/core': patch
+'@seedcord/errors': patch
+'@seedcord/gateway': patch
+'@seedcord/http': patch
+'seedcord': patch
+---
+
+Better encapsulate framework internals.

--- a/.changeset/encapsulate-framework-internals.md
+++ b/.changeset/encapsulate-framework-internals.md
@@ -1,9 +1,11 @@
 ---
 '@seedcord/core': patch
-'@seedcord/errors': patch
+'@seedcord/errors': minor
 '@seedcord/gateway': patch
 '@seedcord/http': patch
 'seedcord': patch
 ---
 
 Better encapsulate framework internals.
+
+**BREAKING:** `SeedcordError.identifier` is accessed via a symbol now. Older framework versions won't be able to access it anymore. Please update to the latest version.

--- a/cli/create-seedcord/vitest.config.ts
+++ b/cli/create-seedcord/vitest.config.ts
@@ -3,6 +3,6 @@ import { createVitestConfig } from '@seedcord/vitest-config';
 export default createVitestConfig(import.meta.url, {
     test: {
         environment: 'node',
-        testTimeout: 10_000
+        testTimeout: 20_000
     }
 });

--- a/cli/seedcord/package.json
+++ b/cli/seedcord/package.json
@@ -71,7 +71,6 @@
         "@seedcord/logger": "workspace:^",
         "@seedcord/types": "workspace:^",
         "@seedcord/utils": "workspace:^",
-        "chalk": "catalog:deps",
         "commander": "^15.0.0",
         "discord-api-types": "catalog:deps",
         "ink": "^7.1.1",

--- a/cli/seedcord/src/commands/commands/cleanPresenters.ts
+++ b/cli/seedcord/src/commands/commands/cleanPresenters.ts
@@ -1,6 +1,5 @@
 import { SeedcordErrorCode, paint } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
-import chalk from 'chalk';
 
 import { plural } from '#core/format';
 import { confirm, log, note, outro, spinner } from '#core/prompts';
@@ -73,7 +72,7 @@ export class InteractivePresenter implements CleanPresenter {
 
     public preview(scan: ScanResult): void {
         const body = groupByGuild(scan.flagged)
-            .map((group) => `${chalk.bold(group.guildName)}\n${group.commands.map((c) => `  ${c.name}`).join('\n')}`)
+            .map((group) => `${paint.bold(group.guildName)}\n${group.commands.map((c) => `  ${c.name}`).join('\n')}`)
             .join('\n\n');
         note(body, `Will delete ${plural(scan.flagged.length, 'guild command')} (nothing deleted yet)`);
         if (scan.skipped.length > 0) log.warn(skippedSummary(scan.skipped));
@@ -126,7 +125,7 @@ export class FlagPresenter implements CleanPresenter {
     }
 
     public preview(scan: ScanResult): void {
-        this.logger.info(chalk.bold(`${plural(scan.flagged.length, 'guild command')} selected for deletion`));
+        this.logger.info(paint.bold(`${plural(scan.flagged.length, 'guild command')} selected for deletion`));
         for (const group of groupByGuild(scan.flagged)) {
             this.logger.info(paint.sky(group.guildName));
             for (const command of group.commands) this.logger.info(`  ${command.name}`);
@@ -170,6 +169,6 @@ export class FlagPresenter implements CleanPresenter {
     }
 
     public dryRunHint(): void {
-        this.logger.info(chalk.italic('Dry run. Re-run with --apply to delete the above.'));
+        this.logger.info(paint.italic('Dry run. Re-run with --apply to delete the above.'));
     }
 }

--- a/cli/seedcord/src/commands/dev/DevRunner.ts
+++ b/cli/seedcord/src/commands/dev/DevRunner.ts
@@ -180,7 +180,7 @@ export class DevRunner {
         });
     }
 
-    public async loadConfig(): Promise<ResolvedSeedcordDevConfig> {
+    private async loadConfig(): Promise<ResolvedSeedcordDevConfig> {
         const configPath = this.deps.locator.locate();
         return this.deps.configLoader.load(configPath);
     }

--- a/cli/seedcord/src/commands/dev/DevSession.ts
+++ b/cli/seedcord/src/commands/dev/DevSession.ts
@@ -1,10 +1,9 @@
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { SeedcordErrorCode } from '@seedcord/errors';
+import { paint, SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { SeedcordBrand, type Brandable, type SeedcordInstance } from '@seedcord/types/internal';
-import chalk from 'chalk';
 
 import { profileMark } from '#ui/profile';
 import { resolveDefaultExport } from '#utils/resolveDefaultExport';
@@ -91,7 +90,7 @@ export class DevSession {
             }
 
             this.store.setPhase('running');
-            this.store.setStatus(`${chalk.bold(instance.username ?? 'Bot')} is ready!`);
+            this.store.setStatus(`${paint.bold(instance.username ?? 'Bot')} is ready!`);
             profileMark('ready');
             onReady?.();
             // tsc competes with vite's cold transform when it starts any earlier

--- a/knip.json
+++ b/knip.json
@@ -39,8 +39,16 @@
                 "src/**/*.{ts,tsx,css}"
             ]
         },
-        "packages/core": {},
-        "packages/errors": {},
+        "packages/core": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
+        "packages/errors": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "tooling/eslint-plugin": {
             "ignore": [
                 "tests/fixtures/**"
@@ -59,30 +67,57 @@
         },
         "tooling/eslint-utils": {},
         "packages/event-emitter": {},
-        "packages/gateway": {},
+        "packages/gateway": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "packages/http": {
             "ignore": [
                 "tests/node/commands/fixtures/**",
                 "tests/node/discovery/fixtures/**",
                 "tests/node/discovery/duplicates/**"
+            ],
+            "entry": [
+                "**/*.types-test.ts"
             ]
         },
-        "packages/logger": {},
+        "packages/logger": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "packages/rate-limiter": {},
-        "packages/types": {},
+        "packages/types": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "packages/utils": {
             "ignore": [
                 "tests/node/fixtures/**"
             ]
         },
-        "plugins/kysely-postgres": {},
-        "plugins/mongoose": {},
+        "plugins/kysely-postgres": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
+        "plugins/mongoose": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "cli/seedcord": {
             "ignoreDependencies": [
                 "tsc-alias"
             ]
         },
-        "cli/create-seedcord": {},
+        "cli/create-seedcord": {
+            "entry": [
+                "**/*.types-test.ts"
+            ]
+        },
         "tooling/docs-engine": {},
         "tooling/docs-generator": {
             "ignore": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,6 @@
         "@seedcord/logger": "workspace:^",
         "@seedcord/types": "workspace:^",
         "@seedcord/utils": "workspace:^",
-        "chalk": "catalog:deps",
         "discord-api-types": "catalog:deps",
         "reflect-metadata": "catalog:deps"
     },

--- a/packages/core/src/customId/routing.ts
+++ b/packages/core/src/customId/routing.ts
@@ -5,6 +5,7 @@ import { SeedcordError } from '@seedcord/errors/internal';
 
 import { decodeFor } from './CustomId';
 
+import type { ComponentDefsBrand } from '#src/decorators/brands';
 import type { AnyCustomId } from './CustomId';
 import type { DecodedParams } from './Field';
 import type { Promisable } from 'type-fest';
@@ -25,7 +26,7 @@ export const ComponentDefsKey = Symbol('seedcord:customId:componentDefs');
  */
 export interface HasComponentDefs<Defs extends readonly AnyCustomId[]> {
     /** @internal */
-    readonly __componentDefs?: Defs;
+    readonly [ComponentDefsBrand]?: Defs;
 }
 
 /** @internal */

--- a/packages/core/src/decorators/brands.ts
+++ b/packages/core/src/decorators/brands.ts
@@ -1,0 +1,8 @@
+// A handler base declares these so a route decorator can read what the handler is for. Nothing
+// assigns them at runtime.
+
+export const SlashRouteBrand: unique symbol = Symbol('seedcord:brand:slashRoute');
+export const AutocompleteRouteBrand: unique symbol = Symbol('seedcord:brand:autocompleteRoute');
+export const ContextMenuKindBrand: unique symbol = Symbol('seedcord:brand:contextMenuKind');
+export const ComponentKindBrand: unique symbol = Symbol('seedcord:brand:componentKind');
+export const ComponentDefsBrand: unique symbol = Symbol('seedcord:brand:componentDefs');

--- a/packages/core/src/decorators/routes.ts
+++ b/packages/core/src/decorators/routes.ts
@@ -14,6 +14,13 @@ import type {
     UserContextMenuRegistry
 } from '#registries/ContextMenuRegistry';
 import type { SlashOptionRegistry } from '#registries/SlashOptionRegistry';
+import type {
+    AutocompleteRouteBrand,
+    ComponentDefsBrand,
+    ComponentKindBrand,
+    ContextMenuKindBrand,
+    SlashRouteBrand
+} from './brands';
 import type { ApplicationCommandType } from 'discord-api-types/v10';
 import type { Constructor } from 'type-fest';
 
@@ -24,35 +31,35 @@ type AnyHandlerCtor = new (...args: any[]) => unknown;
 
 type SlashRouteOf<TCtor extends AnyHandlerCtor> =
     InstanceType<TCtor> extends {
-        __slashRoute?: infer Route extends keyof SlashOptionRegistry;
+        [SlashRouteBrand]?: infer Route extends keyof SlashOptionRegistry;
     }
         ? Route
         : never;
 
 type AutocompleteRouteOf<TCtor extends AnyHandlerCtor> =
     InstanceType<TCtor> extends {
-        __autocompleteRoute?: infer Route extends keyof SlashOptionRegistry;
+        [AutocompleteRouteBrand]?: infer Route extends keyof SlashOptionRegistry;
     }
         ? Route
         : never;
 
 type ContextMenuKindOf<TCtor extends AnyHandlerCtor> =
     InstanceType<TCtor> extends {
-        __ctxKind?: infer Kind extends ContextMenuKind;
+        [ContextMenuKindBrand]?: infer Kind extends ContextMenuKind;
     }
         ? Kind
         : never;
 
 type ComponentOf<TCtor extends AnyHandlerCtor> =
     InstanceType<TCtor> extends {
-        __component?: infer Brand extends ComponentBrand;
+        [ComponentKindBrand]?: infer Brand extends ComponentBrand;
     }
         ? Brand
         : never;
 
 type DefsOf<TCtor extends AnyHandlerCtor> =
     InstanceType<TCtor> extends {
-        __componentDefs?: infer Defs extends readonly AnyCustomId[];
+        [ComponentDefsBrand]?: infer Defs extends readonly AnyCustomId[];
     }
         ? Defs
         : never;

--- a/packages/core/src/hmr/HmrManager.ts
+++ b/packages/core/src/hmr/HmrManager.ts
@@ -32,11 +32,6 @@ export class HmrManager {
         this.listeners.add(listener);
     }
 
-    /** @internal */
-    public unregister(listener: HmrAware): void {
-        this.listeners.delete(listener);
-    }
-
     private async handleUpdate(event: HmrUpdateEvent): Promise<void> {
         const promises = [...this.listeners].map(async (listener) => {
             try {

--- a/packages/core/src/internal.index.ts
+++ b/packages/core/src/internal.index.ts
@@ -1,3 +1,4 @@
+export { busLoggerOf } from '#subscribers/Bus';
 export {
     AutocompleteRouteBrand,
     ComponentDefsBrand,

--- a/packages/core/src/internal.index.ts
+++ b/packages/core/src/internal.index.ts
@@ -1,3 +1,10 @@
+export {
+    AutocompleteRouteBrand,
+    ComponentDefsBrand,
+    ComponentKindBrand,
+    ContextMenuKindBrand,
+    SlashRouteBrand
+} from '#decorators/brands';
 export { setBotColor } from '#components/botColorHolder';
 
 export type { PluginArgs, PluginCtor } from '#src/plugin/Plugin';

--- a/packages/core/src/node/HealthCheck.ts
+++ b/packages/core/src/node/HealthCheck.ts
@@ -18,18 +18,26 @@ const DEFAULT_HEALTH_CHECK_PORT = 6967;
 export class HealthCheck {
     public readonly logger = new Logger('HealthCheck', { channel: 'health' });
 
-    private readonly port: number;
-    private readonly host: string | undefined;
+    private readonly _port: number;
+    private readonly _host: string | undefined;
 
     private readonly responder: HealthResponder;
     private server?: Server;
 
     constructor(shutdown: CoordinatedShutdown, options?: HealthCheckConfig) {
-        this.port = options?.port ?? DEFAULT_HEALTH_CHECK_PORT;
-        this.host = options?.host;
+        this._port = options?.port ?? DEFAULT_HEALTH_CHECK_PORT;
+        this._host = options?.host;
         this.responder = new HealthResponder(options?.path);
 
         shutdown.addTask(ShutdownPhase.Drain, 'stop-healthcheck-server', () => this.stop());
+    }
+
+    public get port(): number {
+        return this._port;
+    }
+
+    public get host(): string | undefined {
+        return this._host;
     }
 
     public get path(): string {
@@ -60,19 +68,19 @@ export class HealthCheck {
                 server.on('error', (err) => this.logger.error('Health check server error', err));
 
                 // binds all interfaces, so log an address a browser can open
-                const address = this.host ?? 'localhost';
+                const address = this._host ?? 'localhost';
                 this.logger.info(
-                    `${paint.mint.bold('✔︎')} Health check server listening on ${paint.sky.bold(`http://${address}:${this.port}${this.path}`)}`
+                    `${paint.mint.bold('✔︎')} Health check server listening on ${paint.sky.bold(`http://${address}:${this._port}${this.path}`)}`
                 );
                 resolve();
             });
 
-            if (this.host) {
-                this.logger.debug(`Binding health check server to ${this.host}`);
-                server.listen(this.port, this.host);
+            if (this._host) {
+                this.logger.debug(`Binding health check server to ${this._host}`);
+                server.listen(this._port, this._host);
             } else {
                 this.logger.debug('Binding health check server to all interfaces');
-                server.listen(this.port);
+                server.listen(this._port);
             }
         });
     }

--- a/packages/core/src/node/HealthCheck.ts
+++ b/packages/core/src/node/HealthCheck.ts
@@ -18,8 +18,8 @@ const DEFAULT_HEALTH_CHECK_PORT = 6967;
 export class HealthCheck {
     public readonly logger = new Logger('HealthCheck', { channel: 'health' });
 
-    public readonly port: number;
-    public readonly host: string | undefined;
+    private readonly port: number;
+    private readonly host: string | undefined;
 
     private readonly responder: HealthResponder;
     private server?: Server;

--- a/packages/core/src/node/Lifecycle/CoordinatedStartup.ts
+++ b/packages/core/src/node/Lifecycle/CoordinatedStartup.ts
@@ -112,8 +112,4 @@ export class CoordinatedStartup extends CoordinatedLifecycle<StartupPhase> {
     public get isReady(): boolean {
         return this.hasStarted;
     }
-
-    public get isRunning(): boolean {
-        return this.isStartingUp;
-    }
 }

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -3,7 +3,7 @@ import { SeedcordAggregateError, SeedcordError } from '@seedcord/errors/internal
 import { FRAMEWORK_CHANNELS, Logger } from '@seedcord/logger';
 
 import { StartupPhase } from '#src/lifecycle/phases';
-import { resolvedLifecycleSpecOf } from '#src/plugin/Plugin';
+import { pluginLoggerOf, resolvedLifecycleSpecOf } from '#src/plugin/Plugin';
 
 import { withTimeout } from './Lifecycle/withTimeout';
 
@@ -150,7 +150,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
         }
 
         const instance = new Plugin(this, ...args);
-        instance.logger.setChannel(key);
+        pluginLoggerOf(instance).setChannel(key);
         this.plugins.push(instance);
         this.attachments.push({ key, instance });
 
@@ -185,9 +185,9 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
             const { key, instance } = attachment;
             const spec = resolvedLifecycleSpecOf(instance);
 
-            instance.logger.utils.initialization(key, 'start');
+            pluginLoggerOf(instance).utils.initialization(key, 'start');
             await withTimeout(`Plugin (${key})`, () => instance.init(), spec.init.timeout);
-            instance.logger.utils.initialization(key, 'end');
+            pluginLoggerOf(instance).utils.initialization(key, 'end');
 
             this.completedInits.add(attachment);
             if (instance.dispose) this.registerDisposeTask(spec.dispose.phase);

--- a/packages/core/src/node/subscribers/SubscriberLoader.ts
+++ b/packages/core/src/node/subscribers/SubscriberLoader.ts
@@ -4,6 +4,7 @@ import { Envapter } from 'envapt';
 
 import { HmrModuleHandler } from '#hmr/HmrModuleHandler';
 import { SubscribeMetadataKey } from '#src/metadataKeys';
+import { busLoggerOf } from '#subscribers/Bus';
 import { registrationFor, Subscriber } from '#subscribers/index';
 
 import type { Initializeable } from '#src/plugin/Plugin';
@@ -32,7 +33,7 @@ export class SubscriberLoader implements Initializeable, HmrAware {
             registerHandler: this.registerSubscriber.bind(this),
             unregisterHandler: this.unregisterSubscriber.bind(this),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.bus.logger
+            logger: busLoggerOf(this.bus)
         });
     }
 
@@ -45,9 +46,9 @@ export class SubscriberLoader implements Initializeable, HmrAware {
 
         const { directory } = this;
         if (directory) {
-            this.bus.logger.debug(paint.mute(directory));
+            busLoggerOf(this.bus).debug(paint.mute(directory));
             await this.load(directory);
-            this.bus.logger.utils.list(
+            busLoggerOf(this.bus).utils.list(
                 [`${paint.iris.bold(this.bus.registeredCount)} subscribers`],
                 paint.mint.bold('Loaded'),
                 'debug'
@@ -70,7 +71,7 @@ export class SubscriberLoader implements Initializeable, HmrAware {
 
                 this.registerSubscriber(value);
                 this.hmrHandler?.trackHandler(fullPath, value);
-                this.bus.logger.utils.registration(value.name, relativePath, undefined, 'trace');
+                busLoggerOf(this.bus).utils.registration(value.name, relativePath, undefined, 'trace');
             }
         });
     }

--- a/packages/core/src/notices/index.ts
+++ b/packages/core/src/notices/index.ts
@@ -95,8 +95,8 @@ export class HasDangerousPermissions extends Notice {
 
     public constructor(
         message: string | undefined,
-        public subject: string,
-        public dangerousPerms: readonly string[]
+        private readonly subject: string,
+        private readonly dangerousPerms: readonly string[]
     ) {
         super(message ?? 'A dangerous permission is enabled.');
         this.customLead = message;

--- a/packages/core/src/plugin/Plugin.ts
+++ b/packages/core/src/plugin/Plugin.ts
@@ -17,6 +17,8 @@ export interface Initializeable {
 
 /** @internal */
 const resolvedSpecSlot = Symbol('seedcord.plugin.spec');
+/** @internal */
+const loggerSlot = Symbol('seedcord.plugin.logger');
 
 /**
  * Base class for Seedcord plugins. A subclass declares its options as the `Opts` type argument,
@@ -35,9 +37,11 @@ export abstract class Plugin<Opts extends PluginOptions = {}, TCore extends Core
 
     /** @internal */
     readonly [resolvedSpecSlot]: ResolvedPluginLifecycleSpec;
+    /** @internal */
+    readonly [loggerSlot]: Logger;
 
     /** Logs under the plugin's class name, on the channel its attach key sets. */
-    public readonly logger: Logger;
+    protected readonly logger: Logger;
 
     // CoreBase here keeps the augmented Core out of ConstructorParameters, which attach reads
     constructor(
@@ -45,6 +49,7 @@ export abstract class Plugin<Opts extends PluginOptions = {}, TCore extends Core
         spec?: PluginLifecycleSpec
     ) {
         this.logger = new Logger(this.constructor.name);
+        this[loggerSlot] = this.logger;
         this[resolvedSpecSlot] = resolveLifecycleSpec(spec, this.constructor.name);
     }
 
@@ -93,13 +98,21 @@ export function resolvedLifecycleSpecOf(plugin: PluginLike): ResolvedPluginLifec
     return plugin[resolvedSpecSlot];
 }
 
+/** @internal */
+export function pluginLoggerOf(plugin: PluginLike): Logger {
+    return plugin[loggerSlot];
+}
+
 export type { PluginLifecycleSpec } from './lifecycle';
 export type { PluginOptions } from './options';
 
 // a bound of Plugin<{}> rejects every plugin that declares an option, since Plugin<A> and Plugin<B>
 // are mutually unassignable. every member here must stay Opts-independent.
 /** @internal */
-export type PluginLike = Pick<Plugin, 'init' | 'ready' | 'dispose' | 'logger' | 'onHmr' | typeof resolvedSpecSlot>;
+export type PluginLike = Pick<
+    Plugin,
+    'init' | 'ready' | 'dispose' | 'onHmr' | typeof resolvedSpecSlot | typeof loggerSlot
+>;
 
 // a `CoreBase` first parameter rejects a narrowing ctor on its own, and it also collapses
 // `InstanceType<Ctor>` to `PluginLike` at every attach call. CoreParamAssert checks it instead.

--- a/packages/core/src/subscribers/Bus.ts
+++ b/packages/core/src/subscribers/Bus.ts
@@ -45,13 +45,17 @@ export interface SubscriberRegistration {
     ctor?: StoredSubscriberCtor | undefined;
 }
 
+const loggerSlot = Symbol('seedcord:bus:logger');
+
 /**
  * Registers and dispatches subscribers. Subscribers run on a programmatic or framework publish.
  * Accessed via `core.bus`. Do not construct it directly.
  */
 export class Bus extends TypedEventEmitter<SubscriptionTuples> {
+    private readonly logger = new Logger('Subscribers', { channel: 'subscribers' });
+
     /** @internal */
-    public readonly logger = new Logger('Subscribers', { channel: 'subscribers' });
+    readonly [loggerSlot]: Logger = this.logger;
 
     private readonly subscribersMap = new Map<SubscriptionKey, SubscriberRegistration[]>();
     private readonly executedOnce = new Set<SubscriberRegistration>();
@@ -226,4 +230,9 @@ export class Bus extends TypedEventEmitter<SubscriptionTuples> {
 export function registrationFor(ctor: StoredSubscriberCtor): SubscriberRegistration {
     const meta = Reflect.getMetadata(SubscribeMetadataKey, ctor) as SubscribeMetadataEntry;
     return { keys: [meta.subscriber], frequency: meta.frequency ?? 'on', resolve: () => ctor, ctor };
+}
+
+/** @internal */
+export function busLoggerOf(bus: Bus): Logger {
+    return bus[loggerSlot];
 }

--- a/packages/core/tests/decorators/routes.test.ts
+++ b/packages/core/tests/decorators/routes.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 import { CustomId } from '#customId/CustomId';
 import { ComponentDefsKey } from '#customId/routing';
+import {
+    AutocompleteRouteBrand,
+    ComponentDefsBrand,
+    ComponentKindBrand,
+    ContextMenuKindBrand,
+    SlashRouteBrand
+} from '#decorators/brands';
 import { SelectMenuKind } from '#decorators/interactionRoutes';
 import {
     AutocompleteRoute,
@@ -37,23 +44,23 @@ declare module '#registries/ContextMenuRegistry' {
 
 // stub branded bases, the shape both transports' handler bases carry
 abstract class SlashBase<Route extends keyof SlashOptionRegistry> {
-    declare readonly __slashRoute?: Route;
+    declare readonly [SlashRouteBrand]?: Route;
     abstract execute(): Promise<void>;
 }
 abstract class AutocompleteBase<Route extends keyof SlashOptionRegistry> {
-    declare readonly __autocompleteRoute?: Route;
+    declare readonly [AutocompleteRouteBrand]?: Route;
     abstract execute(): Promise<void>;
 }
 abstract class ContextMenuBase<Kind extends ApplicationCommandType.User | ApplicationCommandType.Message> {
-    declare readonly __ctxKind?: Kind;
+    declare readonly [ContextMenuKindBrand]?: Kind;
     abstract execute(): Promise<void>;
 }
 abstract class ComponentBase<
     Brand extends 'button' | 'modal' | SelectMenuKind,
     Defs extends readonly AnyCustomId[]
 > implements HasComponentDefs<Defs> {
-    declare readonly __component?: Brand;
-    declare readonly __componentDefs?: Defs;
+    declare readonly [ComponentKindBrand]?: Brand;
+    declare readonly [ComponentDefsBrand]?: Defs;
     abstract execute(): Promise<void>;
 }
 

--- a/packages/core/tests/hmr/HmrManager.test.ts
+++ b/packages/core/tests/hmr/HmrManager.test.ts
@@ -25,27 +25,9 @@ describe('HmrManager', () => {
             }
         });
 
-        // @ts-expect-error dispatch is private, the public path needs a vite hot context
+        // @ts-expect-error handleUpdate is private, the public path needs a vite hot context
         await manager.handleUpdate({ file: 'x.ts', type: 'update' });
 
         expect(ran).toEqual(['ok']);
-    });
-
-    it('an unregistered listener no longer receives updates', async () => {
-        const manager = new HmrManager();
-        const ran: string[] = [];
-        const listener = {
-            onHmr: (): Promise<void> => {
-                ran.push('gone');
-                return Promise.resolve();
-            }
-        };
-        manager.register(listener);
-        manager.unregister(listener);
-
-        // @ts-expect-error dispatch is private, the public path needs a vite hot context
-        await manager.handleUpdate({ file: 'x.ts', type: 'update' });
-
-        expect(ran).toEqual([]);
     });
 });

--- a/packages/core/tests/logger-channels.test.ts
+++ b/packages/core/tests/logger-channels.test.ts
@@ -2,7 +2,7 @@ import { LoggerChannelRegistry } from '@seedcord/logger';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { HealthCheck } from '#node/HealthCheck';
-import { Bus } from '#subscribers/Bus';
+import { Bus, busLoggerOf } from '#subscribers/Bus';
 
 import type { CoreBase } from '#interfaces/CoreBase';
 import type { CoordinatedShutdown } from '#node/Lifecycle/CoordinatedShutdown';
@@ -30,7 +30,7 @@ beforeEach(() => {
 describe('flat-site log channels', () => {
     it('puts the bus on the subscribers channel', () => {
         // justified: Bus reads only the host reference in its ctor
-        new Bus({} as CoreBase).logger.info('ran');
+        busLoggerOf(new Bus({} as CoreBase)).info('ran');
 
         expect(sink.records[0]).toMatchObject({ channel: 'subscribers', label: 'Subscribers' });
     });

--- a/packages/core/tests/node/health-check-option.test.ts
+++ b/packages/core/tests/node/health-check-option.test.ts
@@ -20,21 +20,10 @@ describe('HealthCheck.fromOption', () => {
         expect(addTask).not.toHaveBeenCalled();
     });
 
-    it('undefined returns the defaults and registers the stop task', () => {
+    it('undefined registers the stop task', () => {
         const { shutdown, addTask } = stubShutdown();
-        const check = HealthCheck.fromOption(shutdown, undefined);
 
-        expect(check).toBeInstanceOf(HealthCheck);
-        expect(check?.port).toBe(6967);
-        expect(check?.path).toBe('/health');
+        expect(HealthCheck.fromOption(shutdown, undefined)).toBeInstanceOf(HealthCheck);
         expect(addTask).toHaveBeenCalledWith(ShutdownPhase.Drain, 'stop-healthcheck-server', expect.any(Function));
-    });
-
-    it('an options object is applied', () => {
-        const { shutdown } = stubShutdown();
-        const check = HealthCheck.fromOption(shutdown, { port: 7000, path: '/ready' });
-
-        expect(check?.port).toBe(7000);
-        expect(check?.path).toBe('/ready');
     });
 });

--- a/packages/core/tests/node/health-check-option.test.ts
+++ b/packages/core/tests/node/health-check-option.test.ts
@@ -20,10 +20,23 @@ describe('HealthCheck.fromOption', () => {
         expect(addTask).not.toHaveBeenCalled();
     });
 
-    it('undefined registers the stop task', () => {
+    it('undefined takes the defaults and registers the stop task', () => {
         const { shutdown, addTask } = stubShutdown();
 
-        expect(HealthCheck.fromOption(shutdown, undefined)).toBeInstanceOf(HealthCheck);
+        const check = HealthCheck.fromOption(shutdown, undefined);
+
+        expect(check?.port).toBe(6967);
+        expect(check?.path).toBe('/health');
         expect(addTask).toHaveBeenCalledWith(ShutdownPhase.Drain, 'stop-healthcheck-server', expect.any(Function));
+    });
+
+    it('applies an options object', () => {
+        const { shutdown } = stubShutdown();
+
+        const check = HealthCheck.fromOption(shutdown, { port: 7000, host: '0.0.0.0', path: '/ready' });
+
+        expect(check?.port).toBe(7000);
+        expect(check?.host).toBe('0.0.0.0');
+        expect(check?.path).toBe('/ready');
     });
 });

--- a/packages/core/tests/node/pluggable-attach-scopes.test.ts
+++ b/packages/core/tests/node/pluggable-attach-scopes.test.ts
@@ -1,5 +1,4 @@
 import { REST } from '@discordjs/rest';
-import { Logger } from '@seedcord/logger';
 import { MemoryRateLimiter } from '@seedcord/rate-limiter';
 import { describe, it, expect, expectTypeOf, afterEach } from 'vitest';
 
@@ -188,28 +187,26 @@ describe('attaching a plugin that declares options', () => {
 
         expect(attached.wide.options.dir).toBe('./services');
     });
-
-    it('rejects a class that carries no plugin brand', () => {
-        const host = new TestHost();
-
-        // every PluginLike member except the symbol slot
-        class Impostor {
-            public logger = new Logger('Impostor');
-            public init(): Promise<void> {
-                return Promise.resolve();
-            }
-            public ready(): Promise<void> {
-                return Promise.resolve();
-            }
-            public dispose(): Promise<void> {
-                return Promise.resolve();
-            }
-            public onHmr(): Promise<void> {
-                return Promise.resolve();
-            }
-        }
-
-        // @ts-expect-error Impostor lacks the symbol slot
-        host.attach('impostor', Impostor);
-    });
 });
+
+// every PluginLike member except the symbol slots
+class Impostor {
+    public init(): Promise<void> {
+        return Promise.resolve();
+    }
+    public ready(): Promise<void> {
+        return Promise.resolve();
+    }
+    public dispose(): Promise<void> {
+        return Promise.resolve();
+    }
+    public onHmr(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+function RejectsAClassCarryingNoPluginBrand(): void {
+    // @ts-expect-error Impostor lacks the symbol slots
+    new TestHost().attach('impostor', Impostor);
+}
+void RejectsAClassCarryingNoPluginBrand;

--- a/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
+++ b/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { describe, it, expect, vi } from 'vitest';
 
-import { Bus } from '#subscribers/Bus';
+import { Bus, busLoggerOf } from '#subscribers/Bus';
 import { PublishDefault } from '#subscribers/publishDefault';
 
 import type { CoreBase } from '#interfaces/CoreBase';
@@ -52,7 +52,7 @@ describe('Bus listener isolation', () => {
 
     it('logs the listener error through its own logger', () => {
         const bus = stubBus();
-        const error = vi.spyOn(bus.logger, 'error');
+        const error = vi.spyOn(busLoggerOf(bus), 'error');
         const thrown = new Error('listener blew up');
 
         bus.on('unknownException', () => {

--- a/packages/errors/src/SeedcordError.ts
+++ b/packages/errors/src/SeedcordError.ts
@@ -68,9 +68,12 @@ function formatErrorName(name: string, _identifier: SeedcordErrorIdentifier, cod
  */
 export type SeedcordErrorTypeString = `Seedcord${'Error' | 'TypeError' | 'RangeError' | 'AggregateError'}`;
 
+// Symbol.for so two installed copies read the same slot
+const kIdentifier: unique symbol = Symbol.for('seedcord.errors.identifier');
+
 interface BaseSeedcordError {
     readonly code: SeedcordErrorCode;
-    readonly identifier: SeedcordErrorIdentifier;
+    readonly [kIdentifier]: SeedcordErrorIdentifier;
     readonly type: SeedcordErrorTypeString;
 }
 
@@ -90,7 +93,7 @@ export class SeedcordError<Code extends SeedcordErrorCode = SeedcordErrorCode>
     implements BaseSeedcordError
 {
     public readonly code: Code;
-    public readonly identifier: SeedcordErrorIdentifier;
+    readonly [kIdentifier]: SeedcordErrorIdentifier;
     public readonly type = 'SeedcordError';
 
     constructor(code: Code, ...rest: SeedcordErrorCtorRest<Code>) {
@@ -98,8 +101,8 @@ export class SeedcordError<Code extends SeedcordErrorCode = SeedcordErrorCode>
         const message = resolveMessage(code, args);
         super(message, options);
         this.code = code;
-        this.identifier = resolveIdentifier(code);
-        this.name = formatErrorName(new.target.name, this.identifier, this.code);
+        this[kIdentifier] = resolveIdentifier(code);
+        this.name = formatErrorName(new.target.name, this[kIdentifier], this.code);
         Object.setPrototypeOf(this, new.target.prototype);
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, new.target);
@@ -114,7 +117,7 @@ export class SeedcordTypeError<Code extends SeedcordErrorCode = SeedcordErrorCod
     implements BaseSeedcordError
 {
     public readonly code: Code;
-    public readonly identifier: SeedcordErrorIdentifier;
+    readonly [kIdentifier]: SeedcordErrorIdentifier;
     public readonly type = 'SeedcordTypeError';
 
     constructor(code: Code, ...rest: SeedcordErrorCtorRest<Code>) {
@@ -122,8 +125,8 @@ export class SeedcordTypeError<Code extends SeedcordErrorCode = SeedcordErrorCod
         const message = resolveMessage(code, args);
         super(message, options);
         this.code = code;
-        this.identifier = resolveIdentifier(code);
-        this.name = formatErrorName(new.target.name, this.identifier, this.code);
+        this[kIdentifier] = resolveIdentifier(code);
+        this.name = formatErrorName(new.target.name, this[kIdentifier], this.code);
         Object.setPrototypeOf(this, new.target.prototype);
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, new.target);
@@ -138,7 +141,7 @@ export class SeedcordRangeError<Code extends SeedcordErrorCode = SeedcordErrorCo
     implements BaseSeedcordError
 {
     public readonly code: Code;
-    public readonly identifier: SeedcordErrorIdentifier;
+    readonly [kIdentifier]: SeedcordErrorIdentifier;
     public readonly type = 'SeedcordRangeError';
 
     constructor(code: Code, ...rest: SeedcordErrorCtorRest<Code>) {
@@ -146,8 +149,8 @@ export class SeedcordRangeError<Code extends SeedcordErrorCode = SeedcordErrorCo
         const message = resolveMessage(code, args);
         super(message, options);
         this.code = code;
-        this.identifier = resolveIdentifier(code);
-        this.name = formatErrorName(new.target.name, this.identifier, this.code);
+        this[kIdentifier] = resolveIdentifier(code);
+        this.name = formatErrorName(new.target.name, this[kIdentifier], this.code);
         Object.setPrototypeOf(this, new.target.prototype);
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, new.target);
@@ -162,7 +165,7 @@ export class SeedcordAggregateError<Code extends SeedcordErrorCode = SeedcordErr
     implements BaseSeedcordError
 {
     public readonly code: Code;
-    public readonly identifier: SeedcordErrorIdentifier;
+    readonly [kIdentifier]: SeedcordErrorIdentifier;
     public readonly type = 'SeedcordAggregateError';
 
     constructor(code: Code, errors: readonly unknown[], ...rest: SeedcordErrorCtorRest<Code>) {
@@ -170,8 +173,8 @@ export class SeedcordAggregateError<Code extends SeedcordErrorCode = SeedcordErr
         const message = resolveMessage(code, args);
         super(errors, message, options);
         this.code = code;
-        this.identifier = resolveIdentifier(code);
-        this.name = formatErrorName(new.target.name, this.identifier, this.code);
+        this[kIdentifier] = resolveIdentifier(code);
+        this.name = formatErrorName(new.target.name, this[kIdentifier], this.code);
         Object.setPrototypeOf(this, new.target.prototype);
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, new.target);
@@ -248,5 +251,5 @@ export function isSeedcordError<
     if (type && error.type !== type) return false;
     if (code === undefined) return true;
     // another copy of this package may number the same identifier differently
-    return error.identifier === resolveIdentifier(code);
+    return error[kIdentifier] === resolveIdentifier(code);
 }

--- a/packages/errors/tests/errors.test.ts
+++ b/packages/errors/tests/errors.test.ts
@@ -4,13 +4,10 @@ import { SeedcordErrorCode, isSeedcordError } from '#src/index';
 import { SeedcordError, SeedcordTypeError, SeedcordRangeError } from '#src/internal.index';
 
 describe('Seedcord error constructors', () => {
-    it('preserves metadata for parameterless codes', () => {
+    it('puts the code in the error name for parameterless codes', () => {
         const error = new SeedcordError(SeedcordErrorCode.CoreSingletonViolation);
 
         expect(error).toBeInstanceOf(SeedcordError);
-        expect(error.code).toBe(SeedcordErrorCode.CoreSingletonViolation);
-        expect(error.identifier).toBe('CoreSingletonViolation');
-        expect(error.type).toBe('SeedcordError');
         expect(error.name).toContain(String(SeedcordErrorCode.CoreSingletonViolation));
     });
 
@@ -24,10 +21,8 @@ describe('Seedcord error constructors', () => {
 
     it('formats messages with tuple arguments', () => {
         const phase = 'boot';
-        const error = new SeedcordError(SeedcordErrorCode.LifecycleUnknownPhase, [phase]);
 
-        expect(error.message).toContain(phase);
-        expect(error.identifier).toBe('LifecycleUnknownPhase');
+        expect(new SeedcordError(SeedcordErrorCode.LifecycleUnknownPhase, [phase]).message).toContain(phase);
     });
 
     it('supports SeedcordTypeError and SeedcordRangeError variants', () => {
@@ -35,9 +30,7 @@ describe('Seedcord error constructors', () => {
         const rangeError = new SeedcordRangeError(SeedcordErrorCode.PluginKyselyInvalidMigrationModule, ['foo.ts']);
 
         expect(typeError).toBeInstanceOf(TypeError);
-        expect(typeError.type).toBe('SeedcordTypeError');
         expect(rangeError).toBeInstanceOf(RangeError);
-        expect(rangeError.type).toBe('SeedcordRangeError');
         expect(rangeError.message).toContain('foo.ts');
     });
 });

--- a/packages/errors/tests/errors.types-test.ts
+++ b/packages/errors/tests/errors.types-test.ts
@@ -1,19 +1,20 @@
-import { assertType, describe, expect, expectTypeOf, it } from 'vitest';
+import { assertType, expectTypeOf } from 'vitest';
 
 import { SeedcordErrorCode, isSeedcordError } from '#src/index';
 import { SeedcordError, SeedcordTypeError } from '#src/internal.index';
 
 import type { SeedcordErrorTypeString } from '#src/index';
+import type { ErrorCodeFilter } from '#src/SeedcordError';
 
-// never run, the invalid cases would throw, but tc checks the body anyway
+// the invalid cases would throw
 function errorTypeContracts(): void {
-    const singletonError = new SeedcordError(SeedcordErrorCode.CoreSingletonViolation);
-    expectTypeOf(singletonError).toHaveProperty('type').toEqualTypeOf<'SeedcordError'>();
+    expectTypeOf(new SeedcordError(SeedcordErrorCode.CoreSingletonViolation)).toEqualTypeOf<
+        SeedcordError<SeedcordErrorCode.CoreSingletonViolation>
+    >();
 
-    const singletonWithOptions = new SeedcordError(SeedcordErrorCode.CoreSingletonViolation, {
-        cause: new Error('root')
-    });
-    expectTypeOf(singletonWithOptions).toHaveProperty('type').toEqualTypeOf<'SeedcordError'>();
+    expectTypeOf(
+        new SeedcordError(SeedcordErrorCode.CoreSingletonViolation, { cause: new Error('root') })
+    ).toEqualTypeOf<SeedcordError<SeedcordErrorCode.CoreSingletonViolation>>();
 
     // @ts-expect-error LifecycleUnknownPhase requires a [phase] tuple
     void new SeedcordError(SeedcordErrorCode.LifecycleUnknownPhase);
@@ -36,22 +37,17 @@ function errorTypeContracts(): void {
 
     const maybeError: unknown = new SeedcordTypeError(SeedcordErrorCode.DecoratorInvalidMiddlewarePriority);
     if (isSeedcordError(maybeError, 'SeedcordTypeError', SeedcordErrorCode.DecoratorInvalidMiddlewarePriority)) {
-        expectTypeOf(maybeError).toHaveProperty('type').toEqualTypeOf<'SeedcordTypeError'>();
-        expectTypeOf(maybeError.code).toEqualTypeOf<SeedcordErrorCode.DecoratorInvalidMiddlewarePriority>();
+        expectTypeOf(maybeError).toEqualTypeOf<
+            SeedcordTypeError<SeedcordErrorCode.DecoratorInvalidMiddlewarePriority>
+        >();
     }
 
     function narrowByCode(error: unknown): void {
         if (!isSeedcordError(error, undefined, SeedcordErrorCode.CorePluginKeyExists)) return;
 
-        expectTypeOf(error).toHaveProperty('type').toEqualTypeOf<SeedcordErrorTypeString>();
-        expectTypeOf(error.code).toEqualTypeOf<SeedcordErrorCode.CorePluginKeyExists>();
+        expectTypeOf(error).toEqualTypeOf<ErrorCodeFilter<undefined, SeedcordErrorCode.CorePluginKeyExists>>();
     }
 
     narrowByCode(new SeedcordError(SeedcordErrorCode.CorePluginKeyExists, ['logger']));
 }
-
-describe('Seedcord error types', () => {
-    it('enforces the constructor and narrowing contracts at compile time', () => {
-        expect(errorTypeContracts).toBeTypeOf('function');
-    });
-});
+void errorTypeContracts;

--- a/packages/errors/tests/guard-across-copies.test.ts
+++ b/packages/errors/tests/guard-across-copies.test.ts
@@ -37,10 +37,9 @@ describe('isSeedcordError across two copies of the package', () => {
         const renumbered = Object.defineProperty(new Error('from an older copy'), Symbol.for('seedcord.errors.coded'), {
             value: true
         });
-        Object.assign(renumbered, {
-            type: 'SeedcordError',
-            identifier: 'CorePluginAfterInit',
-            code: 9999
+        Object.assign(renumbered, { type: 'SeedcordError', code: 9999 });
+        Object.defineProperty(renumbered, Symbol.for('seedcord.errors.identifier'), {
+            value: 'CorePluginAfterInit'
         });
 
         expect(catcher.isSeedcordError(renumbered, undefined, SeedcordErrorCode.CorePluginAfterInit)).toBe(true);

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -66,7 +66,6 @@
         "@seedcord/rate-limiter": "workspace:^",
         "@seedcord/types": "workspace:^",
         "@seedcord/utils": "workspace:^",
-        "chalk": "catalog:deps",
         "reflect-metadata": "catalog:deps"
     },
     "devDependencies": {

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -1,5 +1,5 @@
 import { Bus } from '@seedcord/core';
-import { HmrManager, setBotColor } from '@seedcord/core/internal';
+import { busLoggerOf, HmrManager, setBotColor } from '@seedcord/core/internal';
 import {
     HealthCheck,
     CoordinatedShutdown,
@@ -14,7 +14,7 @@ import { MemoryRateLimiter } from '@seedcord/rate-limiter';
 import { SeedcordBrand } from '@seedcord/types/internal';
 import { Envapter } from 'envapt';
 
-import { Bot } from './bot/Bot';
+import { botLoggerOf, Bot } from './bot/Bot';
 import { version as packageVersion } from './version';
 
 import type { GatewayConfig } from './interfaces/Config';
@@ -90,15 +90,15 @@ export class Seedcord extends Pluggable<'gateway', 'server'> implements Core, Se
         if (Envapter.isDevelopment || Envapter.isTest) this.registerHmrAwareModules();
 
         this.startup.addTask(StartupPhase.Configuration, 'bus-initialization', async () => {
-            this.bus.logger.utils.initialization('Subscribers', 'start');
+            busLoggerOf(this.bus).utils.initialization('Subscribers', 'start');
             await this.subscribers.init();
-            this.bus.logger.utils.initialization('Subscribers', 'end');
+            busLoggerOf(this.bus).utils.initialization('Subscribers', 'end');
         });
 
         this.startup.addTask(StartupPhase.Login, 'bot-initialization', async () => {
-            this.bot.logger.utils.initialization('Bot', 'start');
+            botLoggerOf(this.bot).utils.initialization('Bot', 'start');
             await this.bot.init();
-            this.bot.logger.utils.initialization('Bot', 'end');
+            botLoggerOf(this.bot).utils.initialization('Bot', 'end');
         });
 
         const { healthCheck } = this;

--- a/packages/gateway/src/bot/Bot.ts
+++ b/packages/gateway/src/bot/Bot.ts
@@ -25,14 +25,18 @@ const LOGOUT_TIMEOUT_MS = 2000;
 /**
  * The Discord client and its controllers. Access it through `core.bot`.
  */
+const loggerSlot = Symbol('seedcord:bot:logger');
+
 export class Bot implements Initializeable, HmrAware {
     @Envapt<string>('DISCORD_BOT_TOKEN', {
         converter: (raw) => validateDiscordToken(raw)
     })
     declare public readonly botToken: string;
 
+    private readonly logger = new Logger('Bot', { channel: 'bot' });
+
     /** @internal */
-    public readonly logger = new Logger('Bot', { channel: 'bot' });
+    readonly [loggerSlot]: Logger = this.logger;
     private isInitialized = false;
 
     private readonly _client: Client;
@@ -161,4 +165,9 @@ export class Bot implements Initializeable, HmrAware {
     public get client(): Client {
         return this._client;
     }
+}
+
+/** @internal */
+export function botLoggerOf(bot: Bot): Logger {
+    return bot[loggerSlot];
 }

--- a/packages/gateway/src/handlers/interaction/AutocompleteHandler.ts
+++ b/packages/gateway/src/handlers/interaction/AutocompleteHandler.ts
@@ -1,4 +1,4 @@
-import { reportedWrite } from '@seedcord/core/internal';
+import { AutocompleteRouteBrand, reportedWrite } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -48,7 +48,7 @@ export abstract class AutocompleteHandler<
 > extends BaseHandler<AutocompleteInteraction<Cache>> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __autocompleteRoute?: Route;
+    declare readonly [AutocompleteRouteBrand]?: Route;
 
     // keep this ctor. it gives typeof AutocompleteHandler a public construct signature that HandlerConstructor
     // needs, and dropping it (inheriting BaseHandler's protected ctor) collapses HandlerConstructor to never.

--- a/packages/gateway/src/handlers/interaction/ContextMenuHandler.ts
+++ b/packages/gateway/src/handlers/interaction/ContextMenuHandler.ts
@@ -1,3 +1,5 @@
+import { ContextMenuKindBrand } from '@seedcord/core/internal';
+
 import { InteractionHandler } from '#handlers/interaction/InteractionHandler';
 
 import type { ContextMenuKind } from '@seedcord/core';
@@ -53,7 +55,7 @@ export abstract class ContextMenuHandler<
 > extends InteractionHandler<InteractionFor<Kind, Cache>> {
     // phantom, nothing reads it. it keeps Kind on the instance type
     /** @internal */
-    declare readonly __ctxKind?: Kind;
+    declare readonly [ContextMenuKindBrand]?: Kind;
 
     protected get target(): TargetFor<Kind, Cache> {
         // justified: the Kind generic decides which interaction member is live, both narrow to TargetFor.

--- a/packages/gateway/src/handlers/interaction/SlashHandler.ts
+++ b/packages/gateway/src/handlers/interaction/SlashHandler.ts
@@ -1,3 +1,4 @@
+import { SlashRouteBrand } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -40,7 +41,7 @@ export abstract class SlashHandler<
 > extends InteractionHandler<ChatInputCommandInteraction<Cache>> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __slashRoute?: Route;
+    declare readonly [SlashRouteBrand]?: Route;
 
     /**
      * The typed options for this command's route. Required options drop the null, choices narrow to their

--- a/packages/gateway/src/handlers/interaction/components/ButtonHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ButtonHandler.ts
@@ -1,3 +1,5 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { AnyCustomId } from '@seedcord/core/internal';
@@ -31,5 +33,5 @@ export abstract class ButtonHandler<
 > extends ComponentHandler<ButtonInteraction<Cache>, Defs> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: 'button';
+    declare readonly [ComponentKindBrand]?: 'button';
 }

--- a/packages/gateway/src/handlers/interaction/components/ComponentHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ComponentHandler.ts
@@ -1,4 +1,4 @@
-import { decodeComponentRoute } from '@seedcord/core/internal';
+import { ComponentDefsBrand, decodeComponentRoute } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -33,7 +33,7 @@ export abstract class ComponentHandler<Event extends ComponentInteraction, Defs 
 {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __componentDefs?: Defs;
+    declare readonly [ComponentDefsBrand]?: Defs;
 
     /** Rewrite the source message this component interaction came from. */
     protected update(response: GatewayReplyResponse | string): Promise<SentMessage> {

--- a/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
@@ -1,3 +1,4 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -37,7 +38,7 @@ export abstract class ModalHandler<
 > extends ComponentHandler<ModalSubmitInteraction<Cache>, Defs> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: 'modal';
+    declare readonly [ComponentKindBrand]?: 'modal';
 
     /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
     protected override update(response: GatewayReplyResponse | string): Promise<SentMessage> {

--- a/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -1,3 +1,5 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { SelectMenuKind } from '@seedcord/core';
@@ -56,5 +58,5 @@ export abstract class SelectMenuHandler<
 > extends ComponentHandler<SelectMenuInteractionFor<Kind, Cache>, Defs> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: Kind;
+    declare readonly [ComponentKindBrand]?: Kind;
 }

--- a/packages/gateway/tests/events/EventDispatcher.test.ts
+++ b/packages/gateway/tests/events/EventDispatcher.test.ts
@@ -1,6 +1,7 @@
 import { PublishDefault } from '@seedcord/core/internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { botLoggerOf } from '#bot/Bot';
 import { Seedcord } from '#src/Seedcord';
 
 import { seedcordPath } from '../utils/source-path';
@@ -525,7 +526,7 @@ describe('EventDispatcher Integration', () => {
         it('runs later unhandledEventError listeners after an earlier one throws', async () => {
             const { controller, fire } = await clientHarness();
             vi.spyOn(controller, 'processEvent').mockRejectedValue(new Error('boom'));
-            vi.spyOn(seedcord.bot.logger, 'error').mockImplementation(() => undefined);
+            vi.spyOn(botLoggerOf(seedcord.bot), 'error').mockImplementation(() => undefined);
 
             let reached = false;
             seedcord.bus.on('unhandledEventError', () => {
@@ -545,7 +546,7 @@ describe('EventDispatcher Integration', () => {
         it('wraps a non-Error rejection at the root, so the payload still carries an Error', async () => {
             const { controller, fire } = await clientHarness();
             vi.spyOn(controller, 'processEvent').mockRejectedValue('a bare string');
-            vi.spyOn(seedcord.bot.logger, 'error').mockImplementation(() => undefined);
+            vi.spyOn(botLoggerOf(seedcord.bot), 'error').mockImplementation(() => undefined);
 
             const seen: SubscriptionData<'unhandledEventError'>[] = [];
             seedcord.bus.on('unhandledEventError', (payload) => seen.push(payload));

--- a/packages/gateway/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/gateway/tests/interactions/InteractionDispatcher.test.ts
@@ -5,6 +5,7 @@ import { SeedcordErrorCode } from '@seedcord/errors';
 import { Logger } from '@seedcord/logger';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+import { botLoggerOf } from '#bot/Bot';
 import { CONFIRM_DEF } from '#bot/confirm/reserved';
 import { Seedcord } from '#src/Seedcord';
 
@@ -862,7 +863,7 @@ describe('InteractionDispatcher Integration', () => {
         it('runs later unhandledInteractionError listeners after an earlier one throws', async () => {
             const { controller, fire } = await clientHarness();
             vi.spyOn(controller, 'handleInteraction').mockRejectedValue(new Error('boom'));
-            vi.spyOn(seedcord.bot.logger, 'error').mockImplementation(() => undefined);
+            vi.spyOn(botLoggerOf(seedcord.bot), 'error').mockImplementation(() => undefined);
 
             let reached = false;
             seedcord.bus.on('unhandledInteractionError', () => {
@@ -882,7 +883,7 @@ describe('InteractionDispatcher Integration', () => {
         it('wraps a non-Error rejection at the root, so the payload still carries an Error', async () => {
             const { controller, fire } = await clientHarness();
             vi.spyOn(controller, 'handleInteraction').mockRejectedValue('a bare string');
-            vi.spyOn(seedcord.bot.logger, 'error').mockImplementation(() => undefined);
+            vi.spyOn(botLoggerOf(seedcord.bot), 'error').mockImplementation(() => undefined);
 
             const seen: SubscriptionData<'unhandledInteractionError'>[] = [];
             seedcord.bus.on('unhandledInteractionError', (payload) => seen.push(payload));

--- a/packages/gateway/tests/subscribers/Bus.registration.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.registration.test.ts
@@ -1,3 +1,4 @@
+import { busLoggerOf } from '@seedcord/core/internal';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { Seedcord } from '#src/Seedcord';
@@ -68,7 +69,7 @@ describe('Bus webhook reporter registration', () => {
         );
 
         seedcord = new Seedcord(testConfig({ subscribers: testEnv.resolvePath('subscribers') }));
-        const warnSpy = vi.spyOn(seedcord.bus.logger, 'warn');
+        const warnSpy = vi.spyOn(busLoggerOf(seedcord.bus), 'warn');
         await loaderOf(seedcord).init();
 
         // justified: PrivateBus exposes the private subscribersMap for assertion
@@ -151,7 +152,7 @@ describe('Bus webhook reporter registration', () => {
         await loaderOf(seedcord).init();
 
         restMocks.getMock.mockRejectedValue(new TypeError('fetch failed'));
-        const warnSpy = vi.spyOn(seedcord.bus.logger, 'warn');
+        const warnSpy = vi.spyOn(busLoggerOf(seedcord.bus), 'warn');
         await expect(seedcord.bus.verifyWebhooks()).resolves.toBeUndefined();
         expect(warnSpy).toHaveBeenCalled();
     });

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -73,7 +73,6 @@
         "@seedcord/rate-limiter": "workspace:^",
         "@seedcord/types": "workspace:^",
         "@seedcord/utils": "workspace:^",
-        "chalk": "catalog:deps",
         "discord-api-types": "catalog:deps",
         "reflect-metadata": "catalog:deps",
         "type-fest": "catalog:deps"

--- a/packages/http/src/handlers/interaction/AutocompleteHandler.ts
+++ b/packages/http/src/handlers/interaction/AutocompleteHandler.ts
@@ -1,5 +1,5 @@
 import { BaseHandler } from '@seedcord/core';
-import { reportedWrite } from '@seedcord/core/internal';
+import { AutocompleteRouteBrand, reportedWrite } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { InteractionResponseType, Routes } from 'discord-api-types/v10';
@@ -48,7 +48,7 @@ export abstract class AutocompleteHandler<Route extends keyof SlashOptionRegistr
 
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __autocompleteRoute?: Route;
+    declare readonly [AutocompleteRouteBrand]?: Route;
 
     /**
      * Typed Discord REST API (`@discordjs/core/http-only`) over `core.rest`, one instance per core.

--- a/packages/http/src/handlers/interaction/ContextMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/ContextMenuHandler.ts
@@ -1,3 +1,4 @@
+import { ContextMenuKindBrand } from '@seedcord/core/internal';
 import { ApplicationCommandType } from 'discord-api-types/v10';
 
 import { InteractionHandler } from '#handlers/interaction/InteractionHandler';
@@ -36,7 +37,7 @@ export abstract class ContextMenuHandler<Kind extends ContextMenuKind> extends I
 > {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __ctxKind?: Kind;
+    declare readonly [ContextMenuKindBrand]?: Kind;
 
     protected get target(): TargetFor<Kind> {
         const data = this.event.data;

--- a/packages/http/src/handlers/interaction/SlashHandler.ts
+++ b/packages/http/src/handlers/interaction/SlashHandler.ts
@@ -1,3 +1,4 @@
+import { SlashRouteBrand } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -28,7 +29,7 @@ export abstract class SlashHandler<
 > extends InteractionHandler<APIChatInputApplicationCommandInteraction> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __slashRoute?: Route;
+    declare readonly [SlashRouteBrand]?: Route;
 
     private resolver?: HttpSlashOptions;
 

--- a/packages/http/src/handlers/interaction/components/ButtonHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ButtonHandler.ts
@@ -1,3 +1,5 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { AnyCustomId } from '@seedcord/core/internal';
@@ -19,5 +21,5 @@ export abstract class ButtonHandler<Defs extends readonly AnyCustomId[]> extends
 > {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: 'button';
+    declare readonly [ComponentKindBrand]?: 'button';
 }

--- a/packages/http/src/handlers/interaction/components/ComponentHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ComponentHandler.ts
@@ -1,4 +1,4 @@
-import { decodeComponentRoute } from '@seedcord/core/internal';
+import { ComponentDefsBrand, decodeComponentRoute } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -35,7 +35,7 @@ export abstract class ComponentHandler<
 {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __componentDefs?: Defs;
+    declare readonly [ComponentDefsBrand]?: Defs;
 
     /** Rewrite the source message this component interaction came from. */
     protected update(response: ReplyResponse | string): Promise<SentMessage> {

--- a/packages/http/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ModalHandler.ts
@@ -1,3 +1,4 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
@@ -23,7 +24,7 @@ export abstract class ModalHandler<Defs extends readonly AnyCustomId[]> extends 
 > {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: 'modal';
+    declare readonly [ComponentKindBrand]?: 'modal';
 
     /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
     protected override update(response: ReplyResponse | string): Promise<SentMessage> {

--- a/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -1,3 +1,5 @@
+import { ComponentKindBrand } from '@seedcord/core/internal';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { SelectMenuKind } from '@seedcord/core';
@@ -42,5 +44,5 @@ export abstract class SelectMenuHandler<
 > extends ComponentHandler<SelectMenuInteractionFor<Kind>, Defs> {
     // phantom, never set at runtime.
     /** @internal */
-    declare readonly __component?: Kind;
+    declare readonly [ComponentKindBrand]?: Kind;
 }

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -3,7 +3,7 @@ import { createServer } from 'node:http';
 
 import { REST } from '@discordjs/rest';
 import { Bus } from '@seedcord/core';
-import { CommandInjector, getDevChannel, HmrManager, setBotColor } from '@seedcord/core/internal';
+import { busLoggerOf, CommandInjector, getDevChannel, HmrManager, setBotColor } from '@seedcord/core/internal';
 import {
     CommandRegistry,
     CoordinatedShutdown,
@@ -156,9 +156,9 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
         if (Envapter.isDevelopment || Envapter.isTest) this.registerHmrAwareModules();
 
         this.startup.addTask(StartupPhase.Configuration, 'bus-initialization', async () => {
-            this.bus.logger.utils.initialization('Subscribers', 'start');
+            busLoggerOf(this.bus).utils.initialization('Subscribers', 'start');
             await this.subscribers.init();
-            this.bus.logger.utils.initialization('Subscribers', 'end');
+            busLoggerOf(this.bus).utils.initialization('Subscribers', 'end');
         });
 
         const { interactions } = this;

--- a/packages/http/tests/node/dispatch/register-subscribers.test.ts
+++ b/packages/http/tests/node/dispatch/register-subscribers.test.ts
@@ -1,5 +1,5 @@
 import { Bus } from '@seedcord/core';
-import { PublishDefault } from '@seedcord/core/internal';
+import { busLoggerOf, PublishDefault } from '@seedcord/core/internal';
 import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -69,7 +69,7 @@ describe('registerSubscribers', () => {
 
     it('logs a row whose export is not a subscriber', async () => {
         const bus = stubBus();
-        const error = vi.spyOn(bus.logger, 'error');
+        const error = vi.spyOn(busLoggerOf(bus), 'error');
         registerSubscribers(
             bus,
             manifestWith(() =>
@@ -94,7 +94,7 @@ describe('registerSubscribers', () => {
 
     it('translates a row whose module throws while importing, keeping the cause', async () => {
         const bus = stubBus();
-        const error = vi.spyOn(bus.logger, 'error');
+        const error = vi.spyOn(busLoggerOf(bus), 'error');
         const boom = new Error('module init exploded');
         registerSubscribers(
             bus,
@@ -113,7 +113,7 @@ describe('registerSubscribers', () => {
 
     it('logs a row whose named export is missing', async () => {
         const bus = stubBus();
-        const error = vi.spyOn(bus.logger, 'error');
+        const error = vi.spyOn(busLoggerOf(bus), 'error');
         registerSubscribers(
             bus,
             manifestWith(() => Promise.resolve({}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,9 +604,6 @@ importers:
       '@seedcord/utils':
         specifier: workspace:^
         version: link:../../packages/utils
-      chalk:
-        specifier: catalog:deps
-        version: 6.0.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,9 +760,6 @@ importers:
       '@seedcord/utils':
         specifier: workspace:^
         version: link:../utils
-      chalk:
-        specifier: catalog:deps
-        version: 6.0.0
       discord-api-types:
         specifier: ^0.38.52
         version: 0.38.52
@@ -868,9 +865,6 @@ importers:
       '@seedcord/utils':
         specifier: workspace:^
         version: link:../utils
-      chalk:
-        specifier: catalog:deps
-        version: 6.0.0
       reflect-metadata:
         specifier: catalog:deps
         version: 0.2.2
@@ -929,9 +923,6 @@ importers:
       '@seedcord/utils':
         specifier: workspace:^
         version: link:../utils
-      chalk:
-        specifier: catalog:deps
-        version: 6.0.0
       discord-api-types:
         specifier: ^0.38.52
         version: 0.38.52

--- a/tooling/docs-engine/src/search-targets.ts
+++ b/tooling/docs-engine/src/search-targets.ts
@@ -35,7 +35,7 @@ export const DEFAULT_SEARCH_TARGETS: SearchTarget[] = [
     { query: 'addTask' },
 
     // Accessors
-    { query: 'isRunning' },
+    { query: 'isReady' },
     { query: 'Notice report' },
     { query: 'client' },
 


### PR DESCRIPTION
## What and why

Closes #242

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved encapsulation of framework internals across core, gateway, HTTP, errors, and CLI packages.
  * Strengthened type metadata for routes and interaction components.
  * Consolidated terminal styling and internal logging access.
  * Several previously public implementation details are no longer exposed.
* **Chores**
  * Removed redundant terminal styling dependencies.
  * Updated documentation search targets for the current lifecycle status API.
* **Tests**
  * Expanded compile-time type checks and adjusted test timeouts for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->