### PR TITLE
fix: docs type literal members + plugin brands

### DIFF
--- a/packages/core/src/plugin/Plugin.ts
+++ b/packages/core/src/plugin/Plugin.ts
@@ -4,6 +4,7 @@ import { Logger } from '@seedcord/logger';
 
 import { getDevChannel } from '#hmr/devChannel';
 
+import { RuntimeBrand, TransportBrand } from './brands';
 import { resolveLifecycleSpec } from './lifecycle';
 
 import type { CoreBase } from '#interfaces/CoreBase';
@@ -30,10 +31,11 @@ const loggerSlot = Symbol('seedcord.plugin.logger');
 export abstract class Plugin<Opts extends PluginOptions = {}, TCore extends CoreBase = CoreBase>
     implements Initializeable, HmrAware
 {
-    /** @internal phantom, never set at runtime */
-    declare readonly __transport?: TransportOf<Opts>;
-    /** @internal phantom, never set at runtime */
-    declare readonly __runtime?: RuntimeOf<Opts>;
+    // phantom, never set at runtime.
+    /** @internal */
+    declare readonly [TransportBrand]?: TransportOf<Opts>;
+    /** @internal */
+    declare readonly [RuntimeBrand]?: RuntimeOf<Opts>;
 
     /** @internal */
     readonly [resolvedSpecSlot]: ResolvedPluginLifecycleSpec;

--- a/packages/core/src/plugin/brands.ts
+++ b/packages/core/src/plugin/brands.ts
@@ -1,0 +1,4 @@
+// Plugin declares these so attach can read what a plugin runs on. Nothing assigns them at runtime.
+
+export const TransportBrand: unique symbol = Symbol('seedcord:brand:transport');
+export const RuntimeBrand: unique symbol = Symbol('seedcord:brand:runtime');

--- a/packages/core/src/plugin/options.ts
+++ b/packages/core/src/plugin/options.ts
@@ -1,3 +1,4 @@
+import type { RuntimeBrand, TransportBrand } from './brands';
 import type { FrameworkChannel, TypedExclude } from '@seedcord/types';
 
 /** The options a plugin declares as its `Plugin<Opts>` type argument. */
@@ -48,8 +49,8 @@ export type ChannelKeyAssert<Key extends string> = Key extends FrameworkChannel
     ? `'${Key}' is a channel the framework logs on. Pick another plugin key.`
     : Key;
 
-type BrandTransport<Plug> = Plug extends { readonly __transport?: infer T extends string } ? T : 'any';
-type BrandRuntime<Plug> = Plug extends { readonly __runtime?: infer R extends string } ? R : 'any';
+type BrandTransport<Plug> = Plug extends { readonly [TransportBrand]?: infer T extends string } ? T : 'any';
+type BrandRuntime<Plug> = Plug extends { readonly [RuntimeBrand]?: infer R extends string } ? R : 'any';
 
 // `unknown` vanishes from the intersection at the attach parameter, and a mismatch object leaves
 // the argument unassignable there.

--- a/packages/core/tests/node/pluggable-attach-scopes.test.ts
+++ b/packages/core/tests/node/pluggable-attach-scopes.test.ts
@@ -9,6 +9,7 @@ import { Plugin } from '#src/plugin/Plugin';
 import { Bus } from '#subscribers/Bus';
 
 import type { CoreBase } from '#interfaces/CoreBase';
+import type { RuntimeBrand, TransportBrand } from '#src/plugin/brands';
 import type { Runtime } from '#src/plugin/options';
 import type { Config, IRateLimiter } from '@seedcord/types';
 
@@ -89,9 +90,9 @@ class TestHost extends Pluggable<'gateway', 'server'> {
     }
 }
 
-expectTypeOf<FullyScoped['__transport']>().toEqualTypeOf<'gateway' | undefined>();
-expectTypeOf<FullyScoped['__runtime']>().toEqualTypeOf<'server' | undefined>();
-expectTypeOf<GatewayScoped['__runtime']>().toEqualTypeOf<'any' | undefined>();
+expectTypeOf<FullyScoped[typeof TransportBrand]>().toEqualTypeOf<'gateway' | undefined>();
+expectTypeOf<FullyScoped[typeof RuntimeBrand]>().toEqualTypeOf<'server' | undefined>();
+expectTypeOf<GatewayScoped[typeof RuntimeBrand]>().toEqualTypeOf<'any' | undefined>();
 
 describe('attaching a plugin that declares options', () => {
     afterEach(() => {

--- a/packages/core/tests/plugin/options.types-test.ts
+++ b/packages/core/tests/plugin/options.types-test.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from 'vitest';
 import { Plugin } from '#src/plugin/Plugin';
 
 import type { CoreBase } from '#interfaces/CoreBase';
+import type { RuntimeBrand, TransportBrand } from '#src/plugin/brands';
 
 class Defaults extends Plugin {
     // justified: never invoked, these fixtures exist for type probes only
@@ -24,8 +25,8 @@ class Narrowed extends Plugin<{ transport: 'gateway'; runtime: 'server' }> {
     }
 }
 
-expectTypeOf<Defaults['__transport']>().toEqualTypeOf<'any' | undefined>();
-expectTypeOf<Defaults['__runtime']>().toEqualTypeOf<'any' | undefined>();
+expectTypeOf<Defaults[typeof TransportBrand]>().toEqualTypeOf<'any' | undefined>();
+expectTypeOf<Defaults[typeof RuntimeBrand]>().toEqualTypeOf<'any' | undefined>();
 
-expectTypeOf<Narrowed['__transport']>().toEqualTypeOf<'gateway' | undefined>();
-expectTypeOf<Narrowed['__runtime']>().toEqualTypeOf<'server' | undefined>();
+expectTypeOf<Narrowed[typeof TransportBrand]>().toEqualTypeOf<'gateway' | undefined>();
+expectTypeOf<Narrowed[typeof RuntimeBrand]>().toEqualTypeOf<'server' | undefined>();

--- a/tooling/docs-engine/src/model/adapter-helpers.ts
+++ b/tooling/docs-engine/src/model/adapter-helpers.ts
@@ -1,6 +1,7 @@
 import {
     ApiDeclaredItem,
     ApiDocumentedItem,
+    ApiItemKind,
     ApiParameterListMixin,
     ApiTypeParameterListMixin,
     type ApiItem,
@@ -277,6 +278,19 @@ export function buildAccessorSignature(
     const throwsTags = comment?.blockTags.filter((tag) => tag.tag === '@throws');
     if (throwsTags && throwsTags.length > 0) signature.throws = throwsTags;
     return signature;
+}
+
+// AE reports the keys of an inline object type in a class's type parameters or heritage clause as
+// class members. `class C<T extends { id: string }>` gets an `id` property.
+const NEVER_IN_A_CLASS_BODY = new Set<ApiItemKind>([
+    ApiItemKind.PropertySignature,
+    ApiItemKind.MethodSignature,
+    ApiItemKind.CallSignature,
+    ApiItemKind.ConstructSignature
+]);
+
+export function belongsInClassBody(item: ApiItem): boolean {
+    return !NEVER_IN_A_CLASS_BODY.has(item.kind);
 }
 
 // TS requires same-name overloads be written adjacently

--- a/tooling/docs-engine/src/model/adapter.ts
+++ b/tooling/docs-engine/src/model/adapter.ts
@@ -16,6 +16,7 @@ import {
     accessorHasSetter,
     accessorRole,
     buildAccessorSignature,
+    belongsInClassBody,
     buildDeclarationHeader,
     emptyInheritance,
     explicitModifiers,
@@ -216,7 +217,8 @@ export class ApiAdapter {
 
     private visitMembers(members: readonly ApiItem[], parentPath: string[], owningContainer?: ApiItem): DocNode[] {
         const nodes: DocNode[] = [];
-        for (const group of groupOverloads(members)) {
+        const declared = owningContainer?.kind === ApiItemKind.Class ? members.filter(belongsInClassBody) : members;
+        for (const group of groupOverloads(declared)) {
             const primary = group[0];
             if (!primary) continue;
             // AE names it `(constructor)`

--- a/tooling/docs-engine/tests/PackageDirectory.test.ts
+++ b/tooling/docs-engine/tests/PackageDirectory.test.ts
@@ -16,7 +16,14 @@ describe('PackageDirectory', () => {
     it('produces a snapshot of top-level entities', () => {
         const snapshot = directory.snapshot();
         expect(snapshot).toEqual({
-            classes: ['base-class', 'mock-class'],
+            classes: [
+                'base-class',
+                'inline-constraint-base',
+                'inline-constraint-callable',
+                'inline-constraint-child',
+                'inline-constraint-shadow',
+                'mock-class'
+            ],
             interfaces: [
                 'extended-interface',
                 'indexable-interface',

--- a/tooling/docs-engine/tests/adapter-class-members.test.ts
+++ b/tooling/docs-engine/tests/adapter-class-members.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMockPackage } from './utils/test-helpers';
+
+import type { DocNode } from '#src/types';
+
+async function topLevel(name: string): Promise<DocNode> {
+    const pkg = await getMockPackage();
+    const node = pkg.root.children.find((child) => child.name === name);
+    if (!node) throw new Error(`${name} not found in the mock package`);
+    return node;
+}
+
+const memberNames = (node: DocNode): string[] => node.children.map((child) => child.name).sort();
+
+describe('class members', () => {
+    it('documents only what the class declares, given an inline type-parameter constraint', async () => {
+        expect(memberNames(await topLevel('InlineConstraintBase'))).toEqual(['stored']);
+    });
+
+    it('keeps a real inherited member and drops the keys of an inline type argument', async () => {
+        expect(memberNames(await topLevel('InlineConstraintChild'))).toEqual(['ownProp', 'stored']);
+    });
+
+    it('keeps the declared property when a constraint key shadows its name', async () => {
+        const node = await topLevel('InlineConstraintShadow');
+        expect(memberNames(node)).toEqual(['token']);
+        expect(node.children[0]?.headerText).toContain('TypeM');
+    });
+
+    it('drops the call, method, and construct signatures a constraint carries', async () => {
+        expect(memberNames(await topLevel('InlineConstraintCallable'))).toEqual(['held']);
+    });
+
+    it('documents every property and method an interface declares', async () => {
+        expect(memberNames(await topLevel('MockInterface'))).toEqual([
+            'method',
+            'nested',
+            'optionalMethod',
+            'optionalProp',
+            'prop',
+            'readonlyProp'
+        ]);
+    });
+});

--- a/tooling/docs-generator/tests/mock/class.ts
+++ b/tooling/docs-generator/tests/mock/class.ts
@@ -162,3 +162,47 @@ export class MockClass<TypeT, TypeU extends number> extends BaseClass {
         return [first, ...rest].join('-');
     }
 }
+
+// new fixtures go at the bottom. source-index.test.ts pins the line numbers above.
+
+/**
+ * A base class whose type parameter is constrained by an inline object type.
+ *
+ * @typeParam TypeM - The stored shape.
+ */
+export class InlineConstraintBase<TypeM extends { token: string }> {
+    /**
+     * The most recently stored value.
+     */
+    public stored: TypeM | null = null;
+}
+
+/**
+ * A subclass that pins the base's type parameter with another inline object type.
+ */
+export class InlineConstraintChild extends InlineConstraintBase<{ token: string; revision: number }> {
+    /**
+     * A property the subclass declares itself.
+     */
+    public ownProp = 'child';
+}
+
+/**
+ * A class whose own property shares its name with the constraint's key.
+ */
+export class InlineConstraintShadow<TypeM extends { token: string }> {
+    /**
+     * The token this instance stores.
+     */
+    public token: TypeM | null = null;
+}
+
+/**
+ * A class whose constraint carries a call, a method, and a construct signature.
+ */
+export class InlineConstraintCallable<TypeM extends { (): void; run(): void; new (): object }> {
+    /**
+     * The value this instance holds.
+     */
+    public held: TypeM | null = null;
+}

--- a/tooling/docs-generator/tests/mock/index.ts
+++ b/tooling/docs-generator/tests/mock/index.ts
@@ -7,8 +7,15 @@
  * @packageDocumentation
  */
 
+export {
+    BaseClass,
+    InlineConstraintBase,
+    InlineConstraintCallable,
+    InlineConstraintChild,
+    InlineConstraintShadow
+} from './class.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
-export { BaseClass, MockClass } from './class.js';
+export { MockClass } from './class.js';
 export { MockEnum } from './enum.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
 export { mockFunction, mockFunctionWithRest, asyncMockFunction, LogDecorator, usesPromoted } from './function.js';


### PR DESCRIPTION
## What and why

coderabbit do your thing

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [-] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation generation for class members using inline object, callable, method, and constructor constraints.
  * Corrected handling of inherited and shadowed class properties in generated documentation.

* **Documentation**
  * Updated generated API documentation coverage and snapshots for inline generic constraints.

* **Refactor**
  * Strengthened internal plugin type identification with symbol-based markers for more reliable type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->